### PR TITLE
feat: 상품, 업체, 재고 도메인 

### DIFF
--- a/hub/src/main/java/com/klp/hub/company/domain/Company.java
+++ b/hub/src/main/java/com/klp/hub/company/domain/Company.java
@@ -1,0 +1,14 @@
+package com.klp.hub.company.domain;
+
+import jakarta.persistence.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_companies")
+public class Company {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(nullable = false)
+    private UUID id;
+}

--- a/hub/src/main/java/com/klp/hub/company/domain/Company.java
+++ b/hub/src/main/java/com/klp/hub/company/domain/Company.java
@@ -1,14 +1,49 @@
 package com.klp.hub.company.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
 
 import java.util.UUID;
 
 @Entity
 @Table(name = "p_companies")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Company {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(nullable = false)
+    @Column(name = "company_id", nullable = false)
     private UUID id;
+
+    @Enumerated(EnumType.STRING)
+    @Comment("업체 종류")
+    @Column(name = "type", nullable = false)
+    private CompanyType type;
+
+    @Comment("업체명")
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Comment("업체 주소")
+    @Column(name = "address", nullable = false)
+    private String address;
+
+    public Company(CompanyType type, String name, String address) {
+        if (type == null) {
+            throw new IllegalArgumentException("업체 종류는 필수입니다.");
+        }
+
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("업체명은 필수입니다.");
+        }
+
+        if (address == null || address.isBlank()) {
+            throw new IllegalArgumentException("업체명은 필수입니다.");
+        }
+
+        this.type = type;
+        this.name = name;
+        this.address = address;
+    }
 }

--- a/hub/src/main/java/com/klp/hub/company/domain/CompanyType.java
+++ b/hub/src/main/java/com/klp/hub/company/domain/CompanyType.java
@@ -1,0 +1,11 @@
+package com.klp.hub.company.domain;
+
+public enum CompanyType {
+    SUPPLIER("생산"), CUSTOMER("수령");
+
+    private String description;
+
+    CompanyType(String description) {
+        this.description = description;
+    }
+}

--- a/hub/src/main/java/com/klp/hub/inventory/domain/Inventory.java
+++ b/hub/src/main/java/com/klp/hub/inventory/domain/Inventory.java
@@ -44,6 +44,10 @@ public class Inventory {
     public void decrease(Integer quantity) {
         validQuantity(quantity);
 
+        if (this.quantity - quantity < 0) {
+            throw new IllegalArgumentException("기존 재고 수량을 초과하여 차감하였습니다.");
+        }
+
         this.quantity -= quantity;
     }
 

--- a/hub/src/main/java/com/klp/hub/inventory/domain/Inventory.java
+++ b/hub/src/main/java/com/klp/hub/inventory/domain/Inventory.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 public class Inventory {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(nullable = false)
+    @Column(name = "invevntory_id", nullable = false)
     private UUID id;
 
     @Comment("재고 수량")

--- a/hub/src/main/java/com/klp/hub/inventory/domain/Inventory.java
+++ b/hub/src/main/java/com/klp/hub/inventory/domain/Inventory.java
@@ -21,13 +21,18 @@ public class Inventory {
     @Column(name = "quantity", nullable = false)
     private Integer quantity;
 
+    @Comment("상품 ID")
+    @Column(name = "product_id", nullable = false)
+    private String productId;
+
     public Inventory() {
         this.quantity = 0;
     }
 
-    public Inventory(Integer quantity) {
+    public Inventory(Integer quantity, String productId) {
         validQuantity(quantity);
         this.quantity = quantity;
+        this.productId = productId;
     }
 
     public void increase(Integer quantity) {
@@ -43,7 +48,7 @@ public class Inventory {
     }
 
     private void validQuantity(Integer quantity) {
-        if (quantity == null || quantity <= 0) {
+        if (quantity == null || quantity < 0) {
             throw new IllegalArgumentException("재고 수량은 필수이면서 음수일 수 없습니다.");
         }
     }

--- a/hub/src/main/java/com/klp/hub/inventory/domain/Inventory.java
+++ b/hub/src/main/java/com/klp/hub/inventory/domain/Inventory.java
@@ -1,0 +1,50 @@
+package com.klp.hub.inventory.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_inventory")
+@Getter
+public class Inventory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(nullable = false)
+    private UUID id;
+
+    @Comment("재고 수량")
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+    public Inventory() {
+        this.quantity = 0;
+    }
+
+    public Inventory(Integer quantity) {
+        if (quantity == null || quantity <= 0) {
+            throw new IllegalArgumentException();
+        }
+        this.quantity = quantity;
+    }
+
+    public void increase(int quantity) {
+        if (quantity <= 0) {
+            throw new IllegalArgumentException();
+        }
+
+        this.quantity += quantity;
+    }
+
+    public void decrease(int quantity) {
+        if (quantity <= 0) {
+            throw new IllegalArgumentException();
+        }
+
+        this.quantity -= quantity;
+    }
+}

--- a/hub/src/main/java/com/klp/hub/inventory/domain/Inventory.java
+++ b/hub/src/main/java/com/klp/hub/inventory/domain/Inventory.java
@@ -26,25 +26,25 @@ public class Inventory {
     }
 
     public Inventory(Integer quantity) {
-        if (quantity == null || quantity <= 0) {
-            throw new IllegalArgumentException();
-        }
+        validQuantity(quantity);
         this.quantity = quantity;
     }
 
-    public void increase(int quantity) {
-        if (quantity <= 0) {
-            throw new IllegalArgumentException();
-        }
+    public void increase(Integer quantity) {
+        validQuantity(quantity);
 
         this.quantity += quantity;
     }
 
-    public void decrease(int quantity) {
-        if (quantity <= 0) {
-            throw new IllegalArgumentException();
-        }
+    public void decrease(Integer quantity) {
+        validQuantity(quantity);
 
         this.quantity -= quantity;
+    }
+
+    private void validQuantity(Integer quantity) {
+        if (quantity == null || quantity <= 0) {
+            throw new IllegalArgumentException("재고 수량은 필수이면서 음수일 수 없습니다.");
+        }
     }
 }

--- a/hub/src/main/java/com/klp/hub/product/domain/Product.java
+++ b/hub/src/main/java/com/klp/hub/product/domain/Product.java
@@ -18,14 +18,23 @@ public class Product {
     @Column(nullable = false)
     private UUID id;
 
+    @Comment("회사 ID")
+    @Column(name = "company_id", nullable = false)
+    private String companyId;
+
     @Comment("상품명")
     @Column(name = "name", nullable = false)
     private String name;
 
-    public Product(String name) {
+    public Product(String companyId, String name) {
         if (name == null || name.isBlank()) {
             throw new IllegalArgumentException("상품명은 필수입니다.");
         }
+
+        if (companyId == null) {
+            throw new IllegalArgumentException("업체 ID는 필수입니다.");
+        }
         this.name = name;
+        this.companyId = companyId;
     }
 }

--- a/hub/src/main/java/com/klp/hub/product/domain/Product.java
+++ b/hub/src/main/java/com/klp/hub/product/domain/Product.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 public class Product {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(nullable = false)
+    @Column(name = "product_id", nullable = false)
     private UUID id;
 
     @Comment("회사 ID")

--- a/hub/src/main/java/com/klp/hub/product/domain/Product.java
+++ b/hub/src/main/java/com/klp/hub/product/domain/Product.java
@@ -1,0 +1,31 @@
+package com.klp.hub.product.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_products")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Product {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(nullable = false)
+    private UUID id;
+
+    @Comment("상품명")
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    public Product(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("상품명은 필수입니다.");
+        }
+        this.name = name;
+    }
+}

--- a/hub/src/test/java/com/klp/hub/company/domain/CompanyTest.java
+++ b/hub/src/test/java/com/klp/hub/company/domain/CompanyTest.java
@@ -1,0 +1,51 @@
+package com.klp.hub.company.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CompanyTest {
+
+    @Test
+    @DisplayName("업체 종류는 Null 일 수 없다")
+    void nullCompanyType() {
+        assertThrows(IllegalArgumentException.class, () -> createCompanyByType(null));
+    }
+
+    @Test
+    @DisplayName("업체명은 Null일 수 없다")
+    void nullCompanyName() {
+        assertThrows(IllegalArgumentException.class, () -> createCompanyByName(null));
+    }
+
+    @Test
+    @DisplayName("업체명은 필수이다")
+    void blankCompanyName() {
+        assertThrows(IllegalArgumentException.class, () -> createCompanyByName(" "));
+    }
+
+    @Test
+    @DisplayName("업체주소은 Null일 수 없다")
+    void nullCompanyAddress() {
+        assertThrows(IllegalArgumentException.class, () -> createCompanyByAddress(null));
+    }
+
+    @Test
+    @DisplayName("업체주소는 필수이다")
+    void blankCompanyAddress() {
+        assertThrows(IllegalArgumentException.class, () -> createCompanyByAddress(" "));
+    }
+
+    private Company createCompanyByType(CompanyType type) {
+        return new Company(type, "name", "address");
+    }
+
+    private Company createCompanyByName(String name) {
+        return new Company(CompanyType.SUPPLIER, name, "address");
+    }
+
+    private Company createCompanyByAddress(String address) {
+        return new Company(CompanyType.SUPPLIER, "상품명", address);
+    }
+}

--- a/hub/src/test/java/com/klp/hub/inventory/domain/InventoryTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/domain/InventoryTest.java
@@ -48,6 +48,15 @@ class InventoryTest {
     }
 
     @Test
+    @DisplayName("기존 재고 수량보다 더 많은 수량을 차감할 수 없다")
+    void betterThanQuantity() {
+        Inventory inventory = inventory(100);
+        assertThrows(IllegalArgumentException.class, () -> {
+            inventory.decrease(101);
+        });
+    }
+
+    @Test
     @DisplayName("재고의 수량을 차감시킬 수 있다")
     void decreaseQuantity() {
         Inventory inventory = inventory(1);

--- a/hub/src/test/java/com/klp/hub/inventory/domain/InventoryTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/domain/InventoryTest.java
@@ -10,19 +10,19 @@ class InventoryTest {
     @Test
     @DisplayName("재고 수량은 음수가 될 수 없다")
     void negativeQuantity() {
-        assertThrows(IllegalArgumentException.class, () -> new Inventory(-1));
+        assertThrows(IllegalArgumentException.class, () -> inventory(-1));
     }
 
     @Test
     @DisplayName("재고 수량은 null이 될 수 없다")
     void nullInventory() {
-        assertThrows(IllegalArgumentException.class, () -> new Inventory(null));
+        assertThrows(IllegalArgumentException.class, () -> inventory(null));
     }
 
     @Test
     @DisplayName("재고 증가시 인자가 음수가 될 수 없다")
     void increaseNegativeQuantity() {
-        Inventory inventory = new Inventory();
+        Inventory inventory = inventory(0);
         assertThrows(IllegalArgumentException.class, () -> {
             inventory.increase(-1);
         });
@@ -31,7 +31,7 @@ class InventoryTest {
     @Test
     @DisplayName("재고의 수량을 증가시킬 수 있다")
     void increaseQuantity() {
-        Inventory inventory = new Inventory(1);
+        Inventory inventory = inventory(1);
 
         inventory.increase(1);
 
@@ -41,7 +41,7 @@ class InventoryTest {
     @Test
     @DisplayName("재고 차감시 인자가 음수가 될 수 없다")
     void decreaseNegativeQuantity() {
-        Inventory inventory = new Inventory();
+        Inventory inventory = inventory(0);
         assertThrows(IllegalArgumentException.class, () -> {
             inventory.decrease(-1);
         });
@@ -50,10 +50,14 @@ class InventoryTest {
     @Test
     @DisplayName("재고의 수량을 차감시킬 수 있다")
     void decreaseQuantity() {
-        Inventory inventory = new Inventory(1);
+        Inventory inventory = inventory(1);
 
         inventory.decrease(1);
 
         assertEquals(0, inventory.getQuantity());
+    }
+
+    private Inventory inventory(Integer quantity) {
+        return new Inventory(quantity, "productId");
     }
 }

--- a/hub/src/test/java/com/klp/hub/inventory/domain/InventoryTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/domain/InventoryTest.java
@@ -1,0 +1,59 @@
+package com.klp.hub.inventory.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InventoryTest {
+
+    @Test
+    @DisplayName("재고 수량은 음수가 될 수 없다")
+    void negativeQuantity() {
+        assertThrows(IllegalArgumentException.class, () -> new Inventory(-1));
+    }
+
+    @Test
+    @DisplayName("재고 수량은 null이 될 수 없다")
+    void nullInventory() {
+        assertThrows(IllegalArgumentException.class, () -> new Inventory(null));
+    }
+
+    @Test
+    @DisplayName("재고 증가시 인자가 음수가 될 수 없다")
+    void increaseNegativeQuantity() {
+        Inventory inventory = new Inventory();
+        assertThrows(IllegalArgumentException.class, () -> {
+            inventory.increase(-1);
+        });
+    }
+
+    @Test
+    @DisplayName("재고의 수량을 증가시킬 수 있다")
+    void increaseQuantity() {
+        Inventory inventory = new Inventory(1);
+
+        inventory.increase(1);
+
+        assertEquals(2, inventory.getQuantity());
+    }
+
+    @Test
+    @DisplayName("재고 차감시 인자가 음수가 될 수 없다")
+    void decreaseNegativeQuantity() {
+        Inventory inventory = new Inventory();
+        assertThrows(IllegalArgumentException.class, () -> {
+            inventory.decrease(-1);
+        });
+    }
+
+    @Test
+    @DisplayName("재고의 수량을 차감시킬 수 있다")
+    void decreaseQuantity() {
+        Inventory inventory = new Inventory(1);
+
+        inventory.decrease(1);
+
+        assertEquals(0, inventory.getQuantity());
+    }
+}

--- a/hub/src/test/java/com/klp/hub/product/domain/ProductTest.java
+++ b/hub/src/test/java/com/klp/hub/product/domain/ProductTest.java
@@ -1,0 +1,21 @@
+package com.klp.hub.product.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProductTest {
+
+    @Test
+    @DisplayName("상품명은 Null일 수 없다")
+    void nullProductName() {
+        assertThrows(IllegalArgumentException.class, () -> new Product(null));
+    }
+
+    @Test
+    @DisplayName("상품명은 필수이다")
+    void blankProductName() {
+        assertThrows(IllegalArgumentException.class, () -> new Product(" "));
+    }
+}

--- a/hub/src/test/java/com/klp/hub/product/domain/ProductTest.java
+++ b/hub/src/test/java/com/klp/hub/product/domain/ProductTest.java
@@ -10,12 +10,26 @@ class ProductTest {
     @Test
     @DisplayName("상품명은 Null일 수 없다")
     void nullProductName() {
-        assertThrows(IllegalArgumentException.class, () -> new Product(null));
+        assertThrows(IllegalArgumentException.class, () -> createProductByName(null));
     }
 
     @Test
     @DisplayName("상품명은 필수이다")
     void blankProductName() {
-        assertThrows(IllegalArgumentException.class, () -> new Product(" "));
+        assertThrows(IllegalArgumentException.class, () -> createProductByName(" "));
+    }
+
+    @Test
+    @DisplayName("업체 ID는 Null일 수 없다")
+    void nullCompanyId() {
+        assertThrows(IllegalArgumentException.class, () -> createProductByCompanyId(null));
+    }
+
+    private Product createProductByName(String name) {
+        return new Product("companyId", name);
+    }
+
+    private Product createProductByCompanyId(String companyId) {
+        return new Product(companyId, "상품명");
     }
 }


### PR DESCRIPTION
## PR 내용
- #11 
  - 상품(`Product`), 업체(`Company`), 재고(`Inventory`) 에 대한 도메인을 설계 및 개발하였습니다
  - 각 도메인마다 패키지로 구성한 이유는 각 도메인이 서로 다른 생애주기를 가진 것 이라고 판단했습니다 (각자가 애그리거트 루트)
  - 그래서 연관관계도 간접참조로 구성했으며 JPA 연관관계로 처리할 경우 서로의 영역을 침범하여 사용한다고 느껴서 간접참조로 구성했습니다

<img width="936" height="424" alt="image" src="https://github.com/user-attachments/assets/9d8f9ec7-78ce-49d7-a006-8962b10bff11" />

<img width="610" height="512" alt="image" src="https://github.com/user-attachments/assets/b8901485-28f6-48b1-8c48-9ccb913e0163" /> 

## 리뷰 포인트
- 각 도메인 정책중에 빠진 부분 혹은 수정해야될 부분이 있는지 리뷰해주시면 좋을 것 같습니다!