### PR TITLE
feat: 상품, 재고 변경 API 

### DIFF
--- a/hub/build.gradle
+++ b/hub/build.gradle
@@ -26,6 +26,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'org.postgresql:postgresql'
 

--- a/hub/src/main/java/com/klp/hub/company/domain/Company.java
+++ b/hub/src/main/java/com/klp/hub/company/domain/Company.java
@@ -1,5 +1,6 @@
 package com.klp.hub.company.domain;
 
+import com.klp.hub.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -15,7 +16,7 @@ import java.util.UUID;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Company {
+public class Company extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "company_id", nullable = false)

--- a/hub/src/main/java/com/klp/hub/global/config/QuerydslConfig.java
+++ b/hub/src/main/java/com/klp/hub/global/config/QuerydslConfig.java
@@ -1,4 +1,4 @@
-package com.klp.hub.config;
+package com.klp.hub.global.config;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;

--- a/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
@@ -32,6 +32,13 @@ public class InventoryService {
         );
     }
 
+    @Transactional
+    public UUID create(UUID productId, UUID hubId, Integer quantity) {
+        Inventory savedInventory = inventoryRepository.save(new Inventory(productId, hubId, quantity));
+        return savedInventory.getId();
+    }
+
+    @Transactional
     public UUID delete(UUID inventoryId) {
         Inventory inventory = getById(inventoryId);
 

--- a/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
@@ -40,6 +40,10 @@ public class InventoryService {
     }
 
     private Inventory getById(UUID inventoryId) {
-        return inventoryRepository.findById(inventoryId).orElse(null);
+        return inventoryRepository.findById(inventoryId).orElseThrow(() -> {
+            log.error("재고가 존재하지 않습니다. inventoryId = {}", inventoryId);
+            // FIXME: 도메인 예외 전까지 임시 예외처리
+            throw new RuntimeException();
+        });
     }
 }

--- a/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
@@ -27,6 +27,7 @@ public class InventoryService {
 
         return new InventoryResponse(
                 productId,
+                inventory.getId(),
                 inventory.getQuantity()
         );
     }

--- a/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
@@ -30,4 +30,16 @@ public class InventoryService {
                 inventory.getQuantity()
         );
     }
+
+    public UUID delete(UUID inventoryId) {
+        Inventory inventory = getById(inventoryId);
+
+        inventory.delete(1L);
+
+        return inventory.getId();
+    }
+
+    private Inventory getById(UUID inventoryId) {
+        return inventoryRepository.findById(inventoryId).orElse(null);
+    }
 }

--- a/hub/src/main/java/com/klp/hub/inventory/domain/Inventory.java
+++ b/hub/src/main/java/com/klp/hub/inventory/domain/Inventory.java
@@ -57,12 +57,20 @@ public class Inventory extends BaseEntity {
         this.quantity = quantity;
     }
 
+    /**
+     * @param quantity 재고 수량
+     * 재고 수량을 증가시킨다
+     */
     public void replenish(Integer quantity) {
         validQuantity(quantity);
 
         this.quantity += quantity;
     }
 
+    /**
+     * @param quantity 재고 수량
+     * 재고 수량을 차감시킨다
+     */
     public void deduct(Integer quantity) {
         validQuantity(quantity);
 

--- a/hub/src/main/java/com/klp/hub/inventory/domain/Inventory.java
+++ b/hub/src/main/java/com/klp/hub/inventory/domain/Inventory.java
@@ -57,13 +57,13 @@ public class Inventory extends BaseEntity {
         this.quantity = quantity;
     }
 
-    public void increase(Integer quantity) {
+    public void replenish(Integer quantity) {
         validQuantity(quantity);
 
         this.quantity += quantity;
     }
 
-    public void decrease(Integer quantity) {
+    public void deduct(Integer quantity) {
         validQuantity(quantity);
 
         if (this.quantity - quantity < 0) {

--- a/hub/src/main/java/com/klp/hub/inventory/domain/Inventory.java
+++ b/hub/src/main/java/com/klp/hub/inventory/domain/Inventory.java
@@ -15,6 +15,7 @@ import java.util.UUID;
         schema = "hub_schema"
 )
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Inventory extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -33,12 +34,16 @@ public class Inventory extends BaseEntity {
     @Column(name = "hub_id", nullable = false)
     private UUID hubId;
 
-    public Inventory() {
+    public Inventory(UUID productId, UUID hubId) {
+        validProduct(productId);
+        this.productId = productId;
+        this.hubId = hubId;
         this.quantity = 0;
     }
 
     public Inventory(UUID productId, UUID hubId, Integer quantity) {
         validQuantity(quantity);
+        validProduct(productId);
         this.productId = productId;
         this.hubId = hubId;
         this.quantity = quantity;
@@ -63,6 +68,12 @@ public class Inventory extends BaseEntity {
     private void validQuantity(Integer quantity) {
         if (quantity == null || quantity < 0) {
             throw new IllegalArgumentException("재고 수량은 필수이면서 음수일 수 없습니다.");
+        }
+    }
+
+    private void validProduct(UUID productId) {
+        if (productId == null) {
+            throw new IllegalArgumentException("상품은 필수입니다.");
         }
     }
 }

--- a/hub/src/main/java/com/klp/hub/inventory/domain/Inventory.java
+++ b/hub/src/main/java/com/klp/hub/inventory/domain/Inventory.java
@@ -1,5 +1,6 @@
 package com.klp.hub.inventory.domain;
 
+import com.klp.hub.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -14,7 +15,7 @@ import java.util.UUID;
         schema = "hub_schema"
 )
 @Getter
-public class Inventory {
+public class Inventory extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "invevntory_id", nullable = false)

--- a/hub/src/main/java/com/klp/hub/inventory/domain/Inventory.java
+++ b/hub/src/main/java/com/klp/hub/inventory/domain/Inventory.java
@@ -36,6 +36,7 @@ public class Inventory extends BaseEntity {
 
     public Inventory(UUID productId, UUID hubId) {
         validProduct(productId);
+        validHub(hubId);
         this.productId = productId;
         this.hubId = hubId;
         this.quantity = 0;
@@ -44,6 +45,7 @@ public class Inventory extends BaseEntity {
     public Inventory(UUID productId, UUID hubId, Integer quantity) {
         validQuantity(quantity);
         validProduct(productId);
+        validHub(hubId);
         this.productId = productId;
         this.hubId = hubId;
         this.quantity = quantity;
@@ -74,6 +76,12 @@ public class Inventory extends BaseEntity {
     private void validProduct(UUID productId) {
         if (productId == null) {
             throw new IllegalArgumentException("상품은 필수입니다.");
+        }
+    }
+
+    private void validHub(UUID hubId) {
+        if (hubId == null) {
+            throw new IllegalArgumentException("허브는 필수입니다.");
         }
     }
 }

--- a/hub/src/main/java/com/klp/hub/inventory/domain/Inventory.java
+++ b/hub/src/main/java/com/klp/hub/inventory/domain/Inventory.java
@@ -12,7 +12,13 @@ import java.util.UUID;
 @Entity
 @Table(
         name = "p_inventory",
-        schema = "hub_schema"
+        schema = "hub_schema",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_inventory_product_hub",
+                        columnNames = {"product_id", "hub_id"}
+                )
+        }
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/hub/src/main/java/com/klp/hub/inventory/domain/InventoryIdempotency.java
+++ b/hub/src/main/java/com/klp/hub/inventory/domain/InventoryIdempotency.java
@@ -1,24 +1,30 @@
 package com.klp.hub.inventory.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 
-import java.util.UUID;
-
 @Entity
 @Table(
-        name = "p_inventory_idempotency",
-        schema = "hub_schema",
-        uniqueConstraints = {
-                @UniqueConstraint(
-                        name = "uk_inventory_idempotency_key", columnNames = "idempotency_key"
-                )
-        }
+    name = "p_inventory_idempotency",
+    schema = "hub_schema",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_inventory_idempotency_key", columnNames = "idempotency_key"
+        )
+    }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class InventoryIdempotency {
+
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "invevntory_idempotency_id", nullable = false)
@@ -29,7 +35,7 @@ public class InventoryIdempotency {
     private String idempotencyKey;
 
     public InventoryIdempotency(String idempotencyKey) {
-        if (idempotencyKey == null) {
+        if (idempotencyKey == null || idempotencyKey.isBlank()) {
             throw new IllegalArgumentException("멱등키는 필수값 입니다.");
         }
         this.idempotencyKey = idempotencyKey;

--- a/hub/src/main/java/com/klp/hub/inventory/domain/InventoryIdempotency.java
+++ b/hub/src/main/java/com/klp/hub/inventory/domain/InventoryIdempotency.java
@@ -1,0 +1,37 @@
+package com.klp.hub.inventory.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import java.util.UUID;
+
+@Entity
+@Table(
+        name = "p_inventory_idempotency",
+        schema = "hub_schema",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_inventory_idempotency_key", columnNames = "idempotency_key"
+                )
+        }
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InventoryIdempotency {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "invevntory_idempotency_id", nullable = false)
+    private UUID id;
+
+    @Comment("멱등키")
+    @Column(name = "idempotency_key", nullable = false)
+    private String idempotencyKey;
+
+    public InventoryIdempotency(String idempotencyKey) {
+        if (idempotencyKey == null) {
+            throw new IllegalArgumentException("멱등키는 필수값 입니다.");
+        }
+        this.idempotencyKey = idempotencyKey;
+    }
+}

--- a/hub/src/main/java/com/klp/hub/inventory/domain/repository/InventoryRepository.java
+++ b/hub/src/main/java/com/klp/hub/inventory/domain/repository/InventoryRepository.java
@@ -9,4 +9,6 @@ public interface InventoryRepository {
     Optional<Inventory> findByProductId(UUID productId);
 
     Optional<Inventory> findById(UUID inventoryId);
+
+    Inventory save(Inventory inventory);
 }

--- a/hub/src/main/java/com/klp/hub/inventory/domain/repository/InventoryRepository.java
+++ b/hub/src/main/java/com/klp/hub/inventory/domain/repository/InventoryRepository.java
@@ -7,4 +7,6 @@ import java.util.UUID;
 
 public interface InventoryRepository {
     Optional<Inventory> findByProductId(UUID productId);
+
+    Optional<Inventory> findById(UUID inventoryId);
 }

--- a/hub/src/main/java/com/klp/hub/inventory/domain/repository/exception/UniqueConstraintException.java
+++ b/hub/src/main/java/com/klp/hub/inventory/domain/repository/exception/UniqueConstraintException.java
@@ -1,0 +1,7 @@
+package com.klp.hub.inventory.domain.repository.exception;
+
+public class UniqueConstraintException extends RuntimeException {
+    public UniqueConstraintException(String message) {
+        super(message);
+    }
+}

--- a/hub/src/main/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryImpl.java
+++ b/hub/src/main/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryImpl.java
@@ -2,7 +2,9 @@ package com.klp.hub.inventory.infrastructure.repository;
 
 import com.klp.hub.inventory.domain.Inventory;
 import com.klp.hub.inventory.domain.repository.InventoryRepository;
+import com.klp.hub.inventory.domain.repository.exception.UniqueConstraintException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -25,6 +27,10 @@ public class InventoryRepositoryImpl implements InventoryRepository {
 
     @Override
     public Inventory save(Inventory inventory) {
-        return inventoryJpaRepository.save(inventory);
+        try {
+            return inventoryJpaRepository.saveAndFlush(inventory);
+        } catch (DataIntegrityViolationException exception) {
+            throw new UniqueConstraintException("이미 해당 재고가 존재합니다.");
+        }
     }
 }

--- a/hub/src/main/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryImpl.java
+++ b/hub/src/main/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryImpl.java
@@ -17,4 +17,9 @@ public class InventoryRepositoryImpl implements InventoryRepository {
     public Optional<Inventory> findByProductId(UUID productId) {
         return inventoryJpaRepository.findByProductId(productId);
     }
+
+    @Override
+    public Optional<Inventory> findById(UUID inventoryId) {
+        return inventoryJpaRepository.findById(inventoryId);
+    }
 }

--- a/hub/src/main/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryImpl.java
+++ b/hub/src/main/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryImpl.java
@@ -22,4 +22,9 @@ public class InventoryRepositoryImpl implements InventoryRepository {
     public Optional<Inventory> findById(UUID inventoryId) {
         return inventoryJpaRepository.findById(inventoryId);
     }
+
+    @Override
+    public Inventory save(Inventory inventory) {
+        return inventoryJpaRepository.save(inventory);
+    }
 }

--- a/hub/src/main/java/com/klp/hub/inventory/presentation/dto/InventoryResponse.java
+++ b/hub/src/main/java/com/klp/hub/inventory/presentation/dto/InventoryResponse.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 public record InventoryResponse(
         UUID productId,
+        UUID inventoryId,
         Integer quantity
 ) {
 }

--- a/hub/src/main/java/com/klp/hub/product/application/ProductService.java
+++ b/hub/src/main/java/com/klp/hub/product/application/ProductService.java
@@ -50,9 +50,12 @@ public class ProductService {
         product.updateName(command.name());
     }
 
+    @Transactional
     public UUID delete(UUID productId) {
         Product product = getById(productId);
-        return null;
+
+        product.delete(1L);
+        return product.getId();
     }
 
     private Product getById(UUID productId) {

--- a/hub/src/main/java/com/klp/hub/product/application/ProductService.java
+++ b/hub/src/main/java/com/klp/hub/product/application/ProductService.java
@@ -49,6 +49,16 @@ public class ProductService {
     }
 
     @Transactional
+    public void create(ProductCreateCommand command) {
+        CompanyResponse companyResponse = companyService.getByCompanyId(command.companyId());
+        Product savedProduct = productRepository.save(
+                new Product(companyResponse.id(), command.name())
+        );
+
+        inventoryService.create(savedProduct.getId(), command.hubId(), command.quantity());
+    }
+
+    @Transactional
     public void update(ProductUpdateCommand command) {
         Product product = getById(command.productId());
 
@@ -72,12 +82,5 @@ public class ProductService {
             return new RuntimeException();
         });
         return product;
-    }
-
-    @Transactional
-    public void create(ProductCreateCommand command) {
-        Product savedProduct = productRepository.save(new Product(command.companyId(), command.name()));
-
-        inventoryService.create(savedProduct.getId(), command.hubId(), command.quantity());
     }
 }

--- a/hub/src/main/java/com/klp/hub/product/application/ProductService.java
+++ b/hub/src/main/java/com/klp/hub/product/application/ProductService.java
@@ -8,6 +8,7 @@ import com.klp.hub.inventory.presentation.dto.InventoryResponse;
 import com.klp.hub.product.application.dto.ProductCreateCommand;
 import com.klp.hub.product.domain.Product;
 import com.klp.hub.product.domain.repository.ProductRepository;
+import com.klp.hub.product.presentation.dto.ProductUpdateResponse;
 import com.klp.hub.product.presentation.dto.ProductsPageRowResponse;
 import com.klp.hub.product.presentation.dto.ProductResponse;
 import lombok.RequiredArgsConstructor;
@@ -66,10 +67,15 @@ public class ProductService {
     }
 
     @Transactional
-    public void update(ProductUpdateCommand command) {
+    public ProductUpdateResponse update(ProductUpdateCommand command) {
         Product product = getById(command.productId());
 
         product.updateName(command.name());
+
+        return new ProductUpdateResponse(
+                product.getId(),
+                product.getName()
+        );
     }
 
     @Transactional

--- a/hub/src/main/java/com/klp/hub/product/application/ProductService.java
+++ b/hub/src/main/java/com/klp/hub/product/application/ProductService.java
@@ -3,6 +3,7 @@ package com.klp.hub.product.application;
 import com.klp.hub.company.application.CompanyService;
 import com.klp.hub.company.presentation.dto.CompanyResponse;
 import com.klp.hub.inventory.application.InventoryService;
+import com.klp.hub.inventory.domain.repository.exception.UniqueConstraintException;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
 import com.klp.hub.product.application.dto.ProductCreateCommand;
 import com.klp.hub.product.domain.Product;
@@ -55,7 +56,13 @@ public class ProductService {
                 new Product(companyResponse.id(), command.name())
         );
 
-        inventoryService.create(savedProduct.getId(), command.hubId(), command.quantity());
+        try {
+            inventoryService.create(savedProduct.getId(), command.hubId(), command.quantity());
+        } catch (UniqueConstraintException exception) {
+            log.error("이미 해당 재고가 존재합니다.");
+            // FIXME: 도메인 예외 교체 필요
+            throw new RuntimeException(exception.getMessage());
+        }
     }
 
     @Transactional

--- a/hub/src/main/java/com/klp/hub/product/application/ProductService.java
+++ b/hub/src/main/java/com/klp/hub/product/application/ProductService.java
@@ -14,6 +14,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
+import com.klp.hub.product.application.dto.ProductUpdateCommand;
+import com.klp.hub.product.domain.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
@@ -44,5 +49,8 @@ public class ProductService {
     @Transactional(readOnly = true)
     public Page<ProductsPageRowResponse> getProductsByPageable(Pageable pageable) {
         return productRepository.findAllByPageable(pageable);
+    }
+
+    public void update(ProductUpdateCommand request) {
     }
 }

--- a/hub/src/main/java/com/klp/hub/product/application/ProductService.java
+++ b/hub/src/main/java/com/klp/hub/product/application/ProductService.java
@@ -2,6 +2,8 @@ package com.klp.hub.product.application;
 
 import com.klp.hub.company.application.CompanyService;
 import com.klp.hub.company.presentation.dto.CompanyResponse;
+import com.klp.hub.inventory.application.InventoryService;
+import com.klp.hub.inventory.presentation.dto.InventoryResponse;
 import com.klp.hub.product.domain.Product;
 import com.klp.hub.product.domain.repository.ProductRepository;
 import com.klp.hub.product.presentation.dto.ProductsPageRowResponse;
@@ -24,6 +26,8 @@ public class ProductService {
     private final ProductRepository productRepository;
 
     private final CompanyService companyService;
+
+    private final InventoryService inventoryService;
 
     @Transactional(readOnly = true)
     public ProductResponse getProductById(UUID productId) {
@@ -55,6 +59,9 @@ public class ProductService {
         Product product = getById(productId);
 
         product.delete(1L);
+
+        InventoryResponse response = inventoryService.getByProductId(productId);
+        inventoryService.delete(response.inventoryId());
         return product.getId();
     }
 

--- a/hub/src/main/java/com/klp/hub/product/application/ProductService.java
+++ b/hub/src/main/java/com/klp/hub/product/application/ProductService.java
@@ -50,6 +50,11 @@ public class ProductService {
         product.updateName(command.name());
     }
 
+    public UUID delete(UUID productId) {
+        Product product = getById(productId);
+        return null;
+    }
+
     private Product getById(UUID productId) {
         Product product = productRepository.findById(productId).orElseThrow(() -> {
             log.error("해당 상품을 찾을 수 없습니다. productId : {}", productId);

--- a/hub/src/main/java/com/klp/hub/product/application/ProductService.java
+++ b/hub/src/main/java/com/klp/hub/product/application/ProductService.java
@@ -51,7 +51,7 @@ public class ProductService {
     }
 
     @Transactional
-    public void create(ProductCreateCommand command) {
+    public UUID create(ProductCreateCommand command) {
         CompanyResponse companyResponse = companyService.getByCompanyId(command.companyId());
         Product savedProduct = productRepository.save(
                 new Product(companyResponse.id(), command.name())
@@ -59,6 +59,7 @@ public class ProductService {
 
         try {
             inventoryService.create(savedProduct.getId(), command.hubId(), command.quantity());
+            return savedProduct.getId();
         } catch (UniqueConstraintException exception) {
             log.error("이미 해당 재고가 존재합니다.");
             // FIXME: 도메인 예외 교체 필요

--- a/hub/src/main/java/com/klp/hub/product/application/ProductService.java
+++ b/hub/src/main/java/com/klp/hub/product/application/ProductService.java
@@ -15,10 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 import com.klp.hub.product.application.dto.ProductUpdateCommand;
-import com.klp.hub.product.domain.repository.ProductRepository;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
@@ -31,11 +27,7 @@ public class ProductService {
 
     @Transactional(readOnly = true)
     public ProductResponse getProductById(UUID productId) {
-        Product product = productRepository.findById(productId).orElseThrow(() -> {
-            log.error("해당 상품을 찾을 수 없습니다. productId : {}", productId);
-            return new RuntimeException();
-        });
-
+        Product product = getById(productId);
         CompanyResponse company = companyService.getByCompanyId(product.getCompanyId());
 
         return new ProductResponse(
@@ -51,6 +43,18 @@ public class ProductService {
         return productRepository.findAllByPageable(pageable);
     }
 
-    public void update(ProductUpdateCommand request) {
+    @Transactional
+    public void update(ProductUpdateCommand command) {
+        Product product = getById(command.productId());
+
+        product.updateName(command.name());
+    }
+
+    private Product getById(UUID productId) {
+        Product product = productRepository.findById(productId).orElseThrow(() -> {
+            log.error("해당 상품을 찾을 수 없습니다. productId : {}", productId);
+            return new RuntimeException();
+        });
+        return product;
     }
 }

--- a/hub/src/main/java/com/klp/hub/product/application/ProductService.java
+++ b/hub/src/main/java/com/klp/hub/product/application/ProductService.java
@@ -4,6 +4,7 @@ import com.klp.hub.company.application.CompanyService;
 import com.klp.hub.company.presentation.dto.CompanyResponse;
 import com.klp.hub.inventory.application.InventoryService;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
+import com.klp.hub.product.application.dto.ProductCreateCommand;
 import com.klp.hub.product.domain.Product;
 import com.klp.hub.product.domain.repository.ProductRepository;
 import com.klp.hub.product.presentation.dto.ProductsPageRowResponse;
@@ -71,5 +72,12 @@ public class ProductService {
             return new RuntimeException();
         });
         return product;
+    }
+
+    @Transactional
+    public void create(ProductCreateCommand command) {
+        Product savedProduct = productRepository.save(new Product(command.companyId(), command.name()));
+
+        inventoryService.create(savedProduct.getId(), command.hubId(), command.quantity());
     }
 }

--- a/hub/src/main/java/com/klp/hub/product/application/dto/ProductCreateCommand.java
+++ b/hub/src/main/java/com/klp/hub/product/application/dto/ProductCreateCommand.java
@@ -1,0 +1,11 @@
+package com.klp.hub.product.application.dto;
+
+import java.util.UUID;
+
+public record ProductCreateCommand(
+        UUID companyId,
+        UUID hubId,
+        String name,
+        Integer quantity
+) {
+}

--- a/hub/src/main/java/com/klp/hub/product/application/dto/ProductUpdateCommand.java
+++ b/hub/src/main/java/com/klp/hub/product/application/dto/ProductUpdateCommand.java
@@ -1,0 +1,9 @@
+package com.klp.hub.product.application.dto;
+
+import java.util.UUID;
+
+public record ProductUpdateCommand(
+        UUID productId,
+        String name
+) {
+}

--- a/hub/src/main/java/com/klp/hub/product/domain/Product.java
+++ b/hub/src/main/java/com/klp/hub/product/domain/Product.java
@@ -40,4 +40,10 @@ public class Product {
         this.name = name;
         this.companyId = companyId;
     }
+
+    public void updateName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("상품명은 필수입니다.");
+        }
+    }
 }

--- a/hub/src/main/java/com/klp/hub/product/domain/Product.java
+++ b/hub/src/main/java/com/klp/hub/product/domain/Product.java
@@ -1,5 +1,6 @@
 package com.klp.hub.product.domain;
 
+import com.klp.hub.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -15,7 +16,7 @@ import java.util.UUID;
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Product {
+public class Product extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "product_id", nullable = false)

--- a/hub/src/main/java/com/klp/hub/product/domain/Product.java
+++ b/hub/src/main/java/com/klp/hub/product/domain/Product.java
@@ -30,9 +30,7 @@ public class Product {
     private String name;
 
     public Product(UUID companyId, String name) {
-        if (name == null || name.isBlank()) {
-            throw new IllegalArgumentException("상품명은 필수입니다.");
-        }
+        validateName(name);
 
         if (companyId == null) {
             throw new IllegalArgumentException("업체 ID는 필수입니다.");
@@ -42,6 +40,10 @@ public class Product {
     }
 
     public void updateName(String name) {
+        validateName(name);
+    }
+
+    private void validateName(String name) {
         if (name == null || name.isBlank()) {
             throw new IllegalArgumentException("상품명은 필수입니다.");
         }

--- a/hub/src/main/java/com/klp/hub/product/domain/Product.java
+++ b/hub/src/main/java/com/klp/hub/product/domain/Product.java
@@ -41,6 +41,8 @@ public class Product {
 
     public void updateName(String name) {
         validateName(name);
+
+        this.name = name;
     }
 
     private void validateName(String name) {

--- a/hub/src/main/java/com/klp/hub/product/domain/repository/ProductRepository.java
+++ b/hub/src/main/java/com/klp/hub/product/domain/repository/ProductRepository.java
@@ -12,4 +12,6 @@ public interface ProductRepository {
     Optional<Product> findById(UUID id);
 
     Page<ProductsPageRowResponse> findAllByPageable(Pageable pageable);
+
+    Product save(Product product);
 }

--- a/hub/src/main/java/com/klp/hub/product/infrastructure/repository/ProductRepositoryImpl.java
+++ b/hub/src/main/java/com/klp/hub/product/infrastructure/repository/ProductRepositoryImpl.java
@@ -53,6 +53,11 @@ public class ProductRepositoryImpl implements ProductRepository {
         return new PageImpl<>(response, pageable, total);
     }
 
+    @Override
+    public Product save(Product product) {
+        return productJpaRepository.save(product);
+    }
+
     private ConstructorExpression<ProductsPageRowResponse> getProductListRowProjection() {
         return Projections.constructor(
                 ProductsPageRowResponse.class,

--- a/hub/src/main/java/com/klp/hub/product/presentation/controller/ProductController.java
+++ b/hub/src/main/java/com/klp/hub/product/presentation/controller/ProductController.java
@@ -37,6 +37,14 @@ public class ProductController {
         return ResponseEntity.ok().body(ProductsPageResponse.from(response));
     }
 
+    @PostMapping
+    public ResponseEntity<ProductCreateResponse> create(@Valid @RequestBody ProductCreateRequest request) {
+        log.info("== 상품 생성 ==");
+        UUID productId = productService.create(request.toCommand());
+        log.info("== 상품 생성 성공 ==");
+        return ResponseEntity.ok().body(new ProductCreateResponse(productId));
+    }
+
     @PatchMapping("/{productId}")
     public ResponseEntity<ProductUpdateResponse> updateProduct(
             @PathVariable("productId") String productId,

--- a/hub/src/main/java/com/klp/hub/product/presentation/controller/ProductController.java
+++ b/hub/src/main/java/com/klp/hub/product/presentation/controller/ProductController.java
@@ -1,6 +1,7 @@
 package com.klp.hub.product.presentation.controller;
 
 import com.klp.hub.product.application.ProductService;
+import com.klp.hub.product.presentation.dto.ProductDeleteResponse;
 import com.klp.hub.product.presentation.dto.ProductResponse;
 import com.klp.hub.product.presentation.dto.ProductsPageResponse;
 import com.klp.hub.product.presentation.dto.ProductsPageRowResponse;
@@ -10,10 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
@@ -39,5 +37,13 @@ public class ProductController {
         Page<ProductsPageRowResponse> response = productService.getProductsByPageable(pageable);
         log.info("== 상품 목록 조회 성공 ==");
         return ResponseEntity.ok().body(ProductsPageResponse.from(response));
+    }
+
+    @DeleteMapping("/{productId}")
+    public ResponseEntity<ProductDeleteResponse> deleteById(@PathVariable("productId") String productId) {
+        log.info("== 상품 삭제 ==");
+        UUID deletedProductId = productService.delete(UUID.fromString(productId));
+        log.info("== 상품 삭제 완료 ==");
+        return ResponseEntity.ok().body(new ProductDeleteResponse(deletedProductId));
     }
 }

--- a/hub/src/main/java/com/klp/hub/product/presentation/controller/ProductController.java
+++ b/hub/src/main/java/com/klp/hub/product/presentation/controller/ProductController.java
@@ -1,10 +1,8 @@
 package com.klp.hub.product.presentation.controller;
 
 import com.klp.hub.product.application.ProductService;
-import com.klp.hub.product.presentation.dto.ProductDeleteResponse;
-import com.klp.hub.product.presentation.dto.ProductResponse;
-import com.klp.hub.product.presentation.dto.ProductsPageResponse;
-import com.klp.hub.product.presentation.dto.ProductsPageRowResponse;
+import com.klp.hub.product.presentation.dto.*;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -37,6 +35,17 @@ public class ProductController {
         Page<ProductsPageRowResponse> response = productService.getProductsByPageable(pageable);
         log.info("== 상품 목록 조회 성공 ==");
         return ResponseEntity.ok().body(ProductsPageResponse.from(response));
+    }
+
+    @PatchMapping("/{productId}")
+    public ResponseEntity<ProductUpdateResponse> updateProduct(
+            @PathVariable("productId") String productId,
+            @Valid @RequestBody ProductUpdateRequest request
+    ) {
+        log.info("== 상품 변경 ==");
+        ProductUpdateResponse response = productService.update(request.toCommand(productId));
+        log.info("== 상품 변경 성공 ==");
+        return ResponseEntity.ok().body(response);
     }
 
     @DeleteMapping("/{productId}")

--- a/hub/src/main/java/com/klp/hub/product/presentation/dto/ProductCreateRequest.java
+++ b/hub/src/main/java/com/klp/hub/product/presentation/dto/ProductCreateRequest.java
@@ -1,0 +1,31 @@
+package com.klp.hub.product.presentation.dto;
+
+import com.klp.hub.product.application.dto.ProductCreateCommand;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record ProductCreateRequest(
+        @NotNull(message = "업체 ID 는 필수입니다.")
+        UUID companyId,
+
+        @NotNull(message = "허브 ID 는 필수입니다.")
+        UUID hubId,
+
+        @NotBlank(message = "상품명은 필수입니다.")
+        String name,
+
+        @Min(value = 0, message = "초기 재고 수량은 0 이상이어야 합니다.")
+        int quantity
+) {
+    public ProductCreateCommand toCommand() {
+        return new ProductCreateCommand(
+                companyId,
+                hubId,
+                name,
+                quantity
+        );
+    }
+}

--- a/hub/src/main/java/com/klp/hub/product/presentation/dto/ProductCreateResponse.java
+++ b/hub/src/main/java/com/klp/hub/product/presentation/dto/ProductCreateResponse.java
@@ -1,0 +1,6 @@
+package com.klp.hub.product.presentation.dto;
+
+import java.util.UUID;
+
+public record ProductCreateResponse(UUID productId) {
+}

--- a/hub/src/main/java/com/klp/hub/product/presentation/dto/ProductDeleteResponse.java
+++ b/hub/src/main/java/com/klp/hub/product/presentation/dto/ProductDeleteResponse.java
@@ -1,0 +1,6 @@
+package com.klp.hub.product.presentation.dto;
+
+import java.util.UUID;
+
+public record ProductDeleteResponse(UUID productId) {
+}

--- a/hub/src/main/java/com/klp/hub/product/presentation/dto/ProductUpdateRequest.java
+++ b/hub/src/main/java/com/klp/hub/product/presentation/dto/ProductUpdateRequest.java
@@ -1,0 +1,18 @@
+package com.klp.hub.product.presentation.dto;
+
+import com.klp.hub.product.application.dto.ProductUpdateCommand;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.UUID;
+
+public record ProductUpdateRequest(
+        @NotBlank(message = "상품명은 필수입니다.")
+        String name
+) {
+    public ProductUpdateCommand toCommand(String productId) {
+        return new ProductUpdateCommand(
+                UUID.fromString(productId),
+                name
+        );
+    }
+}

--- a/hub/src/main/java/com/klp/hub/product/presentation/dto/ProductUpdateResponse.java
+++ b/hub/src/main/java/com/klp/hub/product/presentation/dto/ProductUpdateResponse.java
@@ -1,0 +1,9 @@
+package com.klp.hub.product.presentation.dto;
+
+import java.util.UUID;
+
+public record ProductUpdateResponse(
+        UUID productId,
+        String name
+) {
+}

--- a/hub/src/test/java/com/klp/hub/TestJpaConfig.java
+++ b/hub/src/test/java/com/klp/hub/TestJpaConfig.java
@@ -1,0 +1,9 @@
+package com.klp.hub;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@TestConfiguration
+@EnableJpaAuditing
+public class TestJpaConfig {
+}

--- a/hub/src/test/java/com/klp/hub/company/infrastructure/repository/CompanyRepositoryTest.java
+++ b/hub/src/test/java/com/klp/hub/company/infrastructure/repository/CompanyRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.klp.hub.company.infrastructure.repository;
 
+import com.klp.hub.TestJpaConfig;
 import com.klp.hub.company.domain.Company;
 import com.klp.hub.company.domain.CompanyType;
 import com.klp.hub.company.domain.repository.CompanyRepository;
@@ -19,7 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
 @ActiveProfiles("test")
-@Import(CompanyRepositoryImpl.class)
+@Import({
+        CompanyRepositoryImpl.class,
+        TestJpaConfig.class
+})
 class CompanyRepositoryTest {
 
     @Autowired

--- a/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
@@ -67,4 +67,12 @@ class InventoryServiceTest {
         assertTrue(inventory.isDeleted());
         assertThat(inventory.getDeletedAt()).isNotNull();
     }
+
+    @Test
+    @DisplayName("재고 ID 를 통해 재고를 삭제할때 재고가 없다면 예외가 발생한다")
+    void throwDeletedByNullInventoryId() {
+        when(inventoryRepository.findById(inventoryId)).thenReturn(Optional.empty());
+
+        assertThrows(RuntimeException.class, () -> inventoryService.delete(inventoryId));
+    }
 }

--- a/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
@@ -13,6 +13,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.mock;
@@ -27,6 +29,10 @@ class InventoryServiceTest {
     private InventoryService inventoryService;
 
     private UUID productId = UUID.randomUUID();
+
+    private UUID hubId = UUID.randomUUID();
+
+    private UUID inventoryId = UUID.randomUUID();
 
     @Test
     @DisplayName("한 상품의 재고를 조회할 수 있다")
@@ -48,5 +54,17 @@ class InventoryServiceTest {
         when(inventoryRepository.findByProductId(productId)).thenReturn(Optional.empty());
 
         assertThrows(RuntimeException.class, () -> inventoryService.getByProductId(productId));
+    }
+
+    @Test
+    @DisplayName("재고 ID 를 통해 재고를 softDelete 할 수 있다")
+    void softDelete() {
+        Inventory inventory = new Inventory(productId, hubId);
+        when(inventoryRepository.findById(inventoryId)).thenReturn(Optional.of(inventory));
+
+        inventoryService.delete(inventoryId);
+
+        assertTrue(inventory.isDeleted());
+        assertThat(inventory.getDeletedAt()).isNotNull();
     }
 }

--- a/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
@@ -13,7 +13,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;

--- a/hub/src/test/java/com/klp/hub/inventory/domain/InventoryIdempotencyTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/domain/InventoryIdempotencyTest.java
@@ -1,0 +1,15 @@
+package com.klp.hub.inventory.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InventoryIdempotencyTest {
+
+    @Test
+    @DisplayName("멱등키가 존재하지 않는다면 예외가 발생한다")
+    void nullIdempotencyKey() {
+        assertThrows(IllegalArgumentException.class, () -> new InventoryIdempotency(null));
+    }
+}

--- a/hub/src/test/java/com/klp/hub/inventory/domain/InventoryIdempotencyTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/domain/InventoryIdempotencyTest.java
@@ -1,9 +1,9 @@
 package com.klp.hub.inventory.domain;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 class InventoryIdempotencyTest {
 
@@ -11,5 +11,11 @@ class InventoryIdempotencyTest {
     @DisplayName("멱등키가 존재하지 않는다면 예외가 발생한다")
     void nullIdempotencyKey() {
         assertThrows(IllegalArgumentException.class, () -> new InventoryIdempotency(null));
+    }
+
+    @Test
+    @DisplayName("멱등키가 빈 값이라면 예외가 발생한다")
+    void emptyIdempotencyKey() {
+        assertThrows(IllegalArgumentException.class, () -> new InventoryIdempotency(" "));
     }
 }

--- a/hub/src/test/java/com/klp/hub/inventory/domain/InventoryTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/domain/InventoryTest.java
@@ -11,6 +11,8 @@ class InventoryTest {
 
     private UUID hubId = UUID.randomUUID();
 
+    private UUID productId = UUID.randomUUID();
+
     @Test
     @DisplayName("재고 수량은 음수가 될 수 없다")
     void negativeQuantity() {
@@ -74,6 +76,12 @@ class InventoryTest {
     @DisplayName("상품이 존재하지 않으면 예외가 발생한다")
     void throwNullProduct() {
         assertThrows(IllegalArgumentException.class, () -> new Inventory(null, hubId));
+    }
+
+    @Test
+    @DisplayName("허브가 존재하지 않으면 예외가 발생한다")
+    void throwNullHub() {
+        assertThrows(IllegalArgumentException.class, () -> new Inventory(productId, null));
     }
 
     private Inventory inventory(Integer quantity) {

--- a/hub/src/test/java/com/klp/hub/inventory/domain/InventoryTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/domain/InventoryTest.java
@@ -9,6 +9,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class InventoryTest {
 
+    private UUID hubId = UUID.randomUUID();
+
     @Test
     @DisplayName("재고 수량은 음수가 될 수 없다")
     void negativeQuantity() {
@@ -66,6 +68,12 @@ class InventoryTest {
         inventory.decrease(1);
 
         assertEquals(0, inventory.getQuantity());
+    }
+
+    @Test
+    @DisplayName("상품이 존재하지 않으면 예외가 발생한다")
+    void throwNullProduct() {
+        assertThrows(IllegalArgumentException.class, () -> new Inventory(null, hubId));
     }
 
     private Inventory inventory(Integer quantity) {

--- a/hub/src/test/java/com/klp/hub/inventory/domain/InventoryTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/domain/InventoryTest.java
@@ -27,29 +27,29 @@ class InventoryTest {
 
     @Test
     @DisplayName("재고 증가시 인자가 음수가 될 수 없다")
-    void increaseNegativeQuantity() {
+    void replenishNegativeQuantity() {
         Inventory inventory = inventory(0);
         assertThrows(IllegalArgumentException.class, () -> {
-            inventory.increase(-1);
+            inventory.replenish(-1);
         });
     }
 
     @Test
     @DisplayName("재고의 수량을 증가시킬 수 있다")
-    void increaseQuantity() {
+    void replenishQuantity() {
         Inventory inventory = inventory(1);
 
-        inventory.increase(1);
+        inventory.replenish(1);
 
         assertEquals(2, inventory.getQuantity());
     }
 
     @Test
     @DisplayName("재고 차감시 인자가 음수가 될 수 없다")
-    void decreaseNegativeQuantity() {
+    void deductNegativeQuantity() {
         Inventory inventory = inventory(0);
         assertThrows(IllegalArgumentException.class, () -> {
-            inventory.decrease(-1);
+            inventory.deduct(-1);
         });
     }
 
@@ -58,16 +58,16 @@ class InventoryTest {
     void betterThanQuantity() {
         Inventory inventory = inventory(100);
         assertThrows(IllegalArgumentException.class, () -> {
-            inventory.decrease(101);
+            inventory.deduct(101);
         });
     }
 
     @Test
     @DisplayName("재고의 수량을 차감시킬 수 있다")
-    void decreaseQuantity() {
+    void deductQuantity() {
         Inventory inventory = inventory(1);
 
-        inventory.decrease(1);
+        inventory.deduct(1);
 
         assertEquals(0, inventory.getQuantity());
     }

--- a/hub/src/test/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryTest.java
@@ -1,7 +1,9 @@
 package com.klp.hub.inventory.infrastructure.repository;
 
+import com.klp.hub.TestJpaConfig;
 import com.klp.hub.inventory.domain.Inventory;
 import com.klp.hub.inventory.domain.repository.InventoryRepository;
+import com.klp.hub.inventory.domain.repository.exception.UniqueConstraintException;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,7 +19,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
 @ActiveProfiles("test")
-@Import(InventoryRepositoryImpl.class)
+@Import({
+        InventoryRepositoryImpl.class,
+        TestJpaConfig.class
+})
 class InventoryRepositoryTest {
 
     @Autowired
@@ -49,5 +54,18 @@ class InventoryRepositoryTest {
 
         assertFalse(result.isPresent());
         assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("같은 상품과 허브 조홥으로 재고를 생성하려면 예외가 발생한다")
+    void throwDuplicateInventoryHub() {
+        Inventory inventoryA = new Inventory(productId, hubId, 10);
+        inventoryRepository.save(inventoryA);
+
+        Inventory duplicatedInventory = new Inventory(productId, hubId, 10);
+
+        assertThrows(UniqueConstraintException.class, () -> {
+            inventoryRepository.save(duplicatedInventory);
+        });
     }
 }

--- a/hub/src/test/java/com/klp/hub/inventory/presentation/controller/InventoryControllerTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/presentation/controller/InventoryControllerTest.java
@@ -29,8 +29,9 @@ class InventoryControllerTest {
     @DisplayName("단일 상품에 대한 재고를 조회할 수 있다")
     void getInventoryByProductId() throws Exception {
         UUID productId = UUID.randomUUID();
+        UUID inventoryId = UUID.randomUUID();
         when(inventoryService.getByProductId(productId))
-                .thenReturn(new InventoryResponse(productId, 10));
+                .thenReturn(new InventoryResponse(productId, inventoryId, 10));
 
         mockMvc.perform(get("/v1/inventories/{productId}", productId))
                 .andExpect(status().isOk())

--- a/hub/src/test/java/com/klp/hub/product/application/ProductServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/product/application/ProductServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -90,5 +91,17 @@ class ProductServiceTest {
         when(productRepository.findById(productId)).thenReturn(Optional.empty());
 
         assertThrows(RuntimeException.class, () -> productService.delete(productId));
+    }
+
+    @Test
+    @DisplayName("상품 ID를 통해서 상품을 softDelete 할 수 있다")
+    void softDelete() {
+        Product product = new Product(companyId, "상품명");
+        when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+
+        productService.delete(productId);
+
+        assertTrue(product.isDeleted());
+        assertThat(product.getDeletedAt()).isNotNull();
     }
 }

--- a/hub/src/test/java/com/klp/hub/product/application/ProductServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/product/application/ProductServiceTest.java
@@ -6,11 +6,15 @@ import com.klp.hub.company.presentation.dto.CompanyResponse;
 import com.klp.hub.product.domain.Product;
 import com.klp.hub.product.domain.repository.ProductRepository;
 import com.klp.hub.product.presentation.dto.ProductResponse;
+import com.klp.hub.product.application.dto.ProductUpdateCommand;
+import com.klp.hub.product.domain.Product;
+import com.klp.hub.product.domain.repository.ProductRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
@@ -20,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ProductServiceTest {
@@ -62,5 +67,24 @@ class ProductServiceTest {
         when(productRepository.findById(productId)).thenReturn(Optional.empty());
 
         assertThrows(RuntimeException.class, () -> productService.getProductById(productId));
+    }
+
+    @Test
+    @DisplayName("상품명을 변경할 수 있다")
+    void updateProduct() {
+        var oldName = "기존 상품명";
+        var newName = "새로운 상품명";
+        var request = new ProductUpdateCommand(
+                productId,
+                newName
+        );
+        var product = new Product(companyId, oldName);
+        when(product.getId()).thenReturn(productId);
+        when(productRepository.findById(productId))
+                .thenReturn(Optional.of(product));
+
+        productService.update(request);
+
+        assertThat(product.getName()).isEqualTo(newName);
     }
 }

--- a/hub/src/test/java/com/klp/hub/product/application/ProductServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/product/application/ProductServiceTest.java
@@ -69,18 +69,26 @@ class ProductServiceTest {
     @Test
     @DisplayName("상품명을 변경할 수 있다")
     void updateProduct() {
-        var oldName = "기존 상품명";
-        var newName = "새로운 상품명";
-        var request = new ProductUpdateCommand(
+        String oldName = "기존 상품명";
+        String newName = "새로운 상품명";
+        ProductUpdateCommand command = new ProductUpdateCommand(
                 productId,
                 newName
         );
-        var product = new Product(companyId, oldName);
+        Product product = new Product(companyId, oldName);
         when(productRepository.findById(any(UUID.class)))
                 .thenReturn(Optional.of(product));
 
-        productService.update(request);
+        productService.update(command);
 
         assertThat(product.getName()).isEqualTo(newName);
+    }
+
+    @Test
+    @DisplayName("상품 ID 를 통해 상품을 삭제할 때 상품이 존재하지 않으면 예외가 발생한다")
+    void throwDeleteByNullProduct() {
+        when(productRepository.findById(productId)).thenReturn(Optional.empty());
+
+        assertThrows(RuntimeException.class, () -> productService.delete(productId));
     }
 }

--- a/hub/src/test/java/com/klp/hub/product/application/ProductServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/product/application/ProductServiceTest.java
@@ -7,14 +7,11 @@ import com.klp.hub.product.domain.Product;
 import com.klp.hub.product.domain.repository.ProductRepository;
 import com.klp.hub.product.presentation.dto.ProductResponse;
 import com.klp.hub.product.application.dto.ProductUpdateCommand;
-import com.klp.hub.product.domain.Product;
-import com.klp.hub.product.domain.repository.ProductRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
@@ -22,9 +19,9 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ProductServiceTest {
@@ -79,8 +76,7 @@ class ProductServiceTest {
                 newName
         );
         var product = new Product(companyId, oldName);
-        when(product.getId()).thenReturn(productId);
-        when(productRepository.findById(productId))
+        when(productRepository.findById(any(UUID.class)))
                 .thenReturn(Optional.of(product));
 
         productService.update(request);

--- a/hub/src/test/java/com/klp/hub/product/application/ProductServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/product/application/ProductServiceTest.java
@@ -3,6 +3,8 @@ package com.klp.hub.product.application;
 import com.klp.hub.company.application.CompanyService;
 import com.klp.hub.company.domain.CompanyType;
 import com.klp.hub.company.presentation.dto.CompanyResponse;
+import com.klp.hub.inventory.application.InventoryService;
+import com.klp.hub.inventory.presentation.dto.InventoryResponse;
 import com.klp.hub.product.domain.Product;
 import com.klp.hub.product.domain.repository.ProductRepository;
 import com.klp.hub.product.presentation.dto.ProductResponse;
@@ -21,8 +23,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ProductServiceTest {
@@ -33,12 +34,17 @@ class ProductServiceTest {
     @Mock
     private CompanyService companyService;
 
+    @Mock
+    private InventoryService inventoryService;
+
     @InjectMocks
     private ProductService productService;
 
     private UUID productId = UUID.randomUUID();
 
     private UUID companyId = UUID.randomUUID();
+
+    private UUID inventoryId = UUID.randomUUID();
 
     @Test
     @DisplayName("상품의 ID 로 상품을 조회할 수 있다")
@@ -97,11 +103,27 @@ class ProductServiceTest {
     @DisplayName("상품 ID를 통해서 상품을 softDelete 할 수 있다")
     void softDelete() {
         Product product = new Product(companyId, "상품명");
+        InventoryResponse inventoryResponse = mock(InventoryResponse.class);
         when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+        when(inventoryService.getByProductId(productId)).thenReturn(inventoryResponse);
+        when(inventoryResponse.inventoryId()).thenReturn(inventoryId);
 
         productService.delete(productId);
 
         assertTrue(product.isDeleted());
         assertThat(product.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("상품 삭제시 관련된 재고도 삭제된다")
+    void deletedInventoryWhenProductDeleted() {
+        Product product = new Product(companyId, "상품명");
+        InventoryResponse inventoryResponse = new InventoryResponse(productId, inventoryId, 0);
+        when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+        when(inventoryService.getByProductId(productId)).thenReturn(inventoryResponse);
+
+        productService.delete(productId);
+
+        verify(inventoryService, times(1)).delete(inventoryResponse.inventoryId());
     }
 }

--- a/hub/src/test/java/com/klp/hub/product/application/ProductServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/product/application/ProductServiceTest.java
@@ -5,6 +5,7 @@ import com.klp.hub.company.domain.CompanyType;
 import com.klp.hub.company.presentation.dto.CompanyResponse;
 import com.klp.hub.inventory.application.InventoryService;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
+import com.klp.hub.product.application.dto.ProductCreateCommand;
 import com.klp.hub.product.domain.Product;
 import com.klp.hub.product.domain.repository.ProductRepository;
 import com.klp.hub.product.presentation.dto.ProductResponse;
@@ -45,6 +46,8 @@ class ProductServiceTest {
     private UUID companyId = UUID.randomUUID();
 
     private UUID inventoryId = UUID.randomUUID();
+
+    private UUID hubId = UUID.randomUUID();
 
     @Test
     @DisplayName("상품의 ID 로 상품을 조회할 수 있다")
@@ -97,6 +100,25 @@ class ProductServiceTest {
         when(productRepository.findById(productId)).thenReturn(Optional.empty());
 
         assertThrows(RuntimeException.class, () -> productService.delete(productId));
+    }
+
+    @Test
+    @DisplayName("상품을 생성할때 재고도 같이 생성한다")
+    void withCreateInventory() {
+        Integer quantity = 10;
+        ProductCreateCommand command = new ProductCreateCommand(
+                companyId,
+                hubId,
+                "상품명",
+                quantity
+        );
+        Product product = mock(Product.class);
+        when(productRepository.save(any(Product.class))).thenReturn(product);
+        when(product.getId()).thenReturn(productId);
+
+        productService.create(command);
+
+        verify(inventoryService, times(1)).create(productId, hubId, quantity);
     }
 
     @Test

--- a/hub/src/test/java/com/klp/hub/product/application/ProductServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/product/application/ProductServiceTest.java
@@ -113,12 +113,29 @@ class ProductServiceTest {
                 quantity
         );
         Product product = mock(Product.class);
+        CompanyResponse companyResponse = mock(CompanyResponse.class);
+        when(companyService.getByCompanyId(companyId)).thenReturn(companyResponse);
+        when(companyResponse.id()).thenReturn(companyId);
         when(productRepository.save(any(Product.class))).thenReturn(product);
         when(product.getId()).thenReturn(productId);
 
         productService.create(command);
 
         verify(inventoryService, times(1)).create(productId, hubId, quantity);
+    }
+
+    @Test
+    @DisplayName("상품 생성시 업체가 존재하지 않는다면 예외가 발생한다")
+    void throwNullCompany() {
+        ProductCreateCommand command = new ProductCreateCommand(
+                companyId,
+                hubId,
+                "상품명",
+                10
+        );
+        when(companyService.getByCompanyId(companyId)).thenThrow(RuntimeException.class);
+
+        assertThrows(RuntimeException.class, () -> productService.create(command));
     }
 
     @Test

--- a/hub/src/test/java/com/klp/hub/product/application/ProductServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/product/application/ProductServiceTest.java
@@ -4,6 +4,7 @@ import com.klp.hub.company.application.CompanyService;
 import com.klp.hub.company.domain.CompanyType;
 import com.klp.hub.company.presentation.dto.CompanyResponse;
 import com.klp.hub.inventory.application.InventoryService;
+import com.klp.hub.inventory.domain.repository.exception.UniqueConstraintException;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
 import com.klp.hub.product.application.dto.ProductCreateCommand;
 import com.klp.hub.product.domain.Product;
@@ -134,6 +135,27 @@ class ProductServiceTest {
                 10
         );
         when(companyService.getByCompanyId(companyId)).thenThrow(RuntimeException.class);
+
+        assertThrows(RuntimeException.class, () -> productService.create(command));
+    }
+
+    @Test
+    @DisplayName("상품 생성시 이미 해당 상품의 재고가 존재하면 예외가 발생한다")
+    void throwDuplicatedInventory() {
+        Integer quantity = 10;
+        ProductCreateCommand command = new ProductCreateCommand(
+                companyId,
+                hubId,
+                "상품명",
+                quantity
+        );
+        Product product = mock(Product.class);
+        CompanyResponse companyResponse = mock(CompanyResponse.class);
+        when(companyService.getByCompanyId(companyId)).thenReturn(companyResponse);
+        when(companyResponse.id()).thenReturn(companyId);
+        when(productRepository.save(any(Product.class))).thenReturn(product);
+        when(product.getId()).thenReturn(productId);
+        when(inventoryService.create(productId, command.hubId(), quantity)).thenThrow(UniqueConstraintException.class);
 
         assertThrows(RuntimeException.class, () -> productService.create(command));
     }

--- a/hub/src/test/java/com/klp/hub/product/domain/ProductTest.java
+++ b/hub/src/test/java/com/klp/hub/product/domain/ProductTest.java
@@ -27,6 +27,22 @@ class ProductTest {
         assertThrows(IllegalArgumentException.class, () -> createProductByCompanyId(null));
     }
 
+    @Test
+    @DisplayName("변경할 상품명이 Null인 경우 예외가 발생한다")
+    void throwNullProductName() {
+        var product = createProductByName("기존 상품명");
+
+        assertThrows(IllegalArgumentException.class, () -> product.updateName(null));
+    }
+
+    @Test
+    @DisplayName("변경할 상품명이 빈 값인 경우 예외가 발생한다")
+    void throwBlankProductName() {
+        var product = createProductByName("기존 상품명");
+
+        assertThrows(IllegalArgumentException.class, () -> product.updateName(" "));
+    }
+
     private Product createProductByName(String name) {
         return new Product(UUID.randomUUID(), name);
     }

--- a/hub/src/test/java/com/klp/hub/product/domain/ProductTest.java
+++ b/hub/src/test/java/com/klp/hub/product/domain/ProductTest.java
@@ -43,6 +43,17 @@ class ProductTest {
         assertThrows(IllegalArgumentException.class, () -> product.updateName(" "));
     }
 
+    @Test
+    @DisplayName("상품명을 변경할 수 있다")
+    void updateProductName() {
+        var name = "새로운 상품명";
+        var product = createProductByName("기존 상품명");
+
+        product.updateName(name);
+
+        assertEquals(name, product.getName());
+    }
+
     private Product createProductByName(String name) {
         return new Product(UUID.randomUUID(), name);
     }

--- a/hub/src/test/java/com/klp/hub/product/infrastructure/repository/ProductRepositoryTest.java
+++ b/hub/src/test/java/com/klp/hub/product/infrastructure/repository/ProductRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.klp.hub.product.infrastructure.repository;
 
+import com.klp.hub.TestJpaConfig;
 import com.klp.hub.company.domain.Company;
 import com.klp.hub.company.domain.CompanyType;
 import com.klp.hub.global.config.QuerydslConfig;
@@ -26,7 +27,8 @@ import static org.junit.jupiter.api.Assertions.*;
 @ActiveProfiles("test")
 @Import({
         QuerydslConfig.class,
-        ProductRepositoryImpl.class
+        ProductRepositoryImpl.class,
+        TestJpaConfig.class
 })
 class ProductRepositoryTest {
 

--- a/hub/src/test/java/com/klp/hub/product/infrastructure/repository/ProductRepositoryTest.java
+++ b/hub/src/test/java/com/klp/hub/product/infrastructure/repository/ProductRepositoryTest.java
@@ -2,7 +2,7 @@ package com.klp.hub.product.infrastructure.repository;
 
 import com.klp.hub.company.domain.Company;
 import com.klp.hub.company.domain.CompanyType;
-import com.klp.hub.config.QuerydslConfig;
+import com.klp.hub.global.config.QuerydslConfig;
 import com.klp.hub.product.domain.Product;
 import com.klp.hub.product.domain.repository.ProductRepository;
 import com.klp.hub.product.presentation.dto.ProductsPageRowResponse;

--- a/hub/src/test/java/com/klp/hub/product/presentation/controller/ProductControllerTest.java
+++ b/hub/src/test/java/com/klp/hub/product/presentation/controller/ProductControllerTest.java
@@ -1,7 +1,10 @@
 package com.klp.hub.product.presentation.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.klp.hub.product.application.ProductService;
 import com.klp.hub.product.presentation.dto.ProductResponse;
+import com.klp.hub.product.presentation.dto.ProductUpdateRequest;
+import com.klp.hub.product.presentation.dto.ProductUpdateResponse;
 import com.klp.hub.product.presentation.dto.ProductsPageRowResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +21,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -28,6 +32,9 @@ class ProductControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @MockitoBean
     private ProductService productService;
@@ -79,6 +86,28 @@ class ProductControllerTest {
                 .andExpect(jsonPath("$.pageable.hasNext").isBoolean())
                 .andExpect(jsonPath("$.pageable.isFirst").isBoolean())
                 .andExpect(jsonPath("$.pageable.isLast").isBoolean());
+    }
+
+    @Test
+    @DisplayName("상품을 변경할 수 있다")
+    void updateProduct() throws Exception {
+        UUID productId = UUID.randomUUID();
+        String name = "상품명";
+        ProductUpdateRequest request = new ProductUpdateRequest(
+                name
+        );
+        ProductUpdateResponse response = new ProductUpdateResponse(
+                productId,
+                name
+        );
+        when(productService.update(any())).thenReturn(response);
+
+        mockMvc.perform(patch("/v1/products/{productId}", productId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.productId").isString());
     }
 
     @Test

--- a/hub/src/test/java/com/klp/hub/product/presentation/controller/ProductControllerTest.java
+++ b/hub/src/test/java/com/klp/hub/product/presentation/controller/ProductControllerTest.java
@@ -80,4 +80,17 @@ class ProductControllerTest {
                 .andExpect(jsonPath("$.pageable.isFirst").isBoolean())
                 .andExpect(jsonPath("$.pageable.isLast").isBoolean());
     }
+
+    @Test
+    @DisplayName("상품 ID 로 상품을 삭제할 수 있다")
+    void softDeleteById() throws Exception {
+        UUID productId = UUID.randomUUID();
+        when(productService.delete(productId))
+                .thenReturn(productId);
+
+        mockMvc.perform(delete("/v1/products/{productId}", productId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.productId").isString());
+    }
 }

--- a/hub/src/test/java/com/klp/hub/product/presentation/controller/ProductControllerTest.java
+++ b/hub/src/test/java/com/klp/hub/product/presentation/controller/ProductControllerTest.java
@@ -2,10 +2,7 @@ package com.klp.hub.product.presentation.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.klp.hub.product.application.ProductService;
-import com.klp.hub.product.presentation.dto.ProductResponse;
-import com.klp.hub.product.presentation.dto.ProductUpdateRequest;
-import com.klp.hub.product.presentation.dto.ProductUpdateResponse;
-import com.klp.hub.product.presentation.dto.ProductsPageRowResponse;
+import com.klp.hub.product.presentation.dto.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -86,6 +83,28 @@ class ProductControllerTest {
                 .andExpect(jsonPath("$.pageable.hasNext").isBoolean())
                 .andExpect(jsonPath("$.pageable.isFirst").isBoolean())
                 .andExpect(jsonPath("$.pageable.isLast").isBoolean());
+    }
+
+    @Test
+    @DisplayName("상품을 생성할 수 있다")
+    void createProduct() throws Exception {
+        UUID productId = UUID.randomUUID();
+        UUID companyId = UUID.randomUUID();
+        UUID hubId = UUID.randomUUID();
+        ProductCreateRequest request = new ProductCreateRequest(
+                companyId,
+                hubId,
+                "상품명",
+                10
+        );
+        when(productService.create(any())).thenReturn(productId);
+
+        mockMvc.perform(post("/v1/products")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.productId").isString());
     }
 
     @Test


### PR DESCRIPTION
## PR 내용
- #24 
  - 상품 등록, 변경, 삭제 API
  - 상품 등록시 재고 또한 등록 
  - 상품 삭제시 재고 또한 삭제
  - 이후 재고 관련 처리(차감, 증가)를 위한 멱등키 엔티티 추가
  - `Controller Validation` 관련된 테스트는 `GlobalExceptionHandler` 적용 이후 테스트할 예정입니다
  - 삭제시 `deletedBy` 는 현재 임시로 값을 채웠고 이후 `X-User-ID`가 적용되면 변경 예정입니다

## 리뷰 포인트
- 잘 못 되었거나 수정해야할 부분이 있다면 알려주세요!