### PR TITLE
fix: 공통 모듈 Exception 생성자 추가 및 HttpMessageNotReadableException 핸들링 추가

### DIFF
--- a/common-module/src/main/java/com/klp/common/exception/BusinessException.java
+++ b/common-module/src/main/java/com/klp/common/exception/BusinessException.java
@@ -7,6 +7,11 @@ public class BusinessException extends RuntimeException {
 
     private final ErrorCode errorCode;
 
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
     public BusinessException(String message, ErrorCode errorCode) {
         super(message);
         this.errorCode = errorCode;

--- a/common-module/src/main/java/com/klp/common/exception/GlobalExceptionHandler.java
+++ b/common-module/src/main/java/com/klp/common/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -61,7 +62,8 @@ public class GlobalExceptionHandler {
         MissingServletRequestParameterException.class,
         MissingRequestHeaderException.class,
         TypeMismatchException.class,
-        MethodArgumentTypeMismatchException.class
+        MethodArgumentTypeMismatchException.class,
+        HttpMessageNotReadableException.class
     })
     protected ResponseEntity<String> handleValidException(Exception e) {
         log.warn("handleValidException : {}", e.getMessage());


### PR DESCRIPTION
## PR 내용
- [feat: 핸들러에 ErrorCode 단일 생성자 추가](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/10c90346d16df55a09682ecc57dbdcc59491131e)
  - 현재 방식으로는 ErrorCode 단일 생성만으로는 예외 처리가 불가능 해, 이를 가능하도록 수정했습니다.
  - 에러코드 enum 내부에서 메시지를 설정하고, 이를 사용하도록 설정했습니다. 
  - 적용 시,`new BusinessException(AuthErrorCode.INVALID_AFFILIATION_TYPE)` 같은 형식으로 예외 처리가 가능합니다.

- [feat: HttpMessageNotReadableException 예외 처리 핸들링 추가](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/0728fe1ad12219834eb65a95c6dc7f8d94b8d7df)
  - 컨트롤러 요청에서 Enum 타입 매핑이 올바르지 않을 시 발생하는 `HttpMessageNotReadableException`를 400에러로 추가했습니다.
  - 적용 이전에는 500에러로 발생해 올바른 테스트 코드 통과가 진행되지 않는 문제를 수정했습니다.