### PR TITLE
feat: 재고 차감/증가 API 

### DIFF
--- a/hub/build.gradle
+++ b/hub/build.gradle
@@ -16,6 +16,7 @@ java {
 
 repositories {
     mavenCentral()
+    mavenLocal()
 }
 
 ext {
@@ -31,6 +32,9 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'org.postgresql:postgresql'
+
+    // common-module
+    implementation 'com.klp.common:common-module:1.0.0'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/hub/build.gradle
+++ b/hub/build.gradle
@@ -59,6 +59,10 @@ dependencies {
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation("org.springframework.boot:spring-boot-starter-cache")
+
+    // security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 dependencyManagement {

--- a/hub/src/main/java/com/klp/hub/common/model/UserDetailsImpl.java
+++ b/hub/src/main/java/com/klp/hub/common/model/UserDetailsImpl.java
@@ -1,0 +1,32 @@
+package com.klp.hub.common.model;
+
+import java.util.Collection;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+@AllArgsConstructor
+public class UserDetailsImpl implements UserDetails {
+
+    private final Long userId;
+    private final String username;
+    private final String role;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(() -> "ROLE_" + role);
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+}

--- a/hub/src/main/java/com/klp/hub/company/application/CompanyService.java
+++ b/hub/src/main/java/com/klp/hub/company/application/CompanyService.java
@@ -1,7 +1,9 @@
 package com.klp.hub.company.application;
 
+import com.klp.common.exception.BusinessException;
 import com.klp.hub.company.domain.Company;
 import com.klp.hub.company.domain.repository.CompanyRepository;
+import com.klp.hub.company.exception.CompanyErrorCode;
 import com.klp.hub.company.presentation.dto.CompanyResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +22,7 @@ public class CompanyService {
     public CompanyResponse getByCompanyId(UUID companyId) {
         Company company = companyRepository.findById(companyId).orElseThrow(() -> {
             log.error("업체를 찾을 수 없습니다. companyId : {}", companyId);
-            return new RuntimeException();
+            return new BusinessException(CompanyErrorCode.NOT_FOUND_COMPANY);
         });
 
         return new CompanyResponse(

--- a/hub/src/main/java/com/klp/hub/company/application/CompanyService.java
+++ b/hub/src/main/java/com/klp/hub/company/application/CompanyService.java
@@ -3,12 +3,11 @@ package com.klp.hub.company.application;
 import com.klp.hub.company.domain.Company;
 import com.klp.hub.company.domain.repository.CompanyRepository;
 import com.klp.hub.company.presentation.dto.CompanyResponse;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.UUID;
 
 @Service
 @Slf4j
@@ -25,10 +24,11 @@ public class CompanyService {
         });
 
         return new CompanyResponse(
-                company.getId(),
-                company.getType().name(),
-                company.getName(),
-                company.getAddress()
+            company.getId(),
+            company.getHubId(),
+            company.getType().name(),
+            company.getName(),
+            company.getAddress()
         );
     }
 }

--- a/hub/src/main/java/com/klp/hub/company/exception/CompanyErrorCode.java
+++ b/hub/src/main/java/com/klp/hub/company/exception/CompanyErrorCode.java
@@ -1,0 +1,24 @@
+package com.klp.hub.company.exception;
+
+import com.klp.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum CompanyErrorCode implements ErrorCode {
+    NOT_FOUND_COMPANY(HttpStatus.BAD_REQUEST, "해당 업체는 존재하지 않습니다.");
+
+    private final HttpStatus status;
+
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/hub/src/main/java/com/klp/hub/company/exception/CompanyErrorCode.java
+++ b/hub/src/main/java/com/klp/hub/company/exception/CompanyErrorCode.java
@@ -1,24 +1,15 @@
 package com.klp.hub.company.exception;
 
 import com.klp.common.exception.ErrorCode;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
+@Getter
 @RequiredArgsConstructor
 public enum CompanyErrorCode implements ErrorCode {
     NOT_FOUND_COMPANY(HttpStatus.BAD_REQUEST, "해당 업체는 존재하지 않습니다.");
 
     private final HttpStatus status;
-
     private final String message;
-
-    @Override
-    public HttpStatus getStatus() {
-        return status;
-    }
-
-    @Override
-    public String getMessage() {
-        return message;
-    }
 }

--- a/hub/src/main/java/com/klp/hub/company/presentation/controller/CompanyController.java
+++ b/hub/src/main/java/com/klp/hub/company/presentation/controller/CompanyController.java
@@ -1,0 +1,29 @@
+package com.klp.hub.company.presentation.controller;
+
+import com.klp.hub.company.application.CompanyService;
+import com.klp.hub.company.presentation.dto.CompanyResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/v1/companies")
+public class CompanyController {
+
+    private final CompanyService companyService;
+
+    @GetMapping("/{companyId}")
+    public ResponseEntity<CompanyResponse> getById(@PathVariable("companyId") String companyId) {
+        log.info("== 단일 업체 조회 companyId: {} ==", companyId);
+        CompanyResponse response = companyService.getByCompanyId(UUID.fromString(companyId));
+        log.info("== 단일 업체 조회 성공 ==");
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/hub/src/main/java/com/klp/hub/company/presentation/dto/CompanyResponse.java
+++ b/hub/src/main/java/com/klp/hub/company/presentation/dto/CompanyResponse.java
@@ -3,9 +3,11 @@ package com.klp.hub.company.presentation.dto;
 import java.util.UUID;
 
 public record CompanyResponse(
-        UUID id,
-        String type,
-        String name,
-        String address
+    UUID companyId,
+    UUID hubId,
+    String type,
+    String name,
+    String address
 ) {
+
 }

--- a/hub/src/main/java/com/klp/hub/global/config/SecurityConfig.java
+++ b/hub/src/main/java/com/klp/hub/global/config/SecurityConfig.java
@@ -1,0 +1,42 @@
+package com.klp.hub.global.config;
+
+import com.klp.hub.global.filter.AuthorizationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final AuthorizationFilter authorizationFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .logout(AbstractHttpConfigurer::disable)
+            .sessionManagement(sessionManagement ->
+                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .addFilterBefore(authorizationFilter, UsernamePasswordAuthenticationFilter.class)
+        ;
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/hub/src/main/java/com/klp/hub/global/exception/GlobalExceptionHandler.java
+++ b/hub/src/main/java/com/klp/hub/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,109 @@
+package com.klp.hub.global.exception;
+
+import com.klp.common.exception.BusinessException;
+import com.klp.common.exception.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.TypeMismatchException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+@Slf4j(topic = "GlobalExceptionHandler")
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    public static final String WRONG_REQUEST = "잘못된 요청입니다";
+
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        log.warn("handleBusinessException : {}", e.getMessage());
+
+        ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode().name(), e.getMessage());
+
+        return ResponseEntity.status(e.getErrorCode().getStatus())
+            .body(errorResponse);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<String> handleMethodArgumentNotValidException(
+        MethodArgumentNotValidException e) {
+        log.warn("handleMethodArgumentNotValidException : {}", e.getMessage());
+
+        String errorMessage = e.getBindingResult().getFieldErrors().stream()
+            .map(fieldError -> fieldError.getDefaultMessage())
+            .findFirst()
+            .orElse(WRONG_REQUEST);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(errorMessage);
+    }
+
+    @ExceptionHandler(BindException.class)
+    protected ResponseEntity<String> handleBindException(BindException e) {
+        log.warn("handleBindException : {}", e.getMessage());
+
+        String errorMessage = e.getBindingResult().getFieldErrors().stream()
+            .map(fieldError -> fieldError.getDefaultMessage())
+            .findFirst()
+            .orElse(WRONG_REQUEST);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(errorMessage);
+    }
+
+    @ExceptionHandler({
+        MissingServletRequestParameterException.class,
+        MissingRequestHeaderException.class,
+        TypeMismatchException.class,
+        MethodArgumentTypeMismatchException.class,
+        HttpMessageNotReadableException.class
+    })
+    protected ResponseEntity<String> handleValidException(Exception e) {
+        log.warn("handleValidException : {}", e.getMessage());
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(WRONG_REQUEST);
+    }
+
+    @ExceptionHandler({
+        NoHandlerFoundException.class,
+        NoResourceFoundException.class
+    })
+    protected ResponseEntity<String> handleNotFoundException(Exception e) {
+        log.warn("handleNotFoundException : {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body("요청하신 리소스를 찾을 수 없습니다.");
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    protected ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.warn("handleIllegalArgumentException : {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(e.getMessage());
+    }
+
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    protected ResponseEntity<String> handleAuthorizationDeniedException(
+        AuthorizationDeniedException e) {
+        log.warn("handleAuthorizationDeniedException : {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+            .body(e.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<String> handleException(Exception e) {
+        log.error("handleException : {}", e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body("서버 내부 오류가 발생했습니다.");
+    }
+}

--- a/hub/src/main/java/com/klp/hub/global/filter/AuthorizationFilter.java
+++ b/hub/src/main/java/com/klp/hub/global/filter/AuthorizationFilter.java
@@ -1,0 +1,47 @@
+package com.klp.hub.global.filter;
+
+import com.klp.hub.common.model.UserDetailsImpl;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class AuthorizationFilter extends OncePerRequestFilter {
+
+    private static final String USER_ID_HEADER = "X-User-Id";
+    private static final String USER_NAME_HEADER = "X-User-Name";
+    private static final String USER_ROLE_HEADER = "X-User-Role";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain)
+        throws ServletException, IOException {
+
+        String userId = request.getHeader(USER_ID_HEADER);
+        String userName = request.getHeader(USER_NAME_HEADER);
+        String role = request.getHeader(USER_ROLE_HEADER);
+
+        if (userId == null || userName == null || role == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        UserDetailsImpl userDetails = new UserDetailsImpl(Long.valueOf(userId), userName, role);
+
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+            userDetails, null, userDetails.getAuthorities()
+        );
+
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
@@ -1,7 +1,9 @@
 package com.klp.hub.inventory.application;
 
+import com.klp.hub.inventory.application.dto.InventoryDeductCommand;
 import com.klp.hub.inventory.domain.Inventory;
 import com.klp.hub.inventory.domain.repository.InventoryRepository;
+import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +39,19 @@ public class InventoryService {
         Inventory savedInventory = inventoryRepository.save(
             new Inventory(productId, hubId, quantity));
         return savedInventory.getId();
+    }
+
+    /**
+     * 상품의 재고를 일괄 차감시킨다
+     */
+    @Transactional
+    public InventoryDeductResponse deduct(InventoryDeductCommand command) {
+        boolean acquired = inventoryRepository.tryAcquireIdempotencyKey(command.idempotencyKey());
+        if (!acquired) {
+            log.info("이미 처리된 요청입니다.");
+            return InventoryDeductResponse.already();
+        }
+        return null;
     }
 
     @Transactional

--- a/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
@@ -49,10 +49,12 @@ public class InventoryService {
     public InventoryDeductResponse deduct(InventoryDeductCommand command) {
         boolean acquired = inventoryRepository.tryAcquireIdempotencyKey(command.idempotencyKey());
         if (!acquired) {
-            log.info("이미 처리된 요청입니다.");
+            log.warn("이미 처리된 요청입니다.");
             return InventoryDeductResponse.already();
         }
-        return null;
+
+        inventoryRepository.deductAll(command.toInventoryDeductList());
+        return InventoryDeductResponse.success();
     }
 
     @Transactional

--- a/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
@@ -2,11 +2,13 @@ package com.klp.hub.inventory.application;
 
 import com.klp.common.exception.BusinessException;
 import com.klp.hub.inventory.application.dto.InventoryDeductCommand;
+import com.klp.hub.inventory.application.dto.InventoryReplenishCommand;
 import com.klp.hub.inventory.domain.Inventory;
 import com.klp.hub.inventory.domain.repository.InventoryRepository;
 import com.klp.hub.inventory.domain.repository.exception.UniqueConstraintException;
 import com.klp.hub.inventory.exception.InventoryErrorCode;
 import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse;
+import com.klp.hub.inventory.presentation.dto.InventoryReplenishResponse;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -66,6 +68,22 @@ public class InventoryService {
             throw new BusinessException(InventoryErrorCode.INSUFFICIENT_STOCK);
         }
         return InventoryDeductResponse.success();
+    }
+
+    @Transactional
+    public InventoryReplenishResponse replenish(InventoryReplenishCommand command) {
+        boolean acquired = inventoryRepository.tryAcquireIdempotencyKey(command.idempotencyKey());
+        if (!acquired) {
+            log.warn("이미 처리된 요청입니다.");
+            return InventoryReplenishResponse.already();
+        }
+
+        int updated = inventoryRepository.replenishAll(command.toInventoryReplenish());
+        if (updated != command.size()) {
+            log.error("재고가 존재하지 않습니다.");
+            throw new BusinessException(InventoryErrorCode.NOT_FOUND_INVENTORY);
+        }
+        return InventoryReplenishResponse.success();
     }
 
     @Transactional

--- a/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
@@ -37,7 +37,8 @@ public class InventoryService {
     @Transactional
     public UUID create(UUID productId, UUID hubId, Integer quantity) {
         Inventory savedInventory = inventoryRepository.save(
-            new Inventory(productId, hubId, quantity));
+            new Inventory(productId, hubId, quantity)
+        );
         return savedInventory.getId();
     }
 

--- a/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
@@ -5,11 +5,14 @@ import com.klp.hub.inventory.application.dto.InventoryDeductCommand;
 import com.klp.hub.inventory.application.dto.InventoryReplenishCommand;
 import com.klp.hub.inventory.domain.Inventory;
 import com.klp.hub.inventory.domain.repository.InventoryRepository;
+import com.klp.hub.inventory.domain.repository.dto.InventoryDeduct;
+import com.klp.hub.inventory.domain.repository.dto.InventoryReplenish;
 import com.klp.hub.inventory.domain.repository.exception.UniqueConstraintException;
 import com.klp.hub.inventory.exception.InventoryErrorCode;
 import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse;
 import com.klp.hub.inventory.presentation.dto.InventoryReplenishResponse;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -62,7 +65,10 @@ public class InventoryService {
             return InventoryDeductResponse.already();
         }
 
-        int updated = inventoryRepository.deductAll(command.toInventoryDeductList());
+        List<InventoryDeduct> plans = InventoryUpdatePlanner.planDeduct(
+            command.products()
+        );
+        int updated = inventoryRepository.deductAll(plans);
         if (updated != command.size()) {
             log.error("재고가 부족합니다.");
             throw new BusinessException(InventoryErrorCode.INSUFFICIENT_STOCK);
@@ -81,7 +87,10 @@ public class InventoryService {
             return InventoryReplenishResponse.already();
         }
 
-        int updated = inventoryRepository.replenishAll(command.toInventoryReplenish());
+        List<InventoryReplenish> plans = InventoryUpdatePlanner.planReplenish(
+            command.products()
+        );
+        int updated = inventoryRepository.replenishAll(plans);
         if (updated != command.size()) {
             log.error("재고가 존재하지 않습니다.");
             throw new BusinessException(InventoryErrorCode.NOT_FOUND_INVENTORY);

--- a/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
@@ -4,6 +4,7 @@ import com.klp.common.exception.BusinessException;
 import com.klp.hub.inventory.application.dto.InventoryDeductCommand;
 import com.klp.hub.inventory.domain.Inventory;
 import com.klp.hub.inventory.domain.repository.InventoryRepository;
+import com.klp.hub.inventory.domain.repository.exception.UniqueConstraintException;
 import com.klp.hub.inventory.exception.InventoryErrorCode;
 import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
@@ -37,10 +38,15 @@ public class InventoryService {
 
     @Transactional
     public UUID create(UUID productId, UUID hubId, Integer quantity) {
-        Inventory savedInventory = inventoryRepository.save(
-            new Inventory(productId, hubId, quantity)
-        );
-        return savedInventory.getId();
+        try {
+            Inventory savedInventory = inventoryRepository.save(
+                new Inventory(productId, hubId, quantity)
+            );
+            return savedInventory.getId();
+        } catch (UniqueConstraintException exception) {
+            log.error("이미 해당 재고가 존재합니다.");
+            throw new BusinessException(InventoryErrorCode.INVENTORY_ALREADY_EXISTS);
+        }
     }
 
     /**

--- a/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
@@ -92,8 +92,8 @@ public class InventoryService {
         );
         int updated = inventoryRepository.replenishAll(plans);
         if (updated != command.size()) {
-            log.error("재고가 존재하지 않습니다.");
-            throw new BusinessException(InventoryErrorCode.NOT_FOUND_INVENTORY);
+            log.error("증가하려는 일부 재고를 찾을 수 없습니다.");
+            throw new BusinessException(InventoryErrorCode.PARTIAL_INVENTORY_NOT_FOUND);
         }
         return InventoryReplenishResponse.success();
     }

--- a/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
@@ -53,7 +53,11 @@ public class InventoryService {
             return InventoryDeductResponse.already();
         }
 
-        inventoryRepository.deductAll(command.toInventoryDeductList());
+        int updated = inventoryRepository.deductAll(command.toInventoryDeductList());
+        if (updated != command.size()) {
+            log.error("재고가 부족합니다.");
+            throw new RuntimeException();
+        }
         return InventoryDeductResponse.success();
     }
 

--- a/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
@@ -70,6 +70,9 @@ public class InventoryService {
         return InventoryDeductResponse.success();
     }
 
+    /**
+     * 상품의 재고를 일괄 증가시킨다
+     */
     @Transactional
     public InventoryReplenishResponse replenish(InventoryReplenishCommand command) {
         boolean acquired = inventoryRepository.tryAcquireIdempotencyKey(command.idempotencyKey());

--- a/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
@@ -3,12 +3,11 @@ package com.klp.hub.inventory.application;
 import com.klp.hub.inventory.domain.Inventory;
 import com.klp.hub.inventory.domain.repository.InventoryRepository;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.UUID;
 
 @Service
 @Slf4j
@@ -26,15 +25,17 @@ public class InventoryService {
         });
 
         return new InventoryResponse(
-                productId,
-                inventory.getId(),
-                inventory.getQuantity()
+            productId,
+            inventory.getId(),
+            inventory.getHubId(),
+            inventory.getQuantity()
         );
     }
 
     @Transactional
     public UUID create(UUID productId, UUID hubId, Integer quantity) {
-        Inventory savedInventory = inventoryRepository.save(new Inventory(productId, hubId, quantity));
+        Inventory savedInventory = inventoryRepository.save(
+            new Inventory(productId, hubId, quantity));
         return savedInventory.getId();
     }
 

--- a/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/InventoryService.java
@@ -1,8 +1,10 @@
 package com.klp.hub.inventory.application;
 
+import com.klp.common.exception.BusinessException;
 import com.klp.hub.inventory.application.dto.InventoryDeductCommand;
 import com.klp.hub.inventory.domain.Inventory;
 import com.klp.hub.inventory.domain.repository.InventoryRepository;
+import com.klp.hub.inventory.exception.InventoryErrorCode;
 import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
 import java.util.UUID;
@@ -22,8 +24,7 @@ public class InventoryService {
     public InventoryResponse getByProductId(UUID productId) {
         Inventory inventory = inventoryRepository.findByProductId(productId).orElseThrow(() -> {
             log.error("해당 상품의 재고를 찾을 수 없습니다. productId={}", productId);
-            // FIXME: 도메인 예외가 추가되면 수정 필요
-            return new RuntimeException();
+            return new BusinessException(InventoryErrorCode.NOT_FOUND_INVENTORY);
         });
 
         return new InventoryResponse(
@@ -56,7 +57,7 @@ public class InventoryService {
         int updated = inventoryRepository.deductAll(command.toInventoryDeductList());
         if (updated != command.size()) {
             log.error("재고가 부족합니다.");
-            throw new RuntimeException();
+            throw new BusinessException(InventoryErrorCode.INSUFFICIENT_STOCK);
         }
         return InventoryDeductResponse.success();
     }
@@ -73,8 +74,7 @@ public class InventoryService {
     private Inventory getById(UUID inventoryId) {
         return inventoryRepository.findById(inventoryId).orElseThrow(() -> {
             log.error("재고가 존재하지 않습니다. inventoryId = {}", inventoryId);
-            // FIXME: 도메인 예외 전까지 임시 예외처리
-            throw new RuntimeException();
+            return new BusinessException(InventoryErrorCode.NOT_FOUND_INVENTORY);
         });
     }
 }

--- a/hub/src/main/java/com/klp/hub/inventory/application/InventoryUpdatePlanner.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/InventoryUpdatePlanner.java
@@ -2,13 +2,14 @@ package com.klp.hub.inventory.application;
 
 import com.klp.hub.inventory.application.dto.InventoryDeductCommand;
 import com.klp.hub.inventory.application.dto.InventoryReplenishCommand;
-import com.klp.hub.inventory.application.dto.InventoryReplenishCommand.Product;
 import com.klp.hub.inventory.domain.repository.dto.InventoryDeduct;
 import com.klp.hub.inventory.domain.repository.dto.InventoryReplenish;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -28,12 +29,12 @@ public final class InventoryUpdatePlanner {
             .thenComparing(orderKey -> orderKey.hubId);
 
     public static List<InventoryDeduct> planDeduct(List<InventoryDeductCommand.Product> products) {
-        Map<OrderKey, Integer> aggregatedQty = products.stream()
-            .collect(Collectors.toMap(
-                product -> new OrderKey(product.productId(), product.hubId()),
-                InventoryDeductCommand.Product::quantity,
-                Integer::sum
-            ));
+        Map<OrderKey, Integer> aggregatedQty = aggregate(
+            products,
+            InventoryDeductCommand.Product::productId,
+            InventoryDeductCommand.Product::hubId,
+            InventoryDeductCommand.Product::quantity
+        );
 
         return aggregatedQty.entrySet().stream()
             .sorted(Map.Entry.comparingByKey(ORDER))
@@ -44,13 +45,15 @@ public final class InventoryUpdatePlanner {
             .toList();
     }
 
-    public static List<InventoryReplenish> planReplenish(List<Product> products) {
-        Map<OrderKey, Integer> aggregatedQty = products.stream()
-            .collect(Collectors.toMap(
-                product -> new OrderKey(product.productId(), product.hubId()),
-                InventoryReplenishCommand.Product::quantity,
-                Integer::sum
-            ));
+    public static List<InventoryReplenish> planReplenish(
+        List<InventoryReplenishCommand.Product> products
+    ) {
+        Map<OrderKey, Integer> aggregatedQty = aggregate(
+            products,
+            InventoryReplenishCommand.Product::productId,
+            InventoryReplenishCommand.Product::hubId,
+            InventoryReplenishCommand.Product::quantity
+        );
 
         return aggregatedQty.entrySet().stream()
             .sorted(Map.Entry.comparingByKey(ORDER))
@@ -59,5 +62,19 @@ public final class InventoryUpdatePlanner {
                 entry.getKey().hubId(),
                 entry.getValue()))
             .toList();
+    }
+
+    private static <T> Map<OrderKey, Integer> aggregate(
+        List<T> items,
+        Function<T, UUID> productId,
+        Function<T, UUID> hubId,
+        ToIntFunction<T> quantity
+    ) {
+        return items.stream()
+            .collect(Collectors.toMap(
+                t -> new OrderKey(productId.apply(t), hubId.apply(t)),
+                quantity::applyAsInt,
+                Integer::sum
+            ));
     }
 }

--- a/hub/src/main/java/com/klp/hub/inventory/application/InventoryUpdatePlanner.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/InventoryUpdatePlanner.java
@@ -1,0 +1,43 @@
+package com.klp.hub.inventory.application;
+
+import com.klp.hub.inventory.application.dto.InventoryDeductCommand;
+import com.klp.hub.inventory.domain.repository.dto.InventoryDeduct;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class InventoryUpdatePlanner {
+
+    private record OrderKey(
+        UUID productId,
+        UUID hubId
+    ) {
+
+    }
+
+    private static final Comparator<OrderKey> ORDER =
+        Comparator.comparing((OrderKey orderKey) -> orderKey.productId)
+            .thenComparing(orderKey -> orderKey.hubId);
+
+    public static List<InventoryDeduct> planDeduct(List<InventoryDeductCommand.Product> products) {
+        Map<OrderKey, Integer> aggregatedQty = products.stream()
+            .collect(Collectors.toMap(
+                product -> new OrderKey(product.productId(), product.hubId()),
+                InventoryDeductCommand.Product::quantity,
+                Integer::sum
+            ));
+
+        return aggregatedQty.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey(ORDER))
+            .map(entry -> new InventoryDeduct(
+                entry.getKey().productId(),
+                entry.getKey().hubId(),
+                entry.getValue()))
+            .toList();
+    }
+}

--- a/hub/src/main/java/com/klp/hub/inventory/application/InventoryUpdatePlanner.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/InventoryUpdatePlanner.java
@@ -1,7 +1,10 @@
 package com.klp.hub.inventory.application;
 
 import com.klp.hub.inventory.application.dto.InventoryDeductCommand;
+import com.klp.hub.inventory.application.dto.InventoryReplenishCommand;
+import com.klp.hub.inventory.application.dto.InventoryReplenishCommand.Product;
 import com.klp.hub.inventory.domain.repository.dto.InventoryDeduct;
+import com.klp.hub.inventory.domain.repository.dto.InventoryReplenish;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +38,23 @@ public final class InventoryUpdatePlanner {
         return aggregatedQty.entrySet().stream()
             .sorted(Map.Entry.comparingByKey(ORDER))
             .map(entry -> new InventoryDeduct(
+                entry.getKey().productId(),
+                entry.getKey().hubId(),
+                entry.getValue()))
+            .toList();
+    }
+
+    public static List<InventoryReplenish> planReplenish(List<Product> products) {
+        Map<OrderKey, Integer> aggregatedQty = products.stream()
+            .collect(Collectors.toMap(
+                product -> new OrderKey(product.productId(), product.hubId()),
+                InventoryReplenishCommand.Product::quantity,
+                Integer::sum
+            ));
+
+        return aggregatedQty.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey(ORDER))
+            .map(entry -> new InventoryReplenish(
                 entry.getKey().productId(),
                 entry.getKey().hubId(),
                 entry.getValue()))

--- a/hub/src/main/java/com/klp/hub/inventory/application/dto/InventoryDeductCommand.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/dto/InventoryDeductCommand.java
@@ -27,4 +27,8 @@ public record InventoryDeductCommand(
             );
         }
     }
+
+    public int size() {
+        return products.size();
+    }
 }

--- a/hub/src/main/java/com/klp/hub/inventory/application/dto/InventoryDeductCommand.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/dto/InventoryDeductCommand.java
@@ -1,6 +1,5 @@
 package com.klp.hub.inventory.application.dto;
 
-import com.klp.hub.inventory.domain.repository.dto.InventoryDeduct;
 import java.util.List;
 import java.util.UUID;
 
@@ -9,23 +8,12 @@ public record InventoryDeductCommand(
     List<Product> products
 ) {
 
-    public List<InventoryDeduct> toInventoryDeductList() {
-        return products.stream().map(Product::toInventoryDeduct).toList();
-    }
-
     public record Product(
         UUID productId,
         UUID hubId,
         Integer quantity
     ) {
 
-        public InventoryDeduct toInventoryDeduct() {
-            return new InventoryDeduct(
-                productId,
-                hubId,
-                quantity
-            );
-        }
     }
 
     public int size() {

--- a/hub/src/main/java/com/klp/hub/inventory/application/dto/InventoryDeductCommand.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/dto/InventoryDeductCommand.java
@@ -1,5 +1,6 @@
 package com.klp.hub.inventory.application.dto;
 
+import com.klp.hub.inventory.domain.repository.dto.InventoryDeduct;
 import java.util.List;
 import java.util.UUID;
 
@@ -10,8 +11,16 @@ public record InventoryDeductCommand(
 
     public record Product(
         UUID productId,
+        UUID hubId,
         Integer quantity
     ) {
 
+        public InventoryDeduct toInventoryDeduct() {
+            return new InventoryDeduct(
+                productId,
+                hubId,
+                quantity
+            );
+        }
     }
 }

--- a/hub/src/main/java/com/klp/hub/inventory/application/dto/InventoryDeductCommand.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/dto/InventoryDeductCommand.java
@@ -9,6 +9,10 @@ public record InventoryDeductCommand(
     List<Product> products
 ) {
 
+    public List<InventoryDeduct> toInventoryDeductList() {
+        return products.stream().map(Product::toInventoryDeduct).toList();
+    }
+
     public record Product(
         UUID productId,
         UUID hubId,

--- a/hub/src/main/java/com/klp/hub/inventory/application/dto/InventoryDeductCommand.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/dto/InventoryDeductCommand.java
@@ -1,0 +1,17 @@
+package com.klp.hub.inventory.application.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record InventoryDeductCommand(
+    String idempotencyKey,
+    List<Product> products
+) {
+
+    public record Product(
+        UUID productId,
+        Integer quantity
+    ) {
+
+    }
+}

--- a/hub/src/main/java/com/klp/hub/inventory/application/dto/InventoryReplenishCommand.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/dto/InventoryReplenishCommand.java
@@ -1,6 +1,5 @@
 package com.klp.hub.inventory.application.dto;
 
-import com.klp.hub.inventory.domain.repository.dto.InventoryReplenish;
 import java.util.List;
 import java.util.UUID;
 
@@ -9,23 +8,12 @@ public record InventoryReplenishCommand(
     List<Product> products
 ) {
 
-    public List<InventoryReplenish> toInventoryReplenish() {
-        return products.stream().map(Product::toInventoryReplenish).toList();
-    }
-
     public record Product(
         UUID productId,
         UUID hubId,
         Integer quantity
     ) {
 
-        public InventoryReplenish toInventoryReplenish() {
-            return new InventoryReplenish(
-                productId,
-                hubId,
-                quantity
-            );
-        }
     }
 
     public int size() {

--- a/hub/src/main/java/com/klp/hub/inventory/application/dto/InventoryReplenishCommand.java
+++ b/hub/src/main/java/com/klp/hub/inventory/application/dto/InventoryReplenishCommand.java
@@ -1,0 +1,34 @@
+package com.klp.hub.inventory.application.dto;
+
+import com.klp.hub.inventory.domain.repository.dto.InventoryReplenish;
+import java.util.List;
+import java.util.UUID;
+
+public record InventoryReplenishCommand(
+    String idempotencyKey,
+    List<Product> products
+) {
+
+    public List<InventoryReplenish> toInventoryReplenish() {
+        return products.stream().map(Product::toInventoryReplenish).toList();
+    }
+
+    public record Product(
+        UUID productId,
+        UUID hubId,
+        Integer quantity
+    ) {
+
+        public InventoryReplenish toInventoryReplenish() {
+            return new InventoryReplenish(
+                productId,
+                hubId,
+                quantity
+            );
+        }
+    }
+
+    public int size() {
+        return products.size();
+    }
+}

--- a/hub/src/main/java/com/klp/hub/inventory/domain/InventoryIdempotency.java
+++ b/hub/src/main/java/com/klp/hub/inventory/domain/InventoryIdempotency.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.util.UUID;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 
@@ -22,6 +23,7 @@ import org.hibernate.annotations.Comment;
         )
     }
 )
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class InventoryIdempotency {
 

--- a/hub/src/main/java/com/klp/hub/inventory/domain/repository/InventoryRepository.java
+++ b/hub/src/main/java/com/klp/hub/inventory/domain/repository/InventoryRepository.java
@@ -2,6 +2,7 @@ package com.klp.hub.inventory.domain.repository;
 
 import com.klp.hub.inventory.domain.Inventory;
 import com.klp.hub.inventory.domain.repository.dto.InventoryDeduct;
+import com.klp.hub.inventory.domain.repository.dto.InventoryReplenish;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -17,4 +18,6 @@ public interface InventoryRepository {
     boolean tryAcquireIdempotencyKey(String idempotencyKey);
 
     int deductAll(List<InventoryDeduct> inventoryDeducts);
+
+    int replenishAll(List<InventoryReplenish> inventoryReplenishes);
 }

--- a/hub/src/main/java/com/klp/hub/inventory/domain/repository/InventoryRepository.java
+++ b/hub/src/main/java/com/klp/hub/inventory/domain/repository/InventoryRepository.java
@@ -1,14 +1,16 @@
 package com.klp.hub.inventory.domain.repository;
 
 import com.klp.hub.inventory.domain.Inventory;
-
 import java.util.Optional;
 import java.util.UUID;
 
 public interface InventoryRepository {
+
     Optional<Inventory> findByProductId(UUID productId);
 
     Optional<Inventory> findById(UUID inventoryId);
 
     Inventory save(Inventory inventory);
+
+    boolean tryAcquireIdempotencyKey(String idempotencyKey);
 }

--- a/hub/src/main/java/com/klp/hub/inventory/domain/repository/InventoryRepository.java
+++ b/hub/src/main/java/com/klp/hub/inventory/domain/repository/InventoryRepository.java
@@ -1,6 +1,8 @@
 package com.klp.hub.inventory.domain.repository;
 
 import com.klp.hub.inventory.domain.Inventory;
+import com.klp.hub.inventory.domain.repository.dto.InventoryDeduct;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -13,4 +15,6 @@ public interface InventoryRepository {
     Inventory save(Inventory inventory);
 
     boolean tryAcquireIdempotencyKey(String idempotencyKey);
+
+    int deductAll(List<InventoryDeduct> inventoryDeducts);
 }

--- a/hub/src/main/java/com/klp/hub/inventory/domain/repository/dto/InventoryDeduct.java
+++ b/hub/src/main/java/com/klp/hub/inventory/domain/repository/dto/InventoryDeduct.java
@@ -1,0 +1,11 @@
+package com.klp.hub.inventory.domain.repository.dto;
+
+import java.util.UUID;
+
+public record InventoryDeduct(
+    UUID productId,
+    UUID hubId,
+    Integer quantity
+) {
+
+}

--- a/hub/src/main/java/com/klp/hub/inventory/domain/repository/dto/InventoryReplenish.java
+++ b/hub/src/main/java/com/klp/hub/inventory/domain/repository/dto/InventoryReplenish.java
@@ -1,0 +1,11 @@
+package com.klp.hub.inventory.domain.repository.dto;
+
+import java.util.UUID;
+
+public record InventoryReplenish(
+    UUID productId,
+    UUID hubId,
+    Integer quantity
+) {
+
+}

--- a/hub/src/main/java/com/klp/hub/inventory/exception/InventoryErrorCode.java
+++ b/hub/src/main/java/com/klp/hub/inventory/exception/InventoryErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum InventoryErrorCode implements ErrorCode {
     INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "재고 수량이 부족합니다."),
     NOT_FOUND_INVENTORY(HttpStatus.BAD_REQUEST, "재고를 찾을 수 없습니다."),
+    PARTIAL_INVENTORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "일부 재고를 찾을 수 없습니다."),
     INVENTORY_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 해당 상품의 재고가 존재합니다");
 
     private final HttpStatus status;

--- a/hub/src/main/java/com/klp/hub/inventory/exception/InventoryErrorCode.java
+++ b/hub/src/main/java/com/klp/hub/inventory/exception/InventoryErrorCode.java
@@ -1,9 +1,11 @@
 package com.klp.hub.inventory.exception;
 
 import com.klp.common.exception.ErrorCode;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
+@Getter
 @RequiredArgsConstructor
 public enum InventoryErrorCode implements ErrorCode {
     INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "재고 수량이 부족합니다."),
@@ -12,14 +14,4 @@ public enum InventoryErrorCode implements ErrorCode {
 
     private final HttpStatus status;
     private final String message;
-
-    @Override
-    public HttpStatus getStatus() {
-        return status;
-    }
-
-    @Override
-    public String getMessage() {
-        return message;
-    }
 }

--- a/hub/src/main/java/com/klp/hub/inventory/exception/InventoryErrorCode.java
+++ b/hub/src/main/java/com/klp/hub/inventory/exception/InventoryErrorCode.java
@@ -1,0 +1,24 @@
+package com.klp.hub.inventory.exception;
+
+import com.klp.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum InventoryErrorCode implements ErrorCode {
+    INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "재고 수량이 부족합니다."),
+    NOT_FOUND_INVENTORY(HttpStatus.BAD_REQUEST, "재고를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/hub/src/main/java/com/klp/hub/inventory/infrastructure/repository/InventoryIdempotencyJpaRepository.java
+++ b/hub/src/main/java/com/klp/hub/inventory/infrastructure/repository/InventoryIdempotencyJpaRepository.java
@@ -1,0 +1,10 @@
+package com.klp.hub.inventory.infrastructure.repository;
+
+import com.klp.hub.inventory.domain.InventoryIdempotency;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InventoryIdempotencyJpaRepository extends
+    JpaRepository<InventoryIdempotency, UUID> {
+
+}

--- a/hub/src/main/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryImpl.java
+++ b/hub/src/main/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryImpl.java
@@ -25,6 +25,8 @@ public class InventoryRepositoryImpl implements InventoryRepository {
 
     private final JdbcTemplate jdbcTemplate;
 
+    private final String INVENTORY_TABLE = "hub_schema.p_inventory";
+
     @Override
     public Optional<Inventory> findByProductId(UUID productId) {
         return inventoryJpaRepository.findByProductId(productId);
@@ -56,13 +58,13 @@ public class InventoryRepositoryImpl implements InventoryRepository {
 
     @Override
     public int deductAll(List<InventoryDeduct> inventoryDeducts) {
-        String sql = """
-            UPDATE hub_schema.p_inventory
-               SET quantity = quantity - ?
-             WHERE product_id = ?
-               AND hub_id     = ?
-               AND quantity   >= ?
-            """;
+        String sql = String.format("""
+            UPDATE %s
+                SET quantity = quantity - ?
+            WHERE product_id = ?
+                AND hub_id     = ?
+                AND quantity   >= ?
+            """, INVENTORY_TABLE);
 
         List<Object[]> batchArgs = inventoryDeducts.stream()
             .map(line -> new Object[]{
@@ -79,12 +81,12 @@ public class InventoryRepositoryImpl implements InventoryRepository {
 
     @Override
     public int replenishAll(List<InventoryReplenish> inventoryReplenishes) {
-        String sql = """
-            UPDATE hub_schema.p_inventory
+        String sql = String.format("""
+            UPDATE %s
                SET quantity = quantity + ?
-             WHERE product_id = ?
-               AND hub_id     = ?
-            """;
+            WHERE product_id = ?
+                AND hub_id     = ?
+            """, INVENTORY_TABLE);
 
         List<Object[]> batchArgs = inventoryReplenishes.stream()
             .map(line -> new Object[]{

--- a/hub/src/main/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryImpl.java
+++ b/hub/src/main/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryImpl.java
@@ -3,11 +3,15 @@ package com.klp.hub.inventory.infrastructure.repository;
 import com.klp.hub.inventory.domain.Inventory;
 import com.klp.hub.inventory.domain.InventoryIdempotency;
 import com.klp.hub.inventory.domain.repository.InventoryRepository;
+import com.klp.hub.inventory.domain.repository.dto.InventoryDeduct;
 import com.klp.hub.inventory.domain.repository.exception.UniqueConstraintException;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -17,6 +21,8 @@ public class InventoryRepositoryImpl implements InventoryRepository {
     private final InventoryJpaRepository inventoryJpaRepository;
 
     private final InventoryIdempotencyJpaRepository idempotencyJpaRepository;
+
+    private final JdbcTemplate jdbcTemplate;
 
     @Override
     public Optional<Inventory> findByProductId(UUID productId) {
@@ -45,5 +51,28 @@ public class InventoryRepositoryImpl implements InventoryRepository {
         } catch (DataIntegrityViolationException exception) {
             return false;
         }
+    }
+
+    @Override
+    public int deductAll(List<InventoryDeduct> inventoryDeducts) {
+        String sql = """
+            UPDATE hub_schema.p_inventory
+               SET quantity = quantity - ?
+             WHERE product_id = ?
+               AND hub_id     = ?
+               AND quantity   >= ?
+            """;
+
+        List<Object[]> batchArgs = inventoryDeducts.stream()
+            .map(line -> new Object[]{
+                line.quantity(),
+                line.productId(),
+                line.hubId(),
+                line.quantity()
+            })
+            .toList();
+
+        int[] updateCount = jdbcTemplate.batchUpdate(sql, batchArgs);
+        return IntStream.of(updateCount).sum();
     }
 }

--- a/hub/src/main/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryImpl.java
+++ b/hub/src/main/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryImpl.java
@@ -25,7 +25,7 @@ public class InventoryRepositoryImpl implements InventoryRepository {
 
     private final JdbcTemplate jdbcTemplate;
 
-    private final String INVENTORY_TABLE = "hub_schema.p_inventory";
+    private final static String INVENTORY_TABLE = "hub_schema.p_inventory";
 
     @Override
     public Optional<Inventory> findByProductId(UUID productId) {

--- a/hub/src/main/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryImpl.java
+++ b/hub/src/main/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.klp.hub.inventory.domain.Inventory;
 import com.klp.hub.inventory.domain.InventoryIdempotency;
 import com.klp.hub.inventory.domain.repository.InventoryRepository;
 import com.klp.hub.inventory.domain.repository.dto.InventoryDeduct;
+import com.klp.hub.inventory.domain.repository.dto.InventoryReplenish;
 import com.klp.hub.inventory.domain.repository.exception.UniqueConstraintException;
 import java.util.List;
 import java.util.Optional;
@@ -69,6 +70,27 @@ public class InventoryRepositoryImpl implements InventoryRepository {
                 line.productId(),
                 line.hubId(),
                 line.quantity()
+            })
+            .toList();
+
+        int[] updateCount = jdbcTemplate.batchUpdate(sql, batchArgs);
+        return IntStream.of(updateCount).sum();
+    }
+
+    @Override
+    public int replenishAll(List<InventoryReplenish> inventoryReplenishes) {
+        String sql = """
+            UPDATE hub_schema.p_inventory
+               SET quantity = quantity + ?
+             WHERE product_id = ?
+               AND hub_id     = ?
+            """;
+
+        List<Object[]> batchArgs = inventoryReplenishes.stream()
+            .map(line -> new Object[]{
+                line.quantity(),
+                line.productId(),
+                line.hubId(),
             })
             .toList();
 

--- a/hub/src/main/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryImpl.java
+++ b/hub/src/main/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryImpl.java
@@ -1,19 +1,22 @@
 package com.klp.hub.inventory.infrastructure.repository;
 
 import com.klp.hub.inventory.domain.Inventory;
+import com.klp.hub.inventory.domain.InventoryIdempotency;
 import com.klp.hub.inventory.domain.repository.InventoryRepository;
 import com.klp.hub.inventory.domain.repository.exception.UniqueConstraintException;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-import java.util.UUID;
-
 @Repository
 @RequiredArgsConstructor
 public class InventoryRepositoryImpl implements InventoryRepository {
+
     private final InventoryJpaRepository inventoryJpaRepository;
+
+    private final InventoryIdempotencyJpaRepository idempotencyJpaRepository;
 
     @Override
     public Optional<Inventory> findByProductId(UUID productId) {
@@ -31,6 +34,16 @@ public class InventoryRepositoryImpl implements InventoryRepository {
             return inventoryJpaRepository.saveAndFlush(inventory);
         } catch (DataIntegrityViolationException exception) {
             throw new UniqueConstraintException("이미 해당 재고가 존재합니다.");
+        }
+    }
+
+    @Override
+    public boolean tryAcquireIdempotencyKey(String idempotencyKey) {
+        try {
+            idempotencyJpaRepository.saveAndFlush(new InventoryIdempotency(idempotencyKey));
+            return true;
+        } catch (DataIntegrityViolationException exception) {
+            return false;
         }
     }
 }

--- a/hub/src/main/java/com/klp/hub/inventory/presentation/controller/InventoryController.java
+++ b/hub/src/main/java/com/klp/hub/inventory/presentation/controller/InventoryController.java
@@ -1,16 +1,19 @@
 package com.klp.hub.inventory.presentation.controller;
 
 import com.klp.hub.inventory.application.InventoryService;
+import com.klp.hub.inventory.presentation.dto.InventoryDeductRequest;
+import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,10 +24,21 @@ public class InventoryController {
     private final InventoryService inventoryService;
 
     @GetMapping("/{productId}")
-    public ResponseEntity<InventoryResponse> getInventoryByProductId(@PathVariable("productId") String productId) {
+    public ResponseEntity<InventoryResponse> getInventoryByProductId(
+        @PathVariable("productId") String productId) {
         log.info("== 단일 상품의 재고 조회 productId : {} ==", productId);
         InventoryResponse response = inventoryService.getByProductId(UUID.fromString(productId));
         log.info("== 단일 상품의 재고 조회 성공 ==");
+        return ResponseEntity.ok().body(response);
+    }
+
+    @PostMapping("/deduct")
+    public ResponseEntity<InventoryDeductResponse> deduct(
+        @RequestBody InventoryDeductRequest request
+    ) {
+        log.info("== 재고 차감 멱등키 : {} ==", request.idempotencyKey());
+        InventoryDeductResponse response = inventoryService.deduct(request.toCommand());
+        log.info("== 재고 차감 성공");
         return ResponseEntity.ok().body(response);
     }
 }

--- a/hub/src/main/java/com/klp/hub/inventory/presentation/controller/InventoryController.java
+++ b/hub/src/main/java/com/klp/hub/inventory/presentation/controller/InventoryController.java
@@ -6,6 +6,7 @@ import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse;
 import com.klp.hub.inventory.presentation.dto.InventoryReplenishRequest;
 import com.klp.hub.inventory.presentation.dto.InventoryReplenishResponse;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
+import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,7 +28,8 @@ public class InventoryController {
 
     @GetMapping("/{productId}")
     public ResponseEntity<InventoryResponse> getInventoryByProductId(
-        @PathVariable("productId") String productId) {
+        @PathVariable("productId") String productId
+    ) {
         log.info("== 단일 상품의 재고 조회 productId : {} ==", productId);
         InventoryResponse response = inventoryService.getByProductId(UUID.fromString(productId));
         log.info("== 단일 상품의 재고 조회 성공 ==");
@@ -36,7 +38,7 @@ public class InventoryController {
 
     @PostMapping("/deduct")
     public ResponseEntity<InventoryDeductResponse> deduct(
-        @RequestBody InventoryDeductRequest request
+        @Valid @RequestBody InventoryDeductRequest request
     ) {
         log.info("== 재고 차감 멱등키 : {} ==", request.idempotencyKey());
         InventoryDeductResponse response = inventoryService.deduct(request.toCommand());
@@ -46,11 +48,11 @@ public class InventoryController {
 
     @PostMapping("/replenish")
     public ResponseEntity<InventoryReplenishResponse> replenish(
-        @RequestBody InventoryReplenishRequest request
+        @Valid @RequestBody InventoryReplenishRequest request
     ) {
-        log.info("== 재고 차감 멱등키 : {} ==", request.idempotencyKey());
+        log.info("== 재고 증가 멱등키 : {} ==", request.idempotencyKey());
         InventoryReplenishResponse response = inventoryService.replenish(request.toCommand());
-        log.info("== 재고 차감 성공");
+        log.info("== 재고 증가 성공");
         return ResponseEntity.ok().body(response);
     }
 }

--- a/hub/src/main/java/com/klp/hub/inventory/presentation/controller/InventoryController.java
+++ b/hub/src/main/java/com/klp/hub/inventory/presentation/controller/InventoryController.java
@@ -3,6 +3,8 @@ package com.klp.hub.inventory.presentation.controller;
 import com.klp.hub.inventory.application.InventoryService;
 import com.klp.hub.inventory.presentation.dto.InventoryDeductRequest;
 import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse;
+import com.klp.hub.inventory.presentation.dto.InventoryReplenishRequest;
+import com.klp.hub.inventory.presentation.dto.InventoryReplenishResponse;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +40,16 @@ public class InventoryController {
     ) {
         log.info("== 재고 차감 멱등키 : {} ==", request.idempotencyKey());
         InventoryDeductResponse response = inventoryService.deduct(request.toCommand());
+        log.info("== 재고 차감 성공");
+        return ResponseEntity.ok().body(response);
+    }
+
+    @PostMapping("/replenish")
+    public ResponseEntity<InventoryReplenishResponse> replenish(
+        @RequestBody InventoryReplenishRequest request
+    ) {
+        log.info("== 재고 차감 멱등키 : {} ==", request.idempotencyKey());
+        InventoryReplenishResponse response = inventoryService.replenish(request.toCommand());
         log.info("== 재고 차감 성공");
         return ResponseEntity.ok().body(response);
     }

--- a/hub/src/main/java/com/klp/hub/inventory/presentation/dto/InventoryDeductRequest.java
+++ b/hub/src/main/java/com/klp/hub/inventory/presentation/dto/InventoryDeductRequest.java
@@ -1,11 +1,21 @@
 package com.klp.hub.inventory.presentation.dto;
 
 import com.klp.hub.inventory.application.dto.InventoryDeductCommand;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.UUID;
 
 public record InventoryDeductRequest(
+    @NotBlank(message = "멱등키는 필수 값입니다.")
     String idempotencyKey,
+
+    @NotNull(message = "상품 목록은 필수 값입니다.")
+    @NotEmpty(message = "상품 목록은 최소 1개 이상이어야 합니다.")
+    @Valid
     List<Product> products
 ) {
 
@@ -21,8 +31,12 @@ public record InventoryDeductRequest(
     }
 
     public record Product(
+        @NotNull(message = "상품 ID는 필수 값입니다.")
         UUID productId,
+        @NotNull(message = "허브 ID는 필수 값입니다.")
         UUID hubId,
+        @NotNull(message = "수량은 필수 값입니다.")
+        @Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
         Integer quantity
     ) {
 

--- a/hub/src/main/java/com/klp/hub/inventory/presentation/dto/InventoryDeductRequest.java
+++ b/hub/src/main/java/com/klp/hub/inventory/presentation/dto/InventoryDeductRequest.java
@@ -1,0 +1,30 @@
+package com.klp.hub.inventory.presentation.dto;
+
+import com.klp.hub.inventory.application.dto.InventoryDeductCommand;
+import java.util.List;
+import java.util.UUID;
+
+public record InventoryDeductRequest(
+    String idempotencyKey,
+    List<Product> products
+) {
+
+    public InventoryDeductCommand toCommand() {
+        return new InventoryDeductCommand(
+            idempotencyKey,
+            products.stream().map(product -> new InventoryDeductCommand.Product(
+                product.productId,
+                product.hubId,
+                product.quantity
+            )).toList()
+        );
+    }
+
+    public record Product(
+        UUID productId,
+        UUID hubId,
+        Integer quantity
+    ) {
+
+    }
+}

--- a/hub/src/main/java/com/klp/hub/inventory/presentation/dto/InventoryDeductResponse.java
+++ b/hub/src/main/java/com/klp/hub/inventory/presentation/dto/InventoryDeductResponse.java
@@ -1,18 +1,18 @@
 package com.klp.hub.inventory.presentation.dto;
 
 public record InventoryDeductResponse(
-    Process process
+    Status status
 ) {
 
     public static InventoryDeductResponse success() {
-        return new InventoryDeductResponse(Process.SUCCESS);
+        return new InventoryDeductResponse(Status.SUCCESS);
     }
 
     public static InventoryDeductResponse already() {
-        return new InventoryDeductResponse(Process.ALREADY_DEDUCTED);
+        return new InventoryDeductResponse(Status.ALREADY_DEDUCTED);
     }
 
-    public enum Process {
+    public enum Status {
         SUCCESS, ALREADY_DEDUCTED
     }
 }

--- a/hub/src/main/java/com/klp/hub/inventory/presentation/dto/InventoryDeductResponse.java
+++ b/hub/src/main/java/com/klp/hub/inventory/presentation/dto/InventoryDeductResponse.java
@@ -1,0 +1,18 @@
+package com.klp.hub.inventory.presentation.dto;
+
+public record InventoryDeductResponse(
+    Process process
+) {
+
+    public static InventoryDeductResponse success() {
+        return new InventoryDeductResponse(Process.SUCCESS);
+    }
+
+    public static InventoryDeductResponse already() {
+        return new InventoryDeductResponse(Process.ALREADY_DEDUCTED);
+    }
+
+    public enum Process {
+        SUCCESS, ALREADY_DEDUCTED
+    }
+}

--- a/hub/src/main/java/com/klp/hub/inventory/presentation/dto/InventoryReplenishRequest.java
+++ b/hub/src/main/java/com/klp/hub/inventory/presentation/dto/InventoryReplenishRequest.java
@@ -1,11 +1,20 @@
 package com.klp.hub.inventory.presentation.dto;
 
 import com.klp.hub.inventory.application.dto.InventoryReplenishCommand;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.UUID;
 
 public record InventoryReplenishRequest(
+    @NotBlank(message = "멱등키는 필수 값입니다.")
     String idempotencyKey,
+    @NotNull(message = "상품 목록은 필수 값입니다.")
+    @NotEmpty(message = "상품 목록은 최소 1개 이상이어야 합니다.")
+    @Valid
     List<Product> products
 ) {
 
@@ -21,8 +30,12 @@ public record InventoryReplenishRequest(
     }
 
     public record Product(
+        @NotNull(message = "상품 ID는 필수 값입니다.")
         UUID productId,
+        @NotNull(message = "허브 ID는 필수 값입니다.")
         UUID hubId,
+        @NotNull(message = "수량은 필수 값입니다.")
+        @Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
         Integer quantity
     ) {
 

--- a/hub/src/main/java/com/klp/hub/inventory/presentation/dto/InventoryReplenishRequest.java
+++ b/hub/src/main/java/com/klp/hub/inventory/presentation/dto/InventoryReplenishRequest.java
@@ -1,0 +1,30 @@
+package com.klp.hub.inventory.presentation.dto;
+
+import com.klp.hub.inventory.application.dto.InventoryReplenishCommand;
+import java.util.List;
+import java.util.UUID;
+
+public record InventoryReplenishRequest(
+    String idempotencyKey,
+    List<Product> products
+) {
+
+    public InventoryReplenishCommand toCommand() {
+        return new InventoryReplenishCommand(
+            idempotencyKey,
+            products.stream().map(product -> new InventoryReplenishCommand.Product(
+                product.productId,
+                product.hubId,
+                product.quantity
+            )).toList()
+        );
+    }
+
+    public record Product(
+        UUID productId,
+        UUID hubId,
+        Integer quantity
+    ) {
+
+    }
+}

--- a/hub/src/main/java/com/klp/hub/inventory/presentation/dto/InventoryReplenishResponse.java
+++ b/hub/src/main/java/com/klp/hub/inventory/presentation/dto/InventoryReplenishResponse.java
@@ -1,18 +1,18 @@
 package com.klp.hub.inventory.presentation.dto;
 
 public record InventoryReplenishResponse(
-    Process process
+    Status status
 ) {
 
     public static InventoryReplenishResponse success() {
-        return new InventoryReplenishResponse(Process.SUCCESS);
+        return new InventoryReplenishResponse(Status.SUCCESS);
     }
 
     public static InventoryReplenishResponse already() {
-        return new InventoryReplenishResponse(Process.ALREADY_REPLENISHED);
+        return new InventoryReplenishResponse(Status.ALREADY_REPLENISHED);
     }
 
-    public enum Process {
+    public enum Status {
         SUCCESS, ALREADY_REPLENISHED
     }
 }

--- a/hub/src/main/java/com/klp/hub/inventory/presentation/dto/InventoryReplenishResponse.java
+++ b/hub/src/main/java/com/klp/hub/inventory/presentation/dto/InventoryReplenishResponse.java
@@ -1,0 +1,18 @@
+package com.klp.hub.inventory.presentation.dto;
+
+public record InventoryReplenishResponse(
+    Process process
+) {
+
+    public static InventoryReplenishResponse success() {
+        return new InventoryReplenishResponse(Process.SUCCESS);
+    }
+
+    public static InventoryReplenishResponse already() {
+        return new InventoryReplenishResponse(Process.ALREADY_REPLENISHED);
+    }
+
+    public enum Process {
+        SUCCESS, ALREADY_REPLENISHED
+    }
+}

--- a/hub/src/main/java/com/klp/hub/inventory/presentation/dto/InventoryResponse.java
+++ b/hub/src/main/java/com/klp/hub/inventory/presentation/dto/InventoryResponse.java
@@ -3,8 +3,10 @@ package com.klp.hub.inventory.presentation.dto;
 import java.util.UUID;
 
 public record InventoryResponse(
-        UUID productId,
-        UUID inventoryId,
-        Integer quantity
+    UUID productId,
+    UUID inventoryId,
+    UUID hubId,
+    Integer quantity
 ) {
+
 }

--- a/hub/src/main/java/com/klp/hub/product/application/ProductService.java
+++ b/hub/src/main/java/com/klp/hub/product/application/ProductService.java
@@ -1,14 +1,15 @@
 package com.klp.hub.product.application;
 
+import com.klp.common.exception.BusinessException;
 import com.klp.hub.company.application.CompanyService;
 import com.klp.hub.company.presentation.dto.CompanyResponse;
 import com.klp.hub.inventory.application.InventoryService;
-import com.klp.hub.inventory.domain.repository.exception.UniqueConstraintException;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
 import com.klp.hub.product.application.dto.ProductCreateCommand;
 import com.klp.hub.product.application.dto.ProductUpdateCommand;
 import com.klp.hub.product.domain.Product;
 import com.klp.hub.product.domain.repository.ProductRepository;
+import com.klp.hub.product.exception.ProductErrorCode;
 import com.klp.hub.product.presentation.dto.ProductResponse;
 import com.klp.hub.product.presentation.dto.ProductUpdateResponse;
 import com.klp.hub.product.presentation.dto.ProductsPageRowResponse;
@@ -57,14 +58,8 @@ public class ProductService {
             new Product(companyResponse.companyId(), command.name())
         );
 
-        try {
-            inventoryService.create(savedProduct.getId(), command.hubId(), command.quantity());
-            return savedProduct.getId();
-        } catch (UniqueConstraintException exception) {
-            log.error("이미 해당 재고가 존재합니다.");
-            // FIXME: 도메인 예외 교체 필요
-            throw new RuntimeException(exception.getMessage());
-        }
+        inventoryService.create(savedProduct.getId(), command.hubId(), command.quantity());
+        return savedProduct.getId();
     }
 
     @Transactional
@@ -93,7 +88,7 @@ public class ProductService {
     private Product getById(UUID productId) {
         Product product = productRepository.findById(productId).orElseThrow(() -> {
             log.error("해당 상품을 찾을 수 없습니다. productId : {}", productId);
-            return new RuntimeException();
+            return new BusinessException(ProductErrorCode.NOT_FOUND_PRODUCT);
         });
         return product;
     }

--- a/hub/src/main/java/com/klp/hub/product/application/ProductService.java
+++ b/hub/src/main/java/com/klp/hub/product/application/ProductService.java
@@ -54,7 +54,7 @@ public class ProductService {
     public UUID create(ProductCreateCommand command) {
         CompanyResponse companyResponse = companyService.getByCompanyId(command.companyId());
         Product savedProduct = productRepository.save(
-            new Product(companyResponse.id(), command.name())
+            new Product(companyResponse.companyId(), command.name())
         );
 
         try {

--- a/hub/src/main/java/com/klp/hub/product/application/ProductService.java
+++ b/hub/src/main/java/com/klp/hub/product/application/ProductService.java
@@ -6,20 +6,19 @@ import com.klp.hub.inventory.application.InventoryService;
 import com.klp.hub.inventory.domain.repository.exception.UniqueConstraintException;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
 import com.klp.hub.product.application.dto.ProductCreateCommand;
+import com.klp.hub.product.application.dto.ProductUpdateCommand;
 import com.klp.hub.product.domain.Product;
 import com.klp.hub.product.domain.repository.ProductRepository;
+import com.klp.hub.product.presentation.dto.ProductResponse;
 import com.klp.hub.product.presentation.dto.ProductUpdateResponse;
 import com.klp.hub.product.presentation.dto.ProductsPageRowResponse;
-import com.klp.hub.product.presentation.dto.ProductResponse;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.UUID;
-import com.klp.hub.product.application.dto.ProductUpdateCommand;
 
 @Service
 @Slf4j
@@ -35,13 +34,14 @@ public class ProductService {
     @Transactional(readOnly = true)
     public ProductResponse getProductById(UUID productId) {
         Product product = getById(productId);
+        InventoryResponse inventory = inventoryService.getByProductId(productId);
         CompanyResponse company = companyService.getByCompanyId(product.getCompanyId());
 
         return new ProductResponse(
-                product.getId(),
-                UUID.randomUUID(),
-                company.name(),
-                product.getName()
+            product.getId(),
+            inventory.hubId(),
+            company.name(),
+            product.getName()
         );
     }
 
@@ -54,7 +54,7 @@ public class ProductService {
     public UUID create(ProductCreateCommand command) {
         CompanyResponse companyResponse = companyService.getByCompanyId(command.companyId());
         Product savedProduct = productRepository.save(
-                new Product(companyResponse.id(), command.name())
+            new Product(companyResponse.id(), command.name())
         );
 
         try {
@@ -74,8 +74,8 @@ public class ProductService {
         product.updateName(command.name());
 
         return new ProductUpdateResponse(
-                product.getId(),
-                product.getName()
+            product.getId(),
+            product.getName()
         );
     }
 

--- a/hub/src/main/java/com/klp/hub/product/exception/ProductErrorCode.java
+++ b/hub/src/main/java/com/klp/hub/product/exception/ProductErrorCode.java
@@ -1,16 +1,15 @@
-package com.klp.hub.inventory.exception;
+package com.klp.hub.product.exception;
 
 import com.klp.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
-public enum InventoryErrorCode implements ErrorCode {
-    INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "재고 수량이 부족합니다."),
-    NOT_FOUND_INVENTORY(HttpStatus.BAD_REQUEST, "재고를 찾을 수 없습니다."),
-    INVENTORY_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 해당 상품의 재고가 존재합니다");
+public enum ProductErrorCode implements ErrorCode {
+    NOT_FOUND_PRODUCT(HttpStatus.BAD_REQUEST, "해당 상품을 찾을 수 없습니다.");
 
     private final HttpStatus status;
+
     private final String message;
 
     @Override

--- a/hub/src/main/java/com/klp/hub/product/exception/ProductErrorCode.java
+++ b/hub/src/main/java/com/klp/hub/product/exception/ProductErrorCode.java
@@ -1,24 +1,15 @@
 package com.klp.hub.product.exception;
 
 import com.klp.common.exception.ErrorCode;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 
+@Getter
 @RequiredArgsConstructor
 public enum ProductErrorCode implements ErrorCode {
     NOT_FOUND_PRODUCT(HttpStatus.BAD_REQUEST, "해당 상품을 찾을 수 없습니다.");
 
     private final HttpStatus status;
-
     private final String message;
-
-    @Override
-    public HttpStatus getStatus() {
-        return status;
-    }
-
-    @Override
-    public String getMessage() {
-        return message;
-    }
 }

--- a/hub/src/test/java/com/klp/hub/company/application/CompanyServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/company/application/CompanyServiceTest.java
@@ -1,13 +1,17 @@
 package com.klp.hub.company.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.klp.common.exception.BusinessException;
+import com.klp.common.exception.ErrorCode;
 import com.klp.hub.company.domain.Company;
 import com.klp.hub.company.domain.CompanyType;
 import com.klp.hub.company.domain.repository.CompanyRepository;
+import com.klp.hub.company.exception.CompanyErrorCode;
 import com.klp.hub.company.presentation.dto.CompanyResponse;
 import java.util.Optional;
 import java.util.UUID;
@@ -47,9 +51,12 @@ class CompanyServiceTest {
     @Test
     @DisplayName("해당 업체가 존재하지 않는다면 예외가 발생한다")
     void throwGetCompanyById() {
-        when(companyRepository.findById(UUID.randomUUID())).thenReturn(Optional.empty());
+        UUID companyId = UUID.randomUUID();
+        when(companyRepository.findById(companyId)).thenReturn(Optional.empty());
 
-        assertThrows(RuntimeException.class,
-            () -> companyService.getByCompanyId(UUID.randomUUID()));
+        ErrorCode errorCode = assertThrows(BusinessException.class,
+            () -> companyService.getByCompanyId(companyId))
+            .getErrorCode();
+        assertEquals(CompanyErrorCode.NOT_FOUND_COMPANY, errorCode);
     }
 }

--- a/hub/src/test/java/com/klp/hub/company/application/CompanyServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/company/application/CompanyServiceTest.java
@@ -1,23 +1,22 @@
 package com.klp.hub.company.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.klp.hub.company.domain.Company;
 import com.klp.hub.company.domain.CompanyType;
 import com.klp.hub.company.domain.repository.CompanyRepository;
 import com.klp.hub.company.presentation.dto.CompanyResponse;
+import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Optional;
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class CompanyServiceTest {
@@ -38,11 +37,11 @@ class CompanyServiceTest {
         when(company.getName()).thenReturn("업체명");
         when(company.getAddress()).thenReturn("업체주소");
         when(companyRepository.findById(companyId))
-                .thenReturn(Optional.of(company));
+            .thenReturn(Optional.of(company));
 
         CompanyResponse response = companyService.getByCompanyId(companyId);
 
-        assertThat(response.id()).isNotNull();
+        assertThat(response.companyId()).isNotNull();
     }
 
     @Test
@@ -50,6 +49,7 @@ class CompanyServiceTest {
     void throwGetCompanyById() {
         when(companyRepository.findById(UUID.randomUUID())).thenReturn(Optional.empty());
 
-        assertThrows(RuntimeException.class, () -> companyService.getByCompanyId(UUID.randomUUID()));
+        assertThrows(RuntimeException.class,
+            () -> companyService.getByCompanyId(UUID.randomUUID()));
     }
 }

--- a/hub/src/test/java/com/klp/hub/company/presentation/controller/CompanyControllerTest.java
+++ b/hub/src/test/java/com/klp/hub/company/presentation/controller/CompanyControllerTest.java
@@ -1,0 +1,56 @@
+package com.klp.hub.company.presentation.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.klp.hub.company.application.CompanyService;
+import com.klp.hub.company.domain.CompanyType;
+import com.klp.hub.company.presentation.dto.CompanyResponse;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(CompanyController.class)
+class CompanyControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CompanyService companyService;
+
+    private UUID hubID = UUID.randomUUID();
+
+    @Test
+    @DisplayName("업체 ID 로 업체를 조회할 수 있다")
+    void getCompanyById() throws Exception {
+        UUID companyId = UUID.randomUUID();
+        when(companyService.getByCompanyId(companyId))
+            .thenReturn(
+                new CompanyResponse(
+                    companyId,
+                    hubID,
+                    CompanyType.SUPPLIER.name(),
+                    "업체명",
+                    "업체주소"
+                )
+            );
+
+        mockMvc.perform(get("/v1/companies/{companyId}", companyId))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.companyId").isString())
+            .andExpect(jsonPath("$.hubId").isString())
+            .andExpect(jsonPath("$.type").isString())
+            .andExpect(jsonPath("$.name").isString())
+            .andExpect(jsonPath("$.address").isString());
+    }
+}

--- a/hub/src/test/java/com/klp/hub/company/presentation/controller/CompanyControllerTest.java
+++ b/hub/src/test/java/com/klp/hub/company/presentation/controller/CompanyControllerTest.java
@@ -6,6 +6,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.klp.common.exception.GlobalExceptionHandler;
+import com.klp.common.security.config.SecurityConfig;
+import com.klp.common.security.filter.AuthorizationFilter;
 import com.klp.hub.company.application.CompanyService;
 import com.klp.hub.company.domain.CompanyType;
 import com.klp.hub.company.presentation.dto.CompanyResponse;
@@ -14,11 +17,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(CompanyController.class)
+@Import({SecurityConfig.class, AuthorizationFilter.class, GlobalExceptionHandler.class})
 class CompanyControllerTest {
 
     @Autowired

--- a/hub/src/test/java/com/klp/hub/company/presentation/controller/CompanyControllerTest.java
+++ b/hub/src/test/java/com/klp/hub/company/presentation/controller/CompanyControllerTest.java
@@ -6,12 +6,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.klp.common.exception.GlobalExceptionHandler;
-import com.klp.common.security.config.SecurityConfig;
-import com.klp.common.security.filter.AuthorizationFilter;
 import com.klp.hub.company.application.CompanyService;
 import com.klp.hub.company.domain.CompanyType;
 import com.klp.hub.company.presentation.dto.CompanyResponse;
+import com.klp.hub.global.config.SecurityConfig;
+import com.klp.hub.global.exception.GlobalExceptionHandler;
+import com.klp.hub.global.filter.AuthorizationFilter;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceConcurrencyTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceConcurrencyTest.java
@@ -2,14 +2,12 @@ package com.klp.hub.inventory.application;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.klp.hub.TestJpaConfig;
 import com.klp.hub.inventory.application.dto.InventoryDeductCommand;
 import com.klp.hub.inventory.application.dto.InventoryDeductCommand.Product;
 import com.klp.hub.inventory.application.dto.InventoryReplenishCommand;
 import com.klp.hub.inventory.domain.Inventory;
 import com.klp.hub.inventory.domain.repository.InventoryRepository;
 import com.klp.hub.inventory.infrastructure.repository.InventoryJpaRepository;
-import com.klp.hub.inventory.infrastructure.repository.InventoryRepositoryImpl;
 import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse;
 import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse.Status;
 import java.util.List;
@@ -24,19 +22,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.annotation.Rollback;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-@DataJpaTest
-@Import({
-    InventoryRepositoryImpl.class,
-    InventoryService.class,
-    TestJpaConfig.class
-})
+@SpringBootTest
 @ActiveProfiles("test")
 public class InventoryServiceConcurrencyTest {
 
@@ -73,8 +64,6 @@ public class InventoryServiceConcurrencyTest {
 
         @Test
         @DisplayName("다수의 동시 요청 시 최종 재고는 0이 되어야 한다")
-        @Transactional(propagation = Propagation.NOT_SUPPORTED)
-        @Rollback(false)
         void deductAllConcurrency() throws InterruptedException {
             int qtyPerThread = initQuantity / threadCount;
             ExecutorService executorService = Executors.newFixedThreadPool(32);
@@ -105,8 +94,6 @@ public class InventoryServiceConcurrencyTest {
 
         @Test
         @DisplayName("다수의 동시 요청시 최종 재고는 정확히 증가해야 한다")
-        @Transactional(propagation = Propagation.NOT_SUPPORTED)
-        @Rollback(false)
         void replenishConcurrency() throws InterruptedException {
             int qtyPerThread = initQuantity / threadCount;
             int totalQuantity = qtyPerThread * threadCount;
@@ -140,8 +127,6 @@ public class InventoryServiceConcurrencyTest {
 
         @Test
         @DisplayName("단 하나의 요청만 성공하고 나머지는 중복으로 처리되어야 한다")
-        @Transactional(propagation = Propagation.NOT_SUPPORTED)
-        @Rollback(false)
         void idempotencyConcurrency() throws InterruptedException {
             String sharedIdempotencyKey = "sharedIdempotencyKey";
             int qtyPerThread = initQuantity / threadCount; // 10개

--- a/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceConcurrencyTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceConcurrencyTest.java
@@ -11,7 +11,7 @@ import com.klp.hub.inventory.domain.repository.InventoryRepository;
 import com.klp.hub.inventory.infrastructure.repository.InventoryJpaRepository;
 import com.klp.hub.inventory.infrastructure.repository.InventoryRepositoryImpl;
 import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse;
-import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse.Process;
+import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse.Status;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -158,9 +158,9 @@ public class InventoryServiceConcurrencyTest {
                 try {
                     InventoryDeductResponse response = inventoryService.deduct(command);
 
-                    if (response.process() == Process.SUCCESS) {
+                    if (response.status() == Status.SUCCESS) {
                         successCont[0]++;
-                    } else if (response.process() == Process.ALREADY_DEDUCTED) {
+                    } else if (response.status() == Status.ALREADY_DEDUCTED) {
                         alreadyCount[0]++;
                     }
                 } finally {

--- a/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceConcurrencyTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceConcurrencyTest.java
@@ -1,0 +1,179 @@
+package com.klp.hub.inventory.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.klp.hub.TestJpaConfig;
+import com.klp.hub.inventory.application.dto.InventoryDeductCommand;
+import com.klp.hub.inventory.application.dto.InventoryDeductCommand.Product;
+import com.klp.hub.inventory.application.dto.InventoryReplenishCommand;
+import com.klp.hub.inventory.domain.Inventory;
+import com.klp.hub.inventory.domain.repository.InventoryRepository;
+import com.klp.hub.inventory.infrastructure.repository.InventoryJpaRepository;
+import com.klp.hub.inventory.infrastructure.repository.InventoryRepositoryImpl;
+import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse;
+import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse.Process;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@DataJpaTest
+@Import({
+    InventoryRepositoryImpl.class,
+    InventoryService.class,
+    TestJpaConfig.class
+})
+@ActiveProfiles("test")
+public class InventoryServiceConcurrencyTest {
+
+    @Autowired
+    private InventoryService inventoryService;
+
+    @Autowired
+    private InventoryRepository inventoryRepository;
+
+    @Autowired
+    private InventoryJpaRepository jpaRepository;
+
+    private UUID productId = UUID.randomUUID();
+
+    private UUID hubId = UUID.randomUUID();
+
+    private final int threadCount = 100;
+
+    private final int initQuantity = 1000;
+
+    @BeforeEach
+    void setUp() {
+        inventoryRepository.save(new Inventory(productId, hubId, initQuantity));
+    }
+
+    @AfterEach
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    void tearDown() {
+        jpaRepository.deleteAll();
+    }
+
+    @Nested
+    class Deduct {
+
+        @Test
+        @DisplayName("다수의 동시 요청 시 최종 재고는 0이 되어야 한다")
+        @Transactional(propagation = Propagation.NOT_SUPPORTED)
+        @Rollback(false)
+        void deductAllConcurrency() throws InterruptedException {
+            int qtyPerThread = initQuantity / threadCount;
+            ExecutorService executorService = Executors.newFixedThreadPool(32);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+
+            IntStream.range(0, threadCount).forEach(i -> executorService.submit(() -> {
+                try {
+                    String uniqueIdempotencyKey = UUID.randomUUID().toString();
+                    InventoryDeductCommand command = new InventoryDeductCommand(
+                        uniqueIdempotencyKey,
+                        List.of(new Product(productId, hubId, qtyPerThread))
+                    );
+                    inventoryService.deduct(command);
+                } finally {
+                    latch.countDown();
+                }
+            }));
+            latch.await();
+            executorService.shutdown();
+
+            Inventory inventory = inventoryRepository.findByProductId(productId).orElseThrow();
+            assertEquals(0, inventory.getQuantity());
+        }
+    }
+
+    @Nested
+    class Replenish {
+
+        @Test
+        @DisplayName("다수의 동시 요청시 최종 재고는 정확히 증가해야 한다")
+        @Transactional(propagation = Propagation.NOT_SUPPORTED)
+        @Rollback(false)
+        void replenishConcurrency() throws InterruptedException {
+            int qtyPerThread = initQuantity / threadCount;
+            int totalQuantity = qtyPerThread * threadCount;
+            ExecutorService executorService = Executors.newFixedThreadPool(32);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+
+            IntStream.range(0, threadCount).forEach(i -> executorService.submit(() -> {
+                try {
+                    String uniqueIdempotencyKey = UUID.randomUUID().toString();
+                    InventoryReplenishCommand command = new InventoryReplenishCommand(
+                        uniqueIdempotencyKey,
+                        List.of(
+                            new InventoryReplenishCommand.Product(productId, hubId, qtyPerThread))
+                    );
+                    inventoryService.replenish(command);
+                } finally {
+                    latch.countDown();
+                }
+            }));
+            latch.await();
+            executorService.shutdown();
+
+            Inventory inventory = inventoryRepository.findByProductId(productId).orElseThrow();
+            int expectedQuantity = initQuantity + totalQuantity;
+            assertEquals(expectedQuantity, inventory.getQuantity());
+        }
+    }
+
+    @Nested
+    class Idempotency {
+
+        @Test
+        @DisplayName("단 하나의 요청만 성공하고 나머지는 중복으로 처리되어야 한다")
+        @Transactional(propagation = Propagation.NOT_SUPPORTED)
+        @Rollback(false)
+        void idempotencyConcurrency() throws InterruptedException {
+            String sharedIdempotencyKey = "sharedIdempotencyKey";
+            int qtyPerThread = initQuantity / threadCount; // 10개
+            InventoryDeductCommand command = new InventoryDeductCommand(
+                sharedIdempotencyKey,
+                List.of(new Product(productId, hubId, qtyPerThread))
+            );
+            ExecutorService executorService = Executors.newFixedThreadPool(32);
+            CountDownLatch latch = new CountDownLatch(threadCount);
+            int[] successCont = {0};
+            int[] alreadyCount = {0};
+
+            IntStream.range(0, threadCount).forEach(i -> executorService.submit(() -> {
+                try {
+                    InventoryDeductResponse response = inventoryService.deduct(command);
+
+                    if (response.process() == Process.SUCCESS) {
+                        successCont[0]++;
+                    } else if (response.process() == Process.ALREADY_DEDUCTED) {
+                        alreadyCount[0]++;
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            }));
+            latch.await();
+            executorService.shutdown();
+
+            Inventory inventory = inventoryRepository.findByProductId(productId).orElseThrow();
+            int expectedQuantity = initQuantity - qtyPerThread; // 990 (처음 10개 재고 차감만 성공)
+            assertEquals(1, successCont[0]);
+            assertEquals(expectedQuantity, inventory.getQuantity());
+        }
+    }
+}

--- a/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
@@ -1,22 +1,28 @@
 package com.klp.hub.inventory.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.klp.hub.inventory.application.dto.InventoryDeductCommand;
+import com.klp.hub.inventory.application.dto.InventoryDeductCommand.Product;
 import com.klp.hub.inventory.domain.Inventory;
 import com.klp.hub.inventory.domain.repository.InventoryRepository;
+import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse;
+import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse.Process;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Optional;
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 class InventoryServiceTest {
@@ -39,7 +45,7 @@ class InventoryServiceTest {
         Inventory inventory = mock(Inventory.class);
         when(inventory.getQuantity()).thenReturn(10);
         when(inventoryRepository.findByProductId(productId))
-                .thenReturn(Optional.of(inventory));
+            .thenReturn(Optional.of(inventory));
 
         InventoryResponse response = inventoryService.getByProductId(productId);
 
@@ -73,5 +79,21 @@ class InventoryServiceTest {
         when(inventoryRepository.findById(inventoryId)).thenReturn(Optional.empty());
 
         assertThrows(RuntimeException.class, () -> inventoryService.delete(inventoryId));
+    }
+
+    @Test
+    @DisplayName("재고 차감 요청시 이미 처리된 요청이라면 ALREADY 를 반환한다")
+    void idempotency() {
+        String idempotencyKey = "idempotencyKey";
+        InventoryDeductCommand command = new InventoryDeductCommand(
+            idempotencyKey,
+            List.of(new Product(productId, 10))
+        );
+        when(inventoryRepository.tryAcquireIdempotencyKey(idempotencyKey))
+            .thenReturn(false);
+
+        InventoryDeductResponse response = inventoryService.deduct(command);
+
+        assertEquals(Process.ALREADY_DEDUCTED, response.process());
     }
 }

--- a/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
@@ -201,6 +201,6 @@ class InventoryServiceTest {
         ErrorCode errorCode = assertThrows(
             BusinessException.class, () -> inventoryService.replenish(command))
             .getErrorCode();
-        assertEquals(InventoryErrorCode.NOT_FOUND_INVENTORY, errorCode);
+        assertEquals(InventoryErrorCode.PARTIAL_INVENTORY_NOT_FOUND, errorCode);
     }
 }

--- a/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
@@ -10,10 +10,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.klp.common.exception.BusinessException;
+import com.klp.common.exception.ErrorCode;
 import com.klp.hub.inventory.application.dto.InventoryDeductCommand;
 import com.klp.hub.inventory.application.dto.InventoryDeductCommand.Product;
 import com.klp.hub.inventory.domain.Inventory;
 import com.klp.hub.inventory.domain.repository.InventoryRepository;
+import com.klp.hub.inventory.exception.InventoryErrorCode;
 import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse;
 import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse.Process;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
@@ -63,7 +66,10 @@ class InventoryServiceTest {
     void throwGetInventoryByProductId() {
         when(inventoryRepository.findByProductId(productId)).thenReturn(Optional.empty());
 
-        assertThrows(RuntimeException.class, () -> inventoryService.getByProductId(productId));
+        ErrorCode errorCode = assertThrows(BusinessException.class,
+            () -> inventoryService.getByProductId(productId))
+            .getErrorCode();
+        assertEquals(InventoryErrorCode.NOT_FOUND_INVENTORY, errorCode);
     }
 
     @Test
@@ -83,7 +89,10 @@ class InventoryServiceTest {
     void throwDeletedByNullInventoryId() {
         when(inventoryRepository.findById(inventoryId)).thenReturn(Optional.empty());
 
-        assertThrows(RuntimeException.class, () -> inventoryService.delete(inventoryId));
+        ErrorCode errorCode = assertThrows(BusinessException.class,
+            () -> inventoryService.delete(inventoryId))
+            .getErrorCode();
+        assertEquals(InventoryErrorCode.NOT_FOUND_INVENTORY, errorCode);
     }
 
     @Test
@@ -130,6 +139,9 @@ class InventoryServiceTest {
         when(inventoryRepository.tryAcquireIdempotencyKey(idempotencyKey)).thenReturn(true);
         when(inventoryRepository.deductAll(command.toInventoryDeductList())).thenReturn(0);
 
-        assertThrows(RuntimeException.class, () -> inventoryService.deduct(command));
+        ErrorCode errorCode = assertThrows(
+            BusinessException.class, () -> inventoryService.deduct(command))
+            .getErrorCode();
+        assertEquals(InventoryErrorCode.INSUFFICIENT_STOCK, errorCode);
     }
 }

--- a/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
@@ -4,7 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.klp.hub.inventory.application.dto.InventoryDeductCommand;
@@ -38,6 +41,8 @@ class InventoryServiceTest {
     private UUID hubId = UUID.randomUUID();
 
     private UUID inventoryId = UUID.randomUUID();
+
+    String idempotencyKey = "idempotencyKey";
 
     @Test
     @DisplayName("한 상품의 재고를 조회할 수 있다")
@@ -95,5 +100,22 @@ class InventoryServiceTest {
         InventoryDeductResponse response = inventoryService.deduct(command);
 
         assertEquals(Process.ALREADY_DEDUCTED, response.process());
+    }
+
+    @Test
+    @DisplayName("재고가 충분하고 멱등키가 처음이라면 성공을 반환하고 재고를 차감한다")
+    void deduct() {
+        int quantity = 5;
+        InventoryDeductCommand command = new InventoryDeductCommand(
+            idempotencyKey,
+            List.of(new Product(productId, hubId, quantity))
+        );
+        when(inventoryRepository.tryAcquireIdempotencyKey(idempotencyKey)).thenReturn(true);
+        when(inventoryRepository.deductAll(command.toInventoryDeductList())).thenReturn(1);
+
+        InventoryDeductResponse response = inventoryService.deduct(command);
+
+        assertEquals(Process.SUCCESS, response.process());
+        verify(inventoryRepository, times(1)).deductAll(anyList());
     }
 }

--- a/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
@@ -87,7 +87,7 @@ class InventoryServiceTest {
         String idempotencyKey = "idempotencyKey";
         InventoryDeductCommand command = new InventoryDeductCommand(
             idempotencyKey,
-            List.of(new Product(productId, 10))
+            List.of(new Product(productId, hubId, 10))
         );
         when(inventoryRepository.tryAcquireIdempotencyKey(idempotencyKey))
             .thenReturn(false);

--- a/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
@@ -137,7 +137,9 @@ class InventoryServiceTest {
             List.of(new Product(productId, hubId, quantity))
         );
         when(inventoryRepository.tryAcquireIdempotencyKey(idempotencyKey)).thenReturn(true);
-        when(inventoryRepository.deductAll(command.toInventoryDeductList())).thenReturn(1);
+        when(inventoryRepository.deductAll(
+            InventoryUpdatePlanner.planDeduct(command.products()))
+        ).thenReturn(1);
 
         InventoryDeductResponse response = inventoryService.deduct(command);
 
@@ -154,7 +156,9 @@ class InventoryServiceTest {
             List.of(new Product(productId, hubId, quantity))
         );
         when(inventoryRepository.tryAcquireIdempotencyKey(idempotencyKey)).thenReturn(true);
-        when(inventoryRepository.deductAll(command.toInventoryDeductList())).thenReturn(0);
+        when(inventoryRepository.deductAll(
+            InventoryUpdatePlanner.planDeduct(command.products()))
+        ).thenReturn(0);
 
         ErrorCode errorCode = assertThrows(
             BusinessException.class, () -> inventoryService.deduct(command))
@@ -171,7 +175,9 @@ class InventoryServiceTest {
             List.of(new InventoryReplenishCommand.Product(productId, hubId, quantity))
         );
         when(inventoryRepository.tryAcquireIdempotencyKey(idempotencyKey)).thenReturn(true);
-        when(inventoryRepository.replenishAll(command.toInventoryReplenish())).thenReturn(1);
+        when(inventoryRepository.replenishAll(
+            InventoryUpdatePlanner.planReplenish(command.products()))
+        ).thenReturn(1);
 
         InventoryReplenishResponse response = inventoryService.replenish(command);
 
@@ -188,7 +194,9 @@ class InventoryServiceTest {
             List.of(new InventoryReplenishCommand.Product(productId, hubId, quantity))
         );
         when(inventoryRepository.tryAcquireIdempotencyKey(idempotencyKey)).thenReturn(true);
-        when(inventoryRepository.replenishAll(command.toInventoryReplenish())).thenReturn(0);
+        when(inventoryRepository.replenishAll(
+            InventoryUpdatePlanner.planReplenish(command.products()))
+        ).thenReturn(0);
 
         ErrorCode errorCode = assertThrows(
             BusinessException.class, () -> inventoryService.replenish(command))

--- a/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
@@ -118,4 +118,18 @@ class InventoryServiceTest {
         assertEquals(Process.SUCCESS, response.process());
         verify(inventoryRepository, times(1)).deductAll(anyList());
     }
+
+    @Test
+    @DisplayName("재고가 부족하다면 예외를 반환하고 재고를 차감하지 않는다")
+    void insufficientStock() {
+        int quantity = 10;
+        InventoryDeductCommand command = new InventoryDeductCommand(
+            idempotencyKey,
+            List.of(new Product(productId, hubId, quantity))
+        );
+        when(inventoryRepository.tryAcquireIdempotencyKey(idempotencyKey)).thenReturn(true);
+        when(inventoryRepository.deductAll(command.toInventoryDeductList())).thenReturn(0);
+
+        assertThrows(RuntimeException.class, () -> inventoryService.deduct(command));
+    }
 }

--- a/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
@@ -21,8 +21,8 @@ import com.klp.hub.inventory.domain.repository.InventoryRepository;
 import com.klp.hub.inventory.domain.repository.exception.UniqueConstraintException;
 import com.klp.hub.inventory.exception.InventoryErrorCode;
 import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse;
-import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse.Process;
 import com.klp.hub.inventory.presentation.dto.InventoryReplenishResponse;
+import com.klp.hub.inventory.presentation.dto.InventoryReplenishResponse.Status;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
 import java.util.List;
 import java.util.Optional;
@@ -125,7 +125,7 @@ class InventoryServiceTest {
 
         InventoryDeductResponse response = inventoryService.deduct(command);
 
-        assertEquals(Process.ALREADY_DEDUCTED, response.process());
+        assertEquals(InventoryDeductResponse.Status.ALREADY_DEDUCTED, response.status());
     }
 
     @Test
@@ -141,7 +141,7 @@ class InventoryServiceTest {
 
         InventoryDeductResponse response = inventoryService.deduct(command);
 
-        assertEquals(Process.SUCCESS, response.process());
+        assertEquals(InventoryDeductResponse.Status.SUCCESS, response.status());
         verify(inventoryRepository, times(1)).deductAll(anyList());
     }
 
@@ -175,7 +175,7 @@ class InventoryServiceTest {
 
         InventoryReplenishResponse response = inventoryService.replenish(command);
 
-        assertEquals(InventoryReplenishResponse.Process.SUCCESS, response.process());
+        assertEquals(Status.SUCCESS, response.status());
         verify(inventoryRepository, times(1)).replenishAll(anyList());
     }
 

--- a/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -16,6 +17,7 @@ import com.klp.hub.inventory.application.dto.InventoryDeductCommand;
 import com.klp.hub.inventory.application.dto.InventoryDeductCommand.Product;
 import com.klp.hub.inventory.domain.Inventory;
 import com.klp.hub.inventory.domain.repository.InventoryRepository;
+import com.klp.hub.inventory.domain.repository.exception.UniqueConstraintException;
 import com.klp.hub.inventory.exception.InventoryErrorCode;
 import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse;
 import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse.Process;
@@ -93,6 +95,19 @@ class InventoryServiceTest {
             () -> inventoryService.delete(inventoryId))
             .getErrorCode();
         assertEquals(InventoryErrorCode.NOT_FOUND_INVENTORY, errorCode);
+    }
+
+    @Test
+    @DisplayName("재고 생성시 이미 해당 상품과 허브에 재고가 존재한다면 예외가 발생한다")
+    void throwDuplicatedInventory() {
+        Integer quantity = 10;
+        when(inventoryRepository.save(any(Inventory.class)))
+            .thenThrow(UniqueConstraintException.class);
+
+        ErrorCode errorCode = assertThrows(BusinessException.class,
+            () -> inventoryService.create(productId, hubId, quantity))
+            .getErrorCode();
+        assertEquals(InventoryErrorCode.INVENTORY_ALREADY_EXISTS, errorCode);
     }
 
     @Test

--- a/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/application/InventoryServiceTest.java
@@ -15,12 +15,14 @@ import com.klp.common.exception.BusinessException;
 import com.klp.common.exception.ErrorCode;
 import com.klp.hub.inventory.application.dto.InventoryDeductCommand;
 import com.klp.hub.inventory.application.dto.InventoryDeductCommand.Product;
+import com.klp.hub.inventory.application.dto.InventoryReplenishCommand;
 import com.klp.hub.inventory.domain.Inventory;
 import com.klp.hub.inventory.domain.repository.InventoryRepository;
 import com.klp.hub.inventory.domain.repository.exception.UniqueConstraintException;
 import com.klp.hub.inventory.exception.InventoryErrorCode;
 import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse;
 import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse.Process;
+import com.klp.hub.inventory.presentation.dto.InventoryReplenishResponse;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
 import java.util.List;
 import java.util.Optional;
@@ -158,5 +160,39 @@ class InventoryServiceTest {
             BusinessException.class, () -> inventoryService.deduct(command))
             .getErrorCode();
         assertEquals(InventoryErrorCode.INSUFFICIENT_STOCK, errorCode);
+    }
+
+    @Test
+    @DisplayName("존재하는 재고에 대해서 재고 증가요청시 성공한다")
+    void replenish() {
+        int quantity = 5;
+        InventoryReplenishCommand command = new InventoryReplenishCommand(
+            idempotencyKey,
+            List.of(new InventoryReplenishCommand.Product(productId, hubId, quantity))
+        );
+        when(inventoryRepository.tryAcquireIdempotencyKey(idempotencyKey)).thenReturn(true);
+        when(inventoryRepository.replenishAll(command.toInventoryReplenish())).thenReturn(1);
+
+        InventoryReplenishResponse response = inventoryService.replenish(command);
+
+        assertEquals(InventoryReplenishResponse.Process.SUCCESS, response.process());
+        verify(inventoryRepository, times(1)).replenishAll(anyList());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 재고에 대한 재고 증가시 예외가 발생한다")
+    void replenishNonExistenceInventory() {
+        int quantity = 10;
+        InventoryReplenishCommand command = new InventoryReplenishCommand(
+            idempotencyKey,
+            List.of(new InventoryReplenishCommand.Product(productId, hubId, quantity))
+        );
+        when(inventoryRepository.tryAcquireIdempotencyKey(idempotencyKey)).thenReturn(true);
+        when(inventoryRepository.replenishAll(command.toInventoryReplenish())).thenReturn(0);
+
+        ErrorCode errorCode = assertThrows(
+            BusinessException.class, () -> inventoryService.replenish(command))
+            .getErrorCode();
+        assertEquals(InventoryErrorCode.NOT_FOUND_INVENTORY, errorCode);
     }
 }

--- a/hub/src/test/java/com/klp/hub/inventory/application/InventoryUpdatePlannerTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/application/InventoryUpdatePlannerTest.java
@@ -1,0 +1,55 @@
+package com.klp.hub.inventory.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import com.klp.hub.inventory.application.dto.InventoryDeductCommand;
+import com.klp.hub.inventory.application.dto.InventoryDeductCommand.Product;
+import com.klp.hub.inventory.domain.repository.dto.InventoryDeduct;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class InventoryUpdatePlannerTest {
+
+    private static final UUID P1 = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID P2 = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    private static final UUID H1 = UUID.fromString("10000000-0000-0000-0000-000000000001");
+    private static final UUID H2 = UUID.fromString("10000000-0000-0000-0000-000000000002");
+
+    @Nested
+    class Deduct {
+
+        @Test
+        @DisplayName("동일한 키는 합산되고 productId 와 hubId 순서로 오름차순 정렬된다")
+        void order() {
+            List<Product> products = List.of(
+                deductProduct(P2, H1, 1),
+                deductProduct(P1, H2, 1),
+                deductProduct(P1, H2, 1),
+                deductProduct(P1, H1, 1)
+            );
+
+            List<InventoryDeduct> deducts = InventoryUpdatePlanner.planDeduct(products);
+
+            assertThat(deducts)
+                .extracting(
+                    InventoryDeduct::productId,
+                    InventoryDeduct::hubId,
+                    InventoryDeduct::quantity
+                )
+                .containsExactly(
+                    tuple(P1, H1, 1),
+                    tuple(P1, H2, 2),
+                    tuple(P2, H1, 1)
+                );
+        }
+
+        private InventoryDeductCommand.Product deductProduct(UUID productId, UUID hubId,
+            int quantity) {
+            return new InventoryDeductCommand.Product(productId, hubId, quantity);
+        }
+    }
+}

--- a/hub/src/test/java/com/klp/hub/inventory/application/InventoryUpdatePlannerTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/application/InventoryUpdatePlannerTest.java
@@ -4,8 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
 import com.klp.hub.inventory.application.dto.InventoryDeductCommand;
-import com.klp.hub.inventory.application.dto.InventoryDeductCommand.Product;
+import com.klp.hub.inventory.application.dto.InventoryReplenishCommand;
 import com.klp.hub.inventory.domain.repository.dto.InventoryDeduct;
+import com.klp.hub.inventory.domain.repository.dto.InventoryReplenish;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -25,7 +26,7 @@ class InventoryUpdatePlannerTest {
         @Test
         @DisplayName("동일한 키는 합산되고 productId 와 hubId 순서로 오름차순 정렬된다")
         void order() {
-            List<Product> products = List.of(
+            List<InventoryDeductCommand.Product> products = List.of(
                 deductProduct(P2, H1, 1),
                 deductProduct(P1, H2, 1),
                 deductProduct(P1, H2, 1),
@@ -47,9 +48,49 @@ class InventoryUpdatePlannerTest {
                 );
         }
 
-        private InventoryDeductCommand.Product deductProduct(UUID productId, UUID hubId,
-            int quantity) {
+        private InventoryDeductCommand.Product deductProduct(
+            UUID productId,
+            UUID hubId,
+            int quantity
+        ) {
             return new InventoryDeductCommand.Product(productId, hubId, quantity);
+        }
+    }
+
+    @Nested
+    class Replenish {
+
+        @Test
+        @DisplayName("동일한 키는 합산되고 productId 와 hubId 순서로 오름차순 정렬된다")
+        void order() {
+            List<InventoryReplenishCommand.Product> products = List.of(
+                replenishProduct(P2, H1, 1),
+                replenishProduct(P1, H2, 1),
+                replenishProduct(P1, H2, 1),
+                replenishProduct(P1, H1, 1)
+            );
+
+            List<InventoryReplenish> replenishes = InventoryUpdatePlanner.planReplenish(products);
+
+            assertThat(replenishes)
+                .extracting(
+                    InventoryReplenish::productId,
+                    InventoryReplenish::hubId,
+                    InventoryReplenish::quantity
+                )
+                .containsExactly(
+                    tuple(P1, H1, 1),
+                    tuple(P1, H2, 2),
+                    tuple(P2, H1, 1)
+                );
+        }
+
+        private InventoryReplenishCommand.Product replenishProduct(
+            UUID productId,
+            UUID hubId,
+            int quantity
+        ) {
+            return new InventoryReplenishCommand.Product(productId, hubId, quantity);
         }
     }
 }

--- a/hub/src/test/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryTest.java
@@ -1,10 +1,16 @@
 package com.klp.hub.inventory.infrastructure.repository;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.klp.hub.TestJpaConfig;
 import com.klp.hub.inventory.domain.Inventory;
 import com.klp.hub.inventory.domain.repository.InventoryRepository;
 import com.klp.hub.inventory.domain.repository.exception.UniqueConstraintException;
 import jakarta.persistence.EntityManager;
+import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,16 +18,11 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
-import java.util.Optional;
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.*;
-
 @DataJpaTest
 @ActiveProfiles("test")
 @Import({
-        InventoryRepositoryImpl.class,
-        TestJpaConfig.class
+    InventoryRepositoryImpl.class,
+    TestJpaConfig.class
 })
 class InventoryRepositoryTest {
 
@@ -67,5 +68,27 @@ class InventoryRepositoryTest {
         assertThrows(UniqueConstraintException.class, () -> {
             inventoryRepository.save(duplicatedInventory);
         });
+    }
+
+    @Test
+    @DisplayName("같은 멱등키를 또 생성시도할때 false 를 반환한다")
+    void throwDuplicateIdempotencyKey() {
+        String idempotencyKeyA = "idempotencyKey";
+        inventoryRepository.tryAcquireIdempotencyKey(idempotencyKeyA);
+        String duplicateIdempotencyKey = "idempotencyKey";
+
+        boolean result = inventoryRepository.tryAcquireIdempotencyKey(duplicateIdempotencyKey);
+
+        assertFalse(result);
+    }
+
+    @Test
+    @DisplayName("처음 멱등키를 생성을 시도한다면 true 를 반환한다")
+    void createIdempotencyKey() {
+        String idempotencyKey = "idempotencyKey";
+
+        boolean result = inventoryRepository.tryAcquireIdempotencyKey(idempotencyKey);
+
+        assertTrue(result);
     }
 }

--- a/hub/src/test/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryTest.java
@@ -9,6 +9,7 @@ import com.klp.hub.TestJpaConfig;
 import com.klp.hub.inventory.domain.Inventory;
 import com.klp.hub.inventory.domain.repository.InventoryRepository;
 import com.klp.hub.inventory.domain.repository.dto.InventoryDeduct;
+import com.klp.hub.inventory.domain.repository.dto.InventoryReplenish;
 import com.klp.hub.inventory.domain.repository.exception.UniqueConstraintException;
 import jakarta.persistence.EntityManager;
 import java.util.List;
@@ -114,6 +115,41 @@ class InventoryRepositoryTest {
     }
 
     @Test
+    @DisplayName("재고가 없는 상품에 대해서 재고 차감시 재고는 차감되지 않는다")
+    void deductNonExistentInventory() {
+        int addQuantity = 10;
+        List<InventoryDeduct> inventoryDeducts = List.of(
+            new InventoryDeduct(productId, hubId, addQuantity)
+        );
+
+        int updated = inventoryRepository.deductAll(inventoryDeducts);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertEquals(0, updated);
+    }
+
+    @Test
+    @DisplayName("서로 다른 재고에 대한 차감시 특정 재고가 존재하지 않는다면 해당 재고는 차감에 실패한다")
+    void deductAllNonExistentInventory() {
+        UUID nonExistentProductId = UUID.randomUUID();
+        UUID nonExistentHubId = UUID.randomUUID();
+        UUID productIdB = UUID.randomUUID();
+        UUID hubIdB = UUID.randomUUID();
+        inventoryRepository.save(new Inventory(productIdB, hubIdB, 20));
+        List<InventoryDeduct> inventoryDeducts = List.of(
+            new InventoryDeduct(nonExistentProductId, nonExistentHubId, 10),
+            new InventoryDeduct(productIdB, hubIdB, 20)
+        );
+
+        int updated = inventoryRepository.deductAll(inventoryDeducts);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertEquals(1, updated);
+    }
+
+    @Test
     @DisplayName("재고가 충분하지 않다면 재고는 차감되지 않는다")
     void insufficientStock() {
         int quantity = 10;
@@ -179,5 +215,84 @@ class InventoryRepositoryTest {
         assertEquals(1, updated);
         assertEquals(0, inventoryA.getQuantity());
         assertEquals(20, inventoryB.getQuantity());
+    }
+
+    @Test
+    @DisplayName("재고가 있는 상품의 재고를 증가시킨다")
+    void replenish() {
+        int quantity = 10;
+        int addQuantity = 10;
+        inventoryRepository.save(new Inventory(productId, hubId, quantity));
+        List<InventoryReplenish> inventoryReplenishes = List.of(
+            new InventoryReplenish(productId, hubId, addQuantity)
+        );
+
+        int updated = inventoryRepository.replenishAll(inventoryReplenishes);
+        entityManager.flush();
+        entityManager.clear();
+        Inventory inventory = inventoryRepository.findByProductId(productId).orElseThrow();
+
+        assertEquals(1, updated);
+        assertEquals(quantity + addQuantity, inventory.getQuantity());
+    }
+
+    @Test
+    @DisplayName("서로 다른 재고에 대한 증가시 모두 성공한다")
+    void addAll() {
+        UUID productIdA = UUID.randomUUID();
+        UUID hubIdA = UUID.randomUUID();
+        UUID productIdB = UUID.randomUUID();
+        UUID hubIdB = UUID.randomUUID();
+        inventoryRepository.save(new Inventory(productIdA, hubIdA, 10));
+        inventoryRepository.save(new Inventory(productIdB, hubIdB, 20));
+        List<InventoryReplenish> inventoryReplenishes = List.of(
+            new InventoryReplenish(productIdA, hubIdA, 10),
+            new InventoryReplenish(productIdB, hubIdB, 20)
+        );
+
+        int updated = inventoryRepository.replenishAll(inventoryReplenishes);
+        entityManager.flush();
+        entityManager.clear();
+        Inventory inventoryA = inventoryRepository.findByProductId(productIdA).orElseThrow();
+        Inventory inventoryB = inventoryRepository.findByProductId(productIdB).orElseThrow();
+
+        assertEquals(2, updated);
+        assertEquals(20, inventoryA.getQuantity());
+        assertEquals(40, inventoryB.getQuantity());
+    }
+
+    @Test
+    @DisplayName("재고가 없는 상품에 대해서 재고 증가시 재고는 증가되지 않는다")
+    void replenishNonExistentInventory() {
+        int addQuantity = 10;
+        List<InventoryReplenish> inventoryReplenishes = List.of(
+            new InventoryReplenish(productId, hubId, addQuantity)
+        );
+
+        int updated = inventoryRepository.replenishAll(inventoryReplenishes);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertEquals(0, updated);
+    }
+
+    @Test
+    @DisplayName("서로 다른 재고에 대한 증가시 특정 재고가 존재하지 않는다면 해당 재고는 증가에 실패한다")
+    void replenishAllNonExistentInventory() {
+        UUID nonExistentProductId = UUID.randomUUID();
+        UUID nonExistentHubId = UUID.randomUUID();
+        UUID productIdB = UUID.randomUUID();
+        UUID hubIdB = UUID.randomUUID();
+        inventoryRepository.save(new Inventory(productIdB, hubIdB, 20));
+        List<InventoryReplenish> inventoryReplenishes = List.of(
+            new InventoryReplenish(nonExistentProductId, nonExistentHubId, 10),
+            new InventoryReplenish(productIdB, hubIdB, 20)
+        );
+
+        int updated = inventoryRepository.replenishAll(inventoryReplenishes);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertEquals(1, updated);
     }
 }

--- a/hub/src/test/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.klp.hub.inventory.infrastructure.repository;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -7,8 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.klp.hub.TestJpaConfig;
 import com.klp.hub.inventory.domain.Inventory;
 import com.klp.hub.inventory.domain.repository.InventoryRepository;
+import com.klp.hub.inventory.domain.repository.dto.InventoryDeduct;
 import com.klp.hub.inventory.domain.repository.exception.UniqueConstraintException;
 import jakarta.persistence.EntityManager;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
@@ -58,7 +61,7 @@ class InventoryRepositoryTest {
     }
 
     @Test
-    @DisplayName("같은 상품과 허브 조홥으로 재고를 생성하려면 예외가 발생한다")
+    @DisplayName("같은 상품과 허브 조합으로 재고를 생성하려면 예외가 발생한다")
     void throwDuplicateInventoryHub() {
         Inventory inventoryA = new Inventory(productId, hubId, 10);
         inventoryRepository.save(inventoryA);
@@ -90,5 +93,91 @@ class InventoryRepositoryTest {
         boolean result = inventoryRepository.tryAcquireIdempotencyKey(idempotencyKey);
 
         assertTrue(result);
+    }
+
+    @Test
+    @DisplayName("재고가 충분하다면 재고를 차감한다")
+    void deduct() {
+        int quantity = 10;
+        inventoryRepository.save(new Inventory(productId, hubId, quantity));
+        List<InventoryDeduct> inventoryDeducts = List.of(
+            new InventoryDeduct(productId, hubId, quantity)
+        );
+
+        int updated = inventoryRepository.deductAll(inventoryDeducts);
+        entityManager.flush();
+        entityManager.clear();
+        Inventory inventory = inventoryRepository.findByProductId(productId).orElseThrow();
+
+        assertEquals(1, updated);
+        assertEquals(0, inventory.getQuantity());
+    }
+
+    @Test
+    @DisplayName("재고가 충분하지 않다면 재고는 차감되지 않는다")
+    void insufficientStock() {
+        int quantity = 10;
+        inventoryRepository.save(new Inventory(productId, hubId, quantity));
+        List<InventoryDeduct> insufficientDeducts = List.of(
+            new InventoryDeduct(productId, hubId, 11)
+        );
+
+        int updated = inventoryRepository.deductAll(insufficientDeducts);
+        entityManager.flush();
+        entityManager.clear();
+        Inventory inventory = inventoryRepository.findByProductId(productId).orElseThrow();
+
+        assertEquals(0, updated);
+        assertEquals(10, inventory.getQuantity());
+    }
+
+    @Test
+    @DisplayName("서로 다른 재고에 대한 요청시 재고가 충분하다면 모두 성공한다")
+    void deductAll() {
+        UUID productIdA = UUID.randomUUID();
+        UUID hubIdA = UUID.randomUUID();
+        UUID productIdB = UUID.randomUUID();
+        UUID hubIdB = UUID.randomUUID();
+        inventoryRepository.save(new Inventory(productIdA, hubIdA, 10));
+        inventoryRepository.save(new Inventory(productIdB, hubIdB, 20));
+        List<InventoryDeduct> inventoryDeducts = List.of(
+            new InventoryDeduct(productIdA, hubIdA, 10),
+            new InventoryDeduct(productIdB, hubIdB, 20)
+        );
+
+        int updated = inventoryRepository.deductAll(inventoryDeducts);
+        entityManager.flush();
+        entityManager.clear();
+        Inventory inventoryA = inventoryRepository.findByProductId(productIdA).orElseThrow();
+        Inventory inventoryB = inventoryRepository.findByProductId(productIdB).orElseThrow();
+
+        assertEquals(2, updated);
+        assertEquals(0, inventoryA.getQuantity());
+        assertEquals(0, inventoryB.getQuantity());
+    }
+
+    @Test
+    @DisplayName("서로 다른 재고에 대한 요청시 일부 재고가 부족하다면 해당 재고는 차감에 실패한다")
+    void deductPartialFail() {
+        UUID productIdA = UUID.randomUUID();
+        UUID hubIdA = UUID.randomUUID();
+        UUID productIdB = UUID.randomUUID();
+        UUID hubIdB = UUID.randomUUID();
+        inventoryRepository.save(new Inventory(productIdA, hubIdA, 10));
+        inventoryRepository.save(new Inventory(productIdB, hubIdB, 20));
+        List<InventoryDeduct> inventoryDeducts = List.of(
+            new InventoryDeduct(productIdA, hubIdA, 10),
+            new InventoryDeduct(productIdB, hubIdB, 21) // 1개 더 차감
+        );
+
+        int updated = inventoryRepository.deductAll(inventoryDeducts);
+        entityManager.flush();
+        entityManager.clear();
+        Inventory inventoryA = inventoryRepository.findByProductId(productIdA).orElseThrow();
+        Inventory inventoryB = inventoryRepository.findByProductId(productIdB).orElseThrow();
+
+        assertEquals(1, updated);
+        assertEquals(0, inventoryA.getQuantity());
+        assertEquals(20, inventoryB.getQuantity());
     }
 }

--- a/hub/src/test/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryTest.java
@@ -132,7 +132,7 @@ class InventoryRepositoryTest {
     }
 
     @Test
-    @DisplayName("서로 다른 재고에 대한 요청시 재고가 충분하다면 모두 성공한다")
+    @DisplayName("서로 다른 재고에 대한 차감시 재고가 충분하다면 모두 차감된다")
     void deductAll() {
         UUID productIdA = UUID.randomUUID();
         UUID hubIdA = UUID.randomUUID();
@@ -157,7 +157,7 @@ class InventoryRepositoryTest {
     }
 
     @Test
-    @DisplayName("서로 다른 재고에 대한 요청시 일부 재고가 부족하다면 해당 재고는 차감에 실패한다")
+    @DisplayName("서로 다른 재고에 대한 차감시 일부 재고가 부족하다면 해당 재고는 차감에 실패한다")
     void deductPartialFail() {
         UUID productIdA = UUID.randomUUID();
         UUID hubIdA = UUID.randomUUID();

--- a/hub/src/test/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/infrastructure/repository/InventoryRepositoryTest.java
@@ -283,7 +283,7 @@ class InventoryRepositoryTest {
         UUID nonExistentHubId = UUID.randomUUID();
         UUID productIdB = UUID.randomUUID();
         UUID hubIdB = UUID.randomUUID();
-        inventoryRepository.save(new Inventory(productIdB, hubIdB, 20));
+        Inventory savedInventory = inventoryRepository.save(new Inventory(productIdB, hubIdB, 20));
         List<InventoryReplenish> inventoryReplenishes = List.of(
             new InventoryReplenish(nonExistentProductId, nonExistentHubId, 10),
             new InventoryReplenish(productIdB, hubIdB, 20)
@@ -294,5 +294,6 @@ class InventoryRepositoryTest {
         entityManager.clear();
 
         assertEquals(1, updated);
+        assertEquals(20, savedInventory.getQuantity());
     }
 }

--- a/hub/src/test/java/com/klp/hub/inventory/presentation/controller/InventoryControllerTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/presentation/controller/InventoryControllerTest.java
@@ -16,6 +16,8 @@ import com.klp.hub.inventory.presentation.dto.InventoryDeductRequest;
 import com.klp.hub.inventory.presentation.dto.InventoryDeductRequest.Product;
 import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse;
 import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse.Status;
+import com.klp.hub.inventory.presentation.dto.InventoryReplenishRequest;
+import com.klp.hub.inventory.presentation.dto.InventoryReplenishResponse;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
 import java.util.List;
 import java.util.UUID;
@@ -60,7 +62,7 @@ class InventoryControllerTest {
     }
 
     @Test
-    @DisplayName("재고를 차감할 수 있다")
+    @DisplayName("재고를 차감시킬 수 있다")
     void deduct() throws Exception {
         UUID productId = UUID.randomUUID();
         UUID hubId = UUID.randomUUID();
@@ -74,6 +76,28 @@ class InventoryControllerTest {
             .thenReturn(new InventoryDeductResponse(Status.SUCCESS));
 
         mockMvc.perform(post("/v1/inventories/deduct")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.status").isString());
+    }
+
+    @Test
+    @DisplayName("재고를 증가시킬 수 있다")
+    void replenish() throws Exception {
+        UUID productId = UUID.randomUUID();
+        UUID hubId = UUID.randomUUID();
+        Integer quantity = 10;
+        String idempotencyKey = "idempotencyKey";
+        InventoryReplenishRequest request = new InventoryReplenishRequest(
+            idempotencyKey,
+            List.of(new InventoryReplenishRequest.Product(productId, hubId, quantity))
+        );
+        when(inventoryService.replenish(request.toCommand()))
+            .thenReturn(new InventoryReplenishResponse(InventoryReplenishResponse.Status.SUCCESS));
+
+        mockMvc.perform(post("/v1/inventories/replenish")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isOk())

--- a/hub/src/test/java/com/klp/hub/inventory/presentation/controller/InventoryControllerTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/presentation/controller/InventoryControllerTest.java
@@ -22,6 +22,7 @@ import com.klp.hub.inventory.presentation.dto.InventoryResponse;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -43,65 +44,220 @@ class InventoryControllerTest {
     @MockitoBean
     private InventoryService inventoryService;
 
-    @Test
-    @DisplayName("단일 상품에 대한 재고를 조회할 수 있다")
-    void getInventoryByProductId() throws Exception {
-        UUID productId = UUID.randomUUID();
-        UUID inventoryId = UUID.randomUUID();
-        UUID hubId = UUID.randomUUID();
-        when(inventoryService.getByProductId(productId))
-            .thenReturn(new InventoryResponse(productId, inventoryId, hubId, 10));
+    @Nested
+    class GetInventory {
 
-        mockMvc.perform(get("/v1/inventories/{productId}", productId))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$.productId").isString())
-            .andExpect(jsonPath("$.inventoryId").isString())
-            .andExpect(jsonPath("$.hubId").isString())
-            .andExpect(jsonPath("$.quantity").isNumber());
+        @Test
+        @DisplayName("단일 상품에 대한 재고를 조회할 수 있다")
+        void getInventoryByProductId() throws Exception {
+            UUID productId = UUID.randomUUID();
+            UUID inventoryId = UUID.randomUUID();
+            UUID hubId = UUID.randomUUID();
+            when(inventoryService.getByProductId(productId))
+                .thenReturn(new InventoryResponse(productId, inventoryId, hubId, 10));
+
+            mockMvc.perform(get("/v1/inventories/{productId}", productId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.productId").isString())
+                .andExpect(jsonPath("$.inventoryId").isString())
+                .andExpect(jsonPath("$.hubId").isString())
+                .andExpect(jsonPath("$.quantity").isNumber());
+        }
     }
 
-    @Test
-    @DisplayName("재고를 차감시킬 수 있다")
-    void deduct() throws Exception {
-        UUID productId = UUID.randomUUID();
-        UUID hubId = UUID.randomUUID();
-        Integer quantity = 10;
-        String idempotencyKey = "idempotencyKey";
-        InventoryDeductRequest request = new InventoryDeductRequest(
-            idempotencyKey,
-            List.of(new Product(productId, hubId, quantity))
-        );
-        when(inventoryService.deduct(request.toCommand()))
-            .thenReturn(new InventoryDeductResponse(Status.SUCCESS));
+    @Nested
+    class Deduct {
 
-        mockMvc.perform(post("/v1/inventories/deduct")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$.status").isString());
+        @Test
+        @DisplayName("재고를 차감시킬 수 있다")
+        void deduct() throws Exception {
+            UUID productId = UUID.randomUUID();
+            UUID hubId = UUID.randomUUID();
+            Integer quantity = 10;
+            String idempotencyKey = "idempotencyKey";
+            InventoryDeductRequest request = new InventoryDeductRequest(
+                idempotencyKey,
+                List.of(new Product(productId, hubId, quantity))
+            );
+            when(inventoryService.deduct(request.toCommand()))
+                .thenReturn(new InventoryDeductResponse(Status.SUCCESS));
+
+            mockMvc.perform(post("/v1/inventories/deduct")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").isString());
+        }
+
+        @Test
+        @DisplayName("멱등키가 누락되면 400 Bad Request 를 반환한다")
+        void missingIdempotencyKey() throws Exception {
+            InventoryDeductRequest request = new InventoryDeductRequest(
+                " ",
+                List.of(new Product(UUID.randomUUID(), UUID.randomUUID(), 10))
+            );
+
+            mockMvc.perform(post("/v1/inventories/deduct")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("상품 수량이 1 미만이면 400 Bad Request 를 반환한다")
+        void invalidQuantity() throws Exception {
+            InventoryDeductRequest request = new InventoryDeductRequest(
+                "idempotencyKey",
+                List.of(new Product(UUID.randomUUID(), UUID.randomUUID(), 0))
+            );
+
+            mockMvc.perform(post("/v1/inventories/deduct")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("상품 목록이 비어있으면 400 Bad Request 를 반환한다")
+        void emptyProducts() throws Exception {
+            InventoryDeductRequest request = new InventoryDeductRequest(
+                "idempotencyKey",
+                List.of()
+            );
+
+            mockMvc.perform(post("/v1/inventories/deduct")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("상품 ID 가 누락되면 400 Bad Request 를 반환한다")
+        void missingProductId() throws Exception {
+            InventoryDeductRequest request = new InventoryDeductRequest(
+                "idempotencyKey",
+                List.of(new Product(null, UUID.randomUUID(), 0))
+            );
+
+            mockMvc.perform(post("/v1/inventories/deduct")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("허브 ID 가 누락되면 400 Bad Request 를 반환한다")
+        void missingHubId() throws Exception {
+            InventoryDeductRequest request = new InventoryDeductRequest(
+                "idempotencyKey",
+                List.of(new Product(UUID.randomUUID(), null, 0))
+            );
+
+            mockMvc.perform(post("/v1/inventories/deduct")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+        }
     }
 
-    @Test
-    @DisplayName("재고를 증가시킬 수 있다")
-    void replenish() throws Exception {
-        UUID productId = UUID.randomUUID();
-        UUID hubId = UUID.randomUUID();
-        Integer quantity = 10;
-        String idempotencyKey = "idempotencyKey";
-        InventoryReplenishRequest request = new InventoryReplenishRequest(
-            idempotencyKey,
-            List.of(new InventoryReplenishRequest.Product(productId, hubId, quantity))
-        );
-        when(inventoryService.replenish(request.toCommand()))
-            .thenReturn(new InventoryReplenishResponse(InventoryReplenishResponse.Status.SUCCESS));
+    @Nested
+    class Replenish {
 
-        mockMvc.perform(post("/v1/inventories/replenish")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$.status").isString());
+        @Test
+        @DisplayName("재고를 증가시킬 수 있다")
+        void replenish() throws Exception {
+            UUID productId = UUID.randomUUID();
+            UUID hubId = UUID.randomUUID();
+            Integer quantity = 10;
+            String idempotencyKey = "idempotencyKey";
+            InventoryReplenishRequest request = new InventoryReplenishRequest(
+                idempotencyKey,
+                List.of(new InventoryReplenishRequest.Product(productId, hubId, quantity))
+            );
+            when(inventoryService.replenish(request.toCommand()))
+                .thenReturn(
+                    new InventoryReplenishResponse(InventoryReplenishResponse.Status.SUCCESS));
+
+            mockMvc.perform(post("/v1/inventories/replenish")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").isString());
+        }
+
+        @Test
+        @DisplayName("멱등키가 누락되면 400 Bad Request 를 반환한다")
+        void missingIdempotencyKey() throws Exception {
+            InventoryReplenishRequest request = new InventoryReplenishRequest(
+                " ",
+                List.of(
+                    new InventoryReplenishRequest.Product(UUID.randomUUID(), UUID.randomUUID(), 10))
+            );
+
+            mockMvc.perform(post("/v1/inventories/replenish")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("상품 수량이 1 미만이면 400 Bad Request 를 반환한다")
+        void invalidQuantity() throws Exception {
+            InventoryReplenishRequest request = new InventoryReplenishRequest(
+                "idempotencyKey",
+                List.of(
+                    new InventoryReplenishRequest.Product(UUID.randomUUID(), UUID.randomUUID(), 0))
+            );
+
+            mockMvc.perform(post("/v1/inventories/replenish")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("상품 목록이 비어있으면 400 Bad Request 를 반환한다")
+        void emptyProducts() throws Exception {
+            InventoryReplenishRequest request = new InventoryReplenishRequest(
+                "idempotencyKey",
+                List.of()
+            );
+
+            mockMvc.perform(post("/v1/inventories/replenish")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("상품 ID 가 누락되면 400 Bad Request 를 반환한다")
+        void missingProductId() throws Exception {
+            InventoryReplenishRequest request = new InventoryReplenishRequest(
+                "idempotencyKey",
+                List.of(new InventoryReplenishRequest.Product(null, UUID.randomUUID(), 0))
+            );
+
+            mockMvc.perform(post("/v1/inventories/replenish")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("허브 ID 가 누락되면 400 Bad Request 를 반환한다")
+        void missingHubId() throws Exception {
+            InventoryReplenishRequest request = new InventoryReplenishRequest(
+                "idempotencyKey",
+                List.of(new InventoryReplenishRequest.Product(UUID.randomUUID(), null, 0))
+            );
+
+            mockMvc.perform(post("/v1/inventories/replenish")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+        }
     }
 }

--- a/hub/src/test/java/com/klp/hub/inventory/presentation/controller/InventoryControllerTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/presentation/controller/InventoryControllerTest.java
@@ -8,9 +8,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.klp.common.exception.GlobalExceptionHandler;
-import com.klp.common.security.config.SecurityConfig;
-import com.klp.common.security.filter.AuthorizationFilter;
+import com.klp.hub.global.config.SecurityConfig;
+import com.klp.hub.global.exception.GlobalExceptionHandler;
+import com.klp.hub.global.filter.AuthorizationFilter;
 import com.klp.hub.inventory.application.InventoryService;
 import com.klp.hub.inventory.presentation.dto.InventoryDeductRequest;
 import com.klp.hub.inventory.presentation.dto.InventoryDeductRequest.Product;

--- a/hub/src/test/java/com/klp/hub/inventory/presentation/controller/InventoryControllerTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/presentation/controller/InventoryControllerTest.java
@@ -1,7 +1,14 @@
 package com.klp.hub.inventory.presentation.controller;
 
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.klp.hub.inventory.application.InventoryService;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,12 +16,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.UUID;
-
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(InventoryController.class)
 class InventoryControllerTest {
@@ -30,13 +31,16 @@ class InventoryControllerTest {
     void getInventoryByProductId() throws Exception {
         UUID productId = UUID.randomUUID();
         UUID inventoryId = UUID.randomUUID();
+        UUID hubId = UUID.randomUUID();
         when(inventoryService.getByProductId(productId))
-                .thenReturn(new InventoryResponse(productId, inventoryId, 10));
+            .thenReturn(new InventoryResponse(productId, inventoryId, hubId, 10));
 
         mockMvc.perform(get("/v1/inventories/{productId}", productId))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.productId").isString())
-                .andExpect(jsonPath("$.quantity").isNumber());
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.productId").isString())
+            .andExpect(jsonPath("$.inventoryId").isString())
+            .andExpect(jsonPath("$.hubId").isString())
+            .andExpect(jsonPath("$.quantity").isNumber());
     }
 }

--- a/hub/src/test/java/com/klp/hub/inventory/presentation/controller/InventoryControllerTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/presentation/controller/InventoryControllerTest.java
@@ -6,6 +6,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.klp.common.exception.GlobalExceptionHandler;
+import com.klp.common.security.config.SecurityConfig;
+import com.klp.common.security.filter.AuthorizationFilter;
 import com.klp.hub.inventory.application.InventoryService;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
 import java.util.UUID;
@@ -13,11 +16,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(InventoryController.class)
+@Import({SecurityConfig.class, AuthorizationFilter.class, GlobalExceptionHandler.class})
 class InventoryControllerTest {
 
     @Autowired

--- a/hub/src/test/java/com/klp/hub/inventory/presentation/controller/InventoryControllerTest.java
+++ b/hub/src/test/java/com/klp/hub/inventory/presentation/controller/InventoryControllerTest.java
@@ -2,15 +2,22 @@ package com.klp.hub.inventory.presentation.controller;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.klp.common.exception.GlobalExceptionHandler;
 import com.klp.common.security.config.SecurityConfig;
 import com.klp.common.security.filter.AuthorizationFilter;
 import com.klp.hub.inventory.application.InventoryService;
+import com.klp.hub.inventory.presentation.dto.InventoryDeductRequest;
+import com.klp.hub.inventory.presentation.dto.InventoryDeductRequest.Product;
+import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse;
+import com.klp.hub.inventory.presentation.dto.InventoryDeductResponse.Status;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,6 +34,9 @@ class InventoryControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @MockitoBean
     private InventoryService inventoryService;
@@ -47,5 +57,27 @@ class InventoryControllerTest {
             .andExpect(jsonPath("$.inventoryId").isString())
             .andExpect(jsonPath("$.hubId").isString())
             .andExpect(jsonPath("$.quantity").isNumber());
+    }
+
+    @Test
+    @DisplayName("재고를 차감할 수 있다")
+    void deduct() throws Exception {
+        UUID productId = UUID.randomUUID();
+        UUID hubId = UUID.randomUUID();
+        Integer quantity = 10;
+        String idempotencyKey = "idempotencyKey";
+        InventoryDeductRequest request = new InventoryDeductRequest(
+            idempotencyKey,
+            List.of(new Product(productId, hubId, quantity))
+        );
+        when(inventoryService.deduct(request.toCommand()))
+            .thenReturn(new InventoryDeductResponse(Status.SUCCESS));
+
+        mockMvc.perform(post("/v1/inventories/deduct")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.status").isString());
     }
 }

--- a/hub/src/test/java/com/klp/hub/product/application/ProductServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/product/application/ProductServiceTest.java
@@ -59,6 +59,7 @@ class ProductServiceTest {
         Product product = mock(Product.class);
         CompanyResponse companyResponse = new CompanyResponse(
             companyId,
+            hubId,
             CompanyType.SUPPLIER.name(),
             "업체명",
             "업체주소"
@@ -131,7 +132,7 @@ class ProductServiceTest {
         Product product = mock(Product.class);
         CompanyResponse companyResponse = mock(CompanyResponse.class);
         when(companyService.getByCompanyId(companyId)).thenReturn(companyResponse);
-        when(companyResponse.id()).thenReturn(companyId);
+        when(companyResponse.companyId()).thenReturn(companyId);
         when(productRepository.save(any(Product.class))).thenReturn(product);
         when(product.getId()).thenReturn(productId);
 
@@ -167,7 +168,7 @@ class ProductServiceTest {
         Product product = mock(Product.class);
         CompanyResponse companyResponse = mock(CompanyResponse.class);
         when(companyService.getByCompanyId(companyId)).thenReturn(companyResponse);
-        when(companyResponse.id()).thenReturn(companyId);
+        when(companyResponse.companyId()).thenReturn(companyId);
         when(productRepository.save(any(Product.class))).thenReturn(product);
         when(product.getId()).thenReturn(productId);
         when(inventoryService.create(productId, command.hubId(), quantity)).thenThrow(

--- a/hub/src/test/java/com/klp/hub/product/application/ProductServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/product/application/ProductServiceTest.java
@@ -10,16 +10,18 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.klp.common.exception.BusinessException;
+import com.klp.common.exception.ErrorCode;
 import com.klp.hub.company.application.CompanyService;
 import com.klp.hub.company.domain.CompanyType;
 import com.klp.hub.company.presentation.dto.CompanyResponse;
 import com.klp.hub.inventory.application.InventoryService;
-import com.klp.hub.inventory.domain.repository.exception.UniqueConstraintException;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
 import com.klp.hub.product.application.dto.ProductCreateCommand;
 import com.klp.hub.product.application.dto.ProductUpdateCommand;
 import com.klp.hub.product.domain.Product;
 import com.klp.hub.product.domain.repository.ProductRepository;
+import com.klp.hub.product.exception.ProductErrorCode;
 import com.klp.hub.product.presentation.dto.ProductResponse;
 import java.util.Optional;
 import java.util.UUID;
@@ -90,7 +92,10 @@ class ProductServiceTest {
     void throwGetProductById() {
         when(productRepository.findById(productId)).thenReturn(Optional.empty());
 
-        assertThrows(RuntimeException.class, () -> productService.getProductById(productId));
+        ErrorCode errorCode = assertThrows(BusinessException.class,
+            () -> productService.getProductById(productId))
+            .getErrorCode();
+        assertEquals(ProductErrorCode.NOT_FOUND_PRODUCT, errorCode);
     }
 
     @Test
@@ -116,7 +121,10 @@ class ProductServiceTest {
     void throwDeleteByNullProduct() {
         when(productRepository.findById(productId)).thenReturn(Optional.empty());
 
-        assertThrows(RuntimeException.class, () -> productService.delete(productId));
+        ErrorCode errorCode = assertThrows(BusinessException.class,
+            () -> productService.delete(productId))
+            .getErrorCode();
+        assertEquals(ProductErrorCode.NOT_FOUND_PRODUCT, errorCode);
     }
 
     @Test
@@ -139,42 +147,6 @@ class ProductServiceTest {
         productService.create(command);
 
         verify(inventoryService, times(1)).create(productId, hubId, quantity);
-    }
-
-    @Test
-    @DisplayName("상품 생성시 업체가 존재하지 않는다면 예외가 발생한다")
-    void throwNullCompany() {
-        ProductCreateCommand command = new ProductCreateCommand(
-            companyId,
-            hubId,
-            "상품명",
-            10
-        );
-        when(companyService.getByCompanyId(companyId)).thenThrow(RuntimeException.class);
-
-        assertThrows(RuntimeException.class, () -> productService.create(command));
-    }
-
-    @Test
-    @DisplayName("상품 생성시 이미 해당 상품의 재고가 존재하면 예외가 발생한다")
-    void throwDuplicatedInventory() {
-        Integer quantity = 10;
-        ProductCreateCommand command = new ProductCreateCommand(
-            companyId,
-            hubId,
-            "상품명",
-            quantity
-        );
-        Product product = mock(Product.class);
-        CompanyResponse companyResponse = mock(CompanyResponse.class);
-        when(companyService.getByCompanyId(companyId)).thenReturn(companyResponse);
-        when(companyResponse.companyId()).thenReturn(companyId);
-        when(productRepository.save(any(Product.class))).thenReturn(product);
-        when(product.getId()).thenReturn(productId);
-        when(inventoryService.create(productId, command.hubId(), quantity)).thenThrow(
-            UniqueConstraintException.class);
-
-        assertThrows(RuntimeException.class, () -> productService.create(command));
     }
 
     @Test

--- a/hub/src/test/java/com/klp/hub/product/application/ProductServiceTest.java
+++ b/hub/src/test/java/com/klp/hub/product/application/ProductServiceTest.java
@@ -1,5 +1,15 @@
 package com.klp.hub.product.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.klp.hub.company.application.CompanyService;
 import com.klp.hub.company.domain.CompanyType;
 import com.klp.hub.company.presentation.dto.CompanyResponse;
@@ -7,25 +17,18 @@ import com.klp.hub.inventory.application.InventoryService;
 import com.klp.hub.inventory.domain.repository.exception.UniqueConstraintException;
 import com.klp.hub.inventory.presentation.dto.InventoryResponse;
 import com.klp.hub.product.application.dto.ProductCreateCommand;
+import com.klp.hub.product.application.dto.ProductUpdateCommand;
 import com.klp.hub.product.domain.Product;
 import com.klp.hub.product.domain.repository.ProductRepository;
 import com.klp.hub.product.presentation.dto.ProductResponse;
-import com.klp.hub.product.application.dto.ProductUpdateCommand;
+import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Optional;
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ProductServiceTest {
@@ -54,13 +57,25 @@ class ProductServiceTest {
     @DisplayName("상품의 ID 로 상품을 조회할 수 있다")
     void getProductById() {
         Product product = mock(Product.class);
-        CompanyResponse companyResponse = new CompanyResponse(companyId, CompanyType.SUPPLIER.name(), "업체명", "업체주소");
+        CompanyResponse companyResponse = new CompanyResponse(
+            companyId,
+            CompanyType.SUPPLIER.name(),
+            "업체명",
+            "업체주소"
+        );
+        InventoryResponse inventoryResponse = new InventoryResponse(
+            productId,
+            inventoryId,
+            hubId,
+            10
+        );
         when(product.getName()).thenReturn("상품명");
         when(product.getId()).thenReturn(productId);
         when(product.getCompanyId()).thenReturn(companyId);
         when(productRepository.findById(productId))
-                .thenReturn(Optional.of(product));
+            .thenReturn(Optional.of(product));
         when(companyService.getByCompanyId(companyId)).thenReturn(companyResponse);
+        when(inventoryService.getByProductId(productId)).thenReturn(inventoryResponse);
 
         ProductResponse response = productService.getProductById(productId);
 
@@ -83,12 +98,12 @@ class ProductServiceTest {
         String oldName = "기존 상품명";
         String newName = "새로운 상품명";
         ProductUpdateCommand command = new ProductUpdateCommand(
-                productId,
-                newName
+            productId,
+            newName
         );
         Product product = new Product(companyId, oldName);
         when(productRepository.findById(any(UUID.class)))
-                .thenReturn(Optional.of(product));
+            .thenReturn(Optional.of(product));
 
         productService.update(command);
 
@@ -108,10 +123,10 @@ class ProductServiceTest {
     void withCreateInventory() {
         Integer quantity = 10;
         ProductCreateCommand command = new ProductCreateCommand(
-                companyId,
-                hubId,
-                "상품명",
-                quantity
+            companyId,
+            hubId,
+            "상품명",
+            quantity
         );
         Product product = mock(Product.class);
         CompanyResponse companyResponse = mock(CompanyResponse.class);
@@ -129,10 +144,10 @@ class ProductServiceTest {
     @DisplayName("상품 생성시 업체가 존재하지 않는다면 예외가 발생한다")
     void throwNullCompany() {
         ProductCreateCommand command = new ProductCreateCommand(
-                companyId,
-                hubId,
-                "상품명",
-                10
+            companyId,
+            hubId,
+            "상품명",
+            10
         );
         when(companyService.getByCompanyId(companyId)).thenThrow(RuntimeException.class);
 
@@ -144,10 +159,10 @@ class ProductServiceTest {
     void throwDuplicatedInventory() {
         Integer quantity = 10;
         ProductCreateCommand command = new ProductCreateCommand(
-                companyId,
-                hubId,
-                "상품명",
-                quantity
+            companyId,
+            hubId,
+            "상품명",
+            quantity
         );
         Product product = mock(Product.class);
         CompanyResponse companyResponse = mock(CompanyResponse.class);
@@ -155,7 +170,8 @@ class ProductServiceTest {
         when(companyResponse.id()).thenReturn(companyId);
         when(productRepository.save(any(Product.class))).thenReturn(product);
         when(product.getId()).thenReturn(productId);
-        when(inventoryService.create(productId, command.hubId(), quantity)).thenThrow(UniqueConstraintException.class);
+        when(inventoryService.create(productId, command.hubId(), quantity)).thenThrow(
+            UniqueConstraintException.class);
 
         assertThrows(RuntimeException.class, () -> productService.create(command));
     }
@@ -179,7 +195,8 @@ class ProductServiceTest {
     @DisplayName("상품 삭제시 관련된 재고도 삭제된다")
     void deletedInventoryWhenProductDeleted() {
         Product product = new Product(companyId, "상품명");
-        InventoryResponse inventoryResponse = new InventoryResponse(productId, inventoryId, 0);
+        InventoryResponse inventoryResponse = new InventoryResponse(productId, inventoryId, hubId,
+            0);
         when(productRepository.findById(productId)).thenReturn(Optional.of(product));
         when(inventoryService.getByProductId(productId)).thenReturn(inventoryResponse);
 

--- a/hub/src/test/java/com/klp/hub/product/presentation/controller/ProductControllerTest.java
+++ b/hub/src/test/java/com/klp/hub/product/presentation/controller/ProductControllerTest.java
@@ -11,6 +11,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.klp.common.exception.GlobalExceptionHandler;
+import com.klp.common.security.config.SecurityConfig;
+import com.klp.common.security.filter.AuthorizationFilter;
 import com.klp.hub.product.application.ProductService;
 import com.klp.hub.product.presentation.dto.ProductCreateRequest;
 import com.klp.hub.product.presentation.dto.ProductResponse;
@@ -23,6 +26,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -31,6 +35,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(ProductController.class)
+@Import({SecurityConfig.class, AuthorizationFilter.class, GlobalExceptionHandler.class})
 class ProductControllerTest {
 
     @Autowired

--- a/hub/src/test/java/com/klp/hub/product/presentation/controller/ProductControllerTest.java
+++ b/hub/src/test/java/com/klp/hub/product/presentation/controller/ProductControllerTest.java
@@ -1,8 +1,24 @@
 package com.klp.hub.product.presentation.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.klp.hub.product.application.ProductService;
-import com.klp.hub.product.presentation.dto.*;
+import com.klp.hub.product.presentation.dto.ProductCreateRequest;
+import com.klp.hub.product.presentation.dto.ProductResponse;
+import com.klp.hub.product.presentation.dto.ProductUpdateRequest;
+import com.klp.hub.product.presentation.dto.ProductUpdateResponse;
+import com.klp.hub.product.presentation.dto.ProductsPageRowResponse;
+import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,16 +29,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-
-import java.util.List;
-import java.util.UUID;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProductController.class)
 class ProductControllerTest {
@@ -41,27 +47,28 @@ class ProductControllerTest {
     void getProductById() throws Exception {
         UUID productId = UUID.randomUUID();
         when(productService.getProductById(productId))
-                .thenReturn(new ProductResponse(productId, UUID.randomUUID(), "업체명", "상품명"));
+            .thenReturn(new ProductResponse(productId, UUID.randomUUID(), "업체명", "상품명"));
 
         mockMvc.perform(get("/v1/products/{productId}", productId))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.productId").isString())
-                .andExpect(jsonPath("$.hubId").isString())
-                .andExpect(jsonPath("$.companyName").isString())
-                .andExpect(jsonPath("$.productName").isString());
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.productId").isString())
+            .andExpect(jsonPath("$.hubId").isString())
+            .andExpect(jsonPath("$.companyName").isString())
+            .andExpect(jsonPath("$.productName").isString());
     }
 
     @Test
     @DisplayName("상품 목록을 페이지네이션으로 조회할 수 있다")
     void getProductsByPageable() throws Exception {
         ProductsPageRowResponse row = new ProductsPageRowResponse(
-                UUID.randomUUID(),
-                UUID.randomUUID(),
-                "업체명",
-                "상품명"
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            "업체명",
+            "상품명"
         );
-        PageImpl<ProductsPageRowResponse> page = new PageImpl<>(List.of(row), PageRequest.of(0, 10), 100);
+        PageImpl<ProductsPageRowResponse> page = new PageImpl<>(List.of(row), PageRequest.of(0, 10),
+            100);
 
         when(productService.getProductsByPageable(any(Pageable.class))).thenReturn(page);
 
@@ -69,20 +76,20 @@ class ProductControllerTest {
                 .param("page", "0")
                 .param("size", "10")
                 .accept(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.products").isArray())
-                .andExpect(jsonPath("$.products[0].productId").isString())
-                .andExpect(jsonPath("$.products[0].hubId").isString())
-                .andExpect(jsonPath("$.products[0].companyName").isString())
-                .andExpect(jsonPath("$.products[0].productName").isString())
-                .andExpect(jsonPath("$.pageable.page").isNumber())
-                .andExpect(jsonPath("$.pageable.size").isNumber())
-                .andExpect(jsonPath("$.pageable.totalElements").isNumber())
-                .andExpect(jsonPath("$.pageable.totalPages").isNumber())
-                .andExpect(jsonPath("$.pageable.hasNext").isBoolean())
-                .andExpect(jsonPath("$.pageable.isFirst").isBoolean())
-                .andExpect(jsonPath("$.pageable.isLast").isBoolean());
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.products").isArray())
+            .andExpect(jsonPath("$.products[0].productId").isString())
+            .andExpect(jsonPath("$.products[0].hubId").isString())
+            .andExpect(jsonPath("$.products[0].companyName").isString())
+            .andExpect(jsonPath("$.products[0].productName").isString())
+            .andExpect(jsonPath("$.pageable.page").isNumber())
+            .andExpect(jsonPath("$.pageable.size").isNumber())
+            .andExpect(jsonPath("$.pageable.totalElements").isNumber())
+            .andExpect(jsonPath("$.pageable.totalPages").isNumber())
+            .andExpect(jsonPath("$.pageable.hasNext").isBoolean())
+            .andExpect(jsonPath("$.pageable.isFirst").isBoolean())
+            .andExpect(jsonPath("$.pageable.isLast").isBoolean());
     }
 
     @Test
@@ -92,19 +99,19 @@ class ProductControllerTest {
         UUID companyId = UUID.randomUUID();
         UUID hubId = UUID.randomUUID();
         ProductCreateRequest request = new ProductCreateRequest(
-                companyId,
-                hubId,
-                "상품명",
-                10
+            companyId,
+            hubId,
+            "상품명",
+            10
         );
         when(productService.create(any())).thenReturn(productId);
 
         mockMvc.perform(post("/v1/products")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.productId").isString());
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.productId").isString());
     }
 
     @Test
@@ -113,20 +120,20 @@ class ProductControllerTest {
         UUID productId = UUID.randomUUID();
         String name = "상품명";
         ProductUpdateRequest request = new ProductUpdateRequest(
-                name
+            name
         );
         ProductUpdateResponse response = new ProductUpdateResponse(
-                productId,
-                name
+            productId,
+            name
         );
         when(productService.update(any())).thenReturn(response);
 
         mockMvc.perform(patch("/v1/products/{productId}", productId)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.productId").isString());
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.productId").isString());
     }
 
     @Test
@@ -134,11 +141,11 @@ class ProductControllerTest {
     void softDeleteById() throws Exception {
         UUID productId = UUID.randomUUID();
         when(productService.delete(productId))
-                .thenReturn(productId);
+            .thenReturn(productId);
 
         mockMvc.perform(delete("/v1/products/{productId}", productId))
-                .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.productId").isString());
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.productId").isString());
     }
 }

--- a/hub/src/test/java/com/klp/hub/product/presentation/controller/ProductControllerTest.java
+++ b/hub/src/test/java/com/klp/hub/product/presentation/controller/ProductControllerTest.java
@@ -23,6 +23,7 @@ import com.klp.hub.product.presentation.dto.ProductsPageRowResponse;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -47,98 +48,241 @@ class ProductControllerTest {
     @MockitoBean
     private ProductService productService;
 
-    @Test
-    @DisplayName("상품 ID 로 상품을 조회할 수 있다")
-    void getProductById() throws Exception {
-        UUID productId = UUID.randomUUID();
-        when(productService.getProductById(productId))
-            .thenReturn(new ProductResponse(productId, UUID.randomUUID(), "업체명", "상품명"));
+    @Nested
+    class GetProduct {
 
-        mockMvc.perform(get("/v1/products/{productId}", productId))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$.productId").isString())
-            .andExpect(jsonPath("$.hubId").isString())
-            .andExpect(jsonPath("$.companyName").isString())
-            .andExpect(jsonPath("$.productName").isString());
+        @Test
+        @DisplayName("상품 ID 로 상품을 조회할 수 있다")
+        void getProductById() throws Exception {
+            UUID productId = UUID.randomUUID();
+            when(productService.getProductById(productId))
+                .thenReturn(new ProductResponse(productId, UUID.randomUUID(), "업체명", "상품명"));
+
+            mockMvc.perform(get("/v1/products/{productId}", productId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.productId").isString())
+                .andExpect(jsonPath("$.hubId").isString())
+                .andExpect(jsonPath("$.companyName").isString())
+                .andExpect(jsonPath("$.productName").isString());
+        }
+
+        @Test
+        @DisplayName("상품 목록을 페이지네이션으로 조회할 수 있다")
+        void getProductsByPageable() throws Exception {
+            ProductsPageRowResponse row = new ProductsPageRowResponse(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "업체명",
+                "상품명"
+            );
+            PageImpl<ProductsPageRowResponse> page = new PageImpl<>(List.of(row),
+                PageRequest.of(0, 10),
+                100);
+
+            when(productService.getProductsByPageable(any(Pageable.class))).thenReturn(page);
+
+            mockMvc.perform(get("/v1/products")
+                    .param("page", "0")
+                    .param("size", "10")
+                    .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.products").isArray())
+                .andExpect(jsonPath("$.products[0].productId").isString())
+                .andExpect(jsonPath("$.products[0].hubId").isString())
+                .andExpect(jsonPath("$.products[0].companyName").isString())
+                .andExpect(jsonPath("$.products[0].productName").isString())
+                .andExpect(jsonPath("$.pageable.page").isNumber())
+                .andExpect(jsonPath("$.pageable.size").isNumber())
+                .andExpect(jsonPath("$.pageable.totalElements").isNumber())
+                .andExpect(jsonPath("$.pageable.totalPages").isNumber())
+                .andExpect(jsonPath("$.pageable.hasNext").isBoolean())
+                .andExpect(jsonPath("$.pageable.isFirst").isBoolean())
+                .andExpect(jsonPath("$.pageable.isLast").isBoolean());
+        }
     }
 
-    @Test
-    @DisplayName("상품 목록을 페이지네이션으로 조회할 수 있다")
-    void getProductsByPageable() throws Exception {
-        ProductsPageRowResponse row = new ProductsPageRowResponse(
-            UUID.randomUUID(),
-            UUID.randomUUID(),
-            "업체명",
-            "상품명"
-        );
-        PageImpl<ProductsPageRowResponse> page = new PageImpl<>(List.of(row), PageRequest.of(0, 10),
-            100);
+    @Nested
+    class Create {
 
-        when(productService.getProductsByPageable(any(Pageable.class))).thenReturn(page);
+        @Test
+        @DisplayName("상품을 생성할 수 있다")
+        void createProduct() throws Exception {
+            UUID productId = UUID.randomUUID();
+            UUID companyId = UUID.randomUUID();
+            UUID hubId = UUID.randomUUID();
+            ProductCreateRequest request = new ProductCreateRequest(
+                companyId,
+                hubId,
+                "상품명",
+                10
+            );
+            when(productService.create(any())).thenReturn(productId);
 
-        mockMvc.perform(get("/v1/products")
-                .param("page", "0")
-                .param("size", "10")
-                .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$.products").isArray())
-            .andExpect(jsonPath("$.products[0].productId").isString())
-            .andExpect(jsonPath("$.products[0].hubId").isString())
-            .andExpect(jsonPath("$.products[0].companyName").isString())
-            .andExpect(jsonPath("$.products[0].productName").isString())
-            .andExpect(jsonPath("$.pageable.page").isNumber())
-            .andExpect(jsonPath("$.pageable.size").isNumber())
-            .andExpect(jsonPath("$.pageable.totalElements").isNumber())
-            .andExpect(jsonPath("$.pageable.totalPages").isNumber())
-            .andExpect(jsonPath("$.pageable.hasNext").isBoolean())
-            .andExpect(jsonPath("$.pageable.isFirst").isBoolean())
-            .andExpect(jsonPath("$.pageable.isLast").isBoolean());
+            mockMvc.perform(post("/v1/products")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.productId").isString());
+        }
+
+        @Test
+        @DisplayName("업체 ID 가 누락되면 400 Bad Request 를 반환한다")
+        void missingCompanyId() throws Exception {
+            UUID productId = UUID.randomUUID();
+            UUID companyId = null;
+            UUID hubId = UUID.randomUUID();
+            ProductCreateRequest request = new ProductCreateRequest(
+                companyId,
+                hubId,
+                "상품명",
+                10
+            );
+            when(productService.create(any())).thenReturn(productId);
+
+            mockMvc.perform(post("/v1/products")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("허브 ID 가 누락되면 400 Bad Request 를 반환한다")
+        void missingHubId() throws Exception {
+            UUID productId = UUID.randomUUID();
+            UUID companyId = UUID.randomUUID();
+            UUID hubId = null;
+            ProductCreateRequest request = new ProductCreateRequest(
+                companyId,
+                hubId,
+                "상품명",
+                10
+            );
+            when(productService.create(any())).thenReturn(productId);
+
+            mockMvc.perform(post("/v1/products")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("상품명이 누락되면 400 Bad Request 를 반환한다")
+        void missingProductName() throws Exception {
+            UUID productId = UUID.randomUUID();
+            UUID companyId = UUID.randomUUID();
+            UUID hubId = UUID.randomUUID();
+            ProductCreateRequest request = new ProductCreateRequest(
+                companyId,
+                hubId,
+                null,
+                10
+            );
+            when(productService.create(any())).thenReturn(productId);
+
+            mockMvc.perform(post("/v1/products")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("상품명이 빈값이면 400 Bad Request 를 반환한다")
+        void emptyProductName() throws Exception {
+            UUID productId = UUID.randomUUID();
+            UUID companyId = UUID.randomUUID();
+            UUID hubId = UUID.randomUUID();
+            ProductCreateRequest request = new ProductCreateRequest(
+                companyId,
+                hubId,
+                " ",
+                10
+            );
+            when(productService.create(any())).thenReturn(productId);
+
+            mockMvc.perform(post("/v1/products")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("재고수량이 음수라면 400 Bad Request 를 반환한다")
+        void negativeInventory() throws Exception {
+            UUID productId = UUID.randomUUID();
+            UUID companyId = UUID.randomUUID();
+            UUID hubId = UUID.randomUUID();
+            ProductCreateRequest request = new ProductCreateRequest(
+                companyId,
+                hubId,
+                "상품명",
+                -1
+            );
+            when(productService.create(any())).thenReturn(productId);
+
+            mockMvc.perform(post("/v1/products")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+        }
     }
 
-    @Test
-    @DisplayName("상품을 생성할 수 있다")
-    void createProduct() throws Exception {
-        UUID productId = UUID.randomUUID();
-        UUID companyId = UUID.randomUUID();
-        UUID hubId = UUID.randomUUID();
-        ProductCreateRequest request = new ProductCreateRequest(
-            companyId,
-            hubId,
-            "상품명",
-            10
-        );
-        when(productService.create(any())).thenReturn(productId);
+    @Nested
+    class Update {
 
-        mockMvc.perform(post("/v1/products")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$.productId").isString());
-    }
+        @Test
+        @DisplayName("상품을 변경할 수 있다")
+        void updateProduct() throws Exception {
+            UUID productId = UUID.randomUUID();
+            String name = "상품명";
+            ProductUpdateRequest request = new ProductUpdateRequest(
+                name
+            );
+            ProductUpdateResponse response = new ProductUpdateResponse(
+                productId,
+                name
+            );
+            when(productService.update(any())).thenReturn(response);
 
-    @Test
-    @DisplayName("상품을 변경할 수 있다")
-    void updateProduct() throws Exception {
-        UUID productId = UUID.randomUUID();
-        String name = "상품명";
-        ProductUpdateRequest request = new ProductUpdateRequest(
-            name
-        );
-        ProductUpdateResponse response = new ProductUpdateResponse(
-            productId,
-            name
-        );
-        when(productService.update(any())).thenReturn(response);
+            mockMvc.perform(patch("/v1/products/{productId}", productId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.productId").isString());
+        }
 
-        mockMvc.perform(patch("/v1/products/{productId}", productId)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
-            .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$.productId").isString());
+        @Test
+        @DisplayName("상품명이 누락되면 400 Bad Request 를 반환한다")
+        void missingProductName() throws Exception {
+            UUID productId = UUID.randomUUID();
+            String name = null;
+            ProductUpdateRequest request = new ProductUpdateRequest(
+                name
+            );
+
+            mockMvc.perform(patch("/v1/products/{productId}", productId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("상품명이 빈값이면 400 Bad Request 를 반환한다")
+        void emptyProductName() throws Exception {
+            UUID productId = UUID.randomUUID();
+            String name = " ";
+            ProductUpdateRequest request = new ProductUpdateRequest(
+                name
+            );
+
+            mockMvc.perform(patch("/v1/products/{productId}", productId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+        }
     }
 
     @Test

--- a/hub/src/test/java/com/klp/hub/product/presentation/controller/ProductControllerTest.java
+++ b/hub/src/test/java/com/klp/hub/product/presentation/controller/ProductControllerTest.java
@@ -11,9 +11,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.klp.common.exception.GlobalExceptionHandler;
-import com.klp.common.security.config.SecurityConfig;
-import com.klp.common.security.filter.AuthorizationFilter;
+import com.klp.hub.global.config.SecurityConfig;
+import com.klp.hub.global.exception.GlobalExceptionHandler;
+import com.klp.hub.global.filter.AuthorizationFilter;
 import com.klp.hub.product.application.ProductService;
 import com.klp.hub.product.presentation.dto.ProductCreateRequest;
 import com.klp.hub.product.presentation.dto.ProductResponse;


### PR DESCRIPTION
## PR 내용
- #33 
  - 단일 업체 조회 API 
  - 재고 차감, 증가 API
  - 재고 변경 요청시 멱등성 검증
  - 각 서비스의 예외는 `BusinessException` 예외로 변경

## 리뷰 포인트
- 추가해야하는 테스트 혹은 도메인 정책에 맞지 않는 부분이 있다면 리뷰부탁드립니다