### PR TITLE
feat: 로그인, 로그아웃, 토큰 재발급 기능 구현

### DIFF
--- a/auth-service/build.gradle
+++ b/auth-service/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/auth-service/build.gradle
+++ b/auth-service/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'org.postgresql:postgresql'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // common-module

--- a/auth-service/src/main/java/com/klp/authservice/auth/AuthErrorCode.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/AuthErrorCode.java
@@ -14,6 +14,9 @@ public enum AuthErrorCode implements ErrorCode {
     USER_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "유저 서비스 요청 오류가 발생했습니다"),
     USER_SERVICE_INTERNAL_ERROR(HttpStatus.BAD_GATEWAY, "유저 서비스에 일시적인 오류가 발생했습니다"),
 
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다"),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다"),
+
     // 블랙리스트 도메인 에러 코드
     BLACKLIST_CREATE_ERROR(HttpStatus.BAD_REQUEST, "블랙리스트 토큰 생성에 실패했습니다");
 

--- a/auth-service/src/main/java/com/klp/authservice/auth/AuthErrorCode.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/AuthErrorCode.java
@@ -12,7 +12,10 @@ public enum AuthErrorCode implements ErrorCode {
     INVALID_AFFILIATION_TYPE(HttpStatus.BAD_REQUEST, "올바르지 않은 소속 타입입니다"),
 
     USER_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "유저 서비스 요청 오류가 발생했습니다"),
-    USER_SERVICE_INTERNAL_ERROR(HttpStatus.BAD_GATEWAY, "유저 서비스에 일시적인 오류가 발생했습니다");
+    USER_SERVICE_INTERNAL_ERROR(HttpStatus.BAD_GATEWAY, "유저 서비스에 일시적인 오류가 발생했습니다"),
+
+    // 블랙리스트 도메인 에러 코드
+    BLACKLIST_CREATE_ERROR(HttpStatus.BAD_REQUEST, "블랙리스트 토큰 생성에 실패했습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/auth-service/src/main/java/com/klp/authservice/auth/AuthErrorCode.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/AuthErrorCode.java
@@ -14,8 +14,10 @@ public enum AuthErrorCode implements ErrorCode {
     USER_SERVICE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "유저 서비스 요청 오류가 발생했습니다"),
     USER_SERVICE_INTERNAL_ERROR(HttpStatus.BAD_GATEWAY, "유저 서비스에 일시적인 오류가 발생했습니다"),
 
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다"),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다"),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다"),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    TOKEN_ALREADY_BLACKLISTED(HttpStatus.UNAUTHORIZED, "이미 금지된 토큰입니다"),
 
     // 블랙리스트 도메인 에러 코드
     BLACKLIST_CREATE_ERROR(HttpStatus.BAD_REQUEST, "블랙리스트 토큰 생성에 실패했습니다");

--- a/auth-service/src/main/java/com/klp/authservice/auth/AuthErrorCode.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/AuthErrorCode.java
@@ -17,6 +17,7 @@ public enum AuthErrorCode implements ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다"),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다"),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰을 찾을 수 없습니다"),
     TOKEN_ALREADY_BLACKLISTED(HttpStatus.UNAUTHORIZED, "이미 금지된 토큰입니다"),
 
     // 블랙리스트 도메인 에러 코드

--- a/auth-service/src/main/java/com/klp/authservice/auth/application/AuthService.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/application/AuthService.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -58,7 +59,8 @@ public class AuthService {
         return new LoginResponse(dto.userId(), dto.userName(), dto.role(), accessToken);
     }
 
-    public void logout(String accessToken) {
+    @Transactional
+    public void logout(String accessToken, String refreshToken) {
         if (!accessTokenProvider.validateToken(accessToken)) {
             throw new BusinessException(AuthErrorCode.INVALID_TOKEN);
         }
@@ -66,27 +68,24 @@ public class AuthService {
         String role = accessTokenProvider.getRole(accessToken);
 
         if (isAdmin(role)) {
-            if (blackListTokenRepository.existsByToken(accessToken)) {
-                throw new BusinessException(AuthErrorCode.TOKEN_ALREADY_BLACKLISTED);
-            }
-
-            LocalDateTime expiration = accessTokenProvider.getExpiration(accessToken);
-
-            addBlacklist(accessToken, expiration);
+            addBlacklist(accessToken, accessTokenProvider.getExpiration(accessToken));
+            addBlacklist(refreshToken, refreshTokenProvider.getExpiration(refreshToken));
         }
     }
 
-    public ReissueResponse reissue(String refreshToken) {
+    public ReissueResponse reissue(String accessToken, String refreshToken) {
         validateRefreshToken(refreshToken);
 
         Long userId = Long.valueOf(refreshTokenProvider.getUserId(refreshToken));
         String userName = refreshTokenProvider.getUserName(refreshToken);
         String role = refreshTokenProvider.getRole(refreshToken);
-        LocalDateTime expiration = refreshTokenProvider.getExpiration(refreshToken);
 
         String newAccessToken = accessTokenProvider.generate(userId, userName, role);
 
-        addBlacklist(refreshToken, expiration);
+        addBlacklist(refreshToken, refreshTokenProvider.getExpiration(refreshToken));
+        if (accessToken != null && !accessToken.isBlank()) {
+            addBlacklist(accessToken, accessTokenProvider.getExpiration(accessToken));
+        }
 
         return new ReissueResponse(userId, userName, role, newAccessToken);
     }
@@ -116,6 +115,10 @@ public class AuthService {
     }
 
     private void addBlacklist(String token, LocalDateTime expiration) {
+        if (blackListTokenRepository.existsByToken(token)) {
+            return;
+        }
+
         BlackListToken blackListToken = BlackListToken.create(token, expiration);
         blackListTokenRepository.save(blackListToken);
     }

--- a/auth-service/src/main/java/com/klp/authservice/auth/application/AuthService.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/application/AuthService.java
@@ -2,8 +2,12 @@ package com.klp.authservice.auth.application;
 
 import com.klp.authservice.auth.AuthErrorCode;
 import com.klp.authservice.auth.application.client.UserClient;
+import com.klp.authservice.auth.application.command.LoginCommand;
 import com.klp.authservice.auth.application.command.SignUpCommand;
+import com.klp.authservice.auth.entrypoint.dto.response.LoginResponse;
 import com.klp.authservice.auth.infrastructure.external.dto.request.UserCreateRequest;
+import com.klp.authservice.auth.infrastructure.external.dto.response.UserDataDTO;
+import com.klp.authservice.auth.infrastructure.jwt.TokenProvider;
 import com.klp.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -15,6 +19,7 @@ public class AuthService {
 
     private final UserClient userClient;
     private final PasswordEncoder passwordEncoder;
+    private final TokenProvider accessTokenProvider;
 
     /**
      * 회원가입: 유저 이름 중복 확인 요청 -> 패스워드 암호화 -> 유저 생성 요청
@@ -35,6 +40,18 @@ public class AuthService {
         );
 
         userClient.createUser(request);
+    }
+
+    public LoginResponse login(LoginCommand command) {
+        UserDataDTO dto = userClient.getUserByUserName(command.userName());
+
+        if (!passwordEncoder.matches(command.password(), dto.password())) {
+            throw new BusinessException(AuthErrorCode.INVALID_PASSWORD);
+        }
+
+        String accessToken = accessTokenProvider.generate(dto.userId(), dto.userName(), dto.role());
+
+        return new LoginResponse(dto.userId(), dto.userName(), dto.role(), accessToken);
     }
 
     private boolean checkDuplicateUserName(String userName) {

--- a/auth-service/src/main/java/com/klp/authservice/auth/application/AuthService.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/application/AuthService.java
@@ -59,7 +59,9 @@ public class AuthService {
     }
 
     public void logout(String accessToken) {
-        accessTokenProvider.validateToken(accessToken);
+        if (!accessTokenProvider.validateToken(accessToken)) {
+            throw new BusinessException(AuthErrorCode.INVALID_TOKEN);
+        }
 
         String role = accessTokenProvider.getRole(accessToken);
 
@@ -70,31 +72,23 @@ public class AuthService {
 
             LocalDateTime expiration = accessTokenProvider.getExpiration(accessToken);
 
-            BlackListToken blackListToken = BlackListToken.create(accessToken, expiration);
-            blackListTokenRepository.save(blackListToken);
+            addBlacklist(accessToken, expiration);
         }
     }
 
     public ReissueResponse reissue(String refreshToken) {
-        if (!refreshTokenProvider.validateToken(refreshToken)) {
-            throw new BusinessException(AuthErrorCode.INVALID_TOKEN);
-        }
+        validateRefreshToken(refreshToken);
 
-        if (blackListTokenRepository.existsByToken(refreshToken)) {
-            throw new BusinessException(AuthErrorCode.TOKEN_ALREADY_BLACKLISTED);
-        }
-
-        String userId = refreshTokenProvider.getUserId(refreshToken);
+        Long userId = Long.valueOf(refreshTokenProvider.getUserId(refreshToken));
         String userName = refreshTokenProvider.getUserName(refreshToken);
         String role = refreshTokenProvider.getRole(refreshToken);
         LocalDateTime expiration = refreshTokenProvider.getExpiration(refreshToken);
 
-        String newAccessToken = accessTokenProvider.generate(Long.valueOf(userId), userName, role);
+        String newAccessToken = accessTokenProvider.generate(userId, userName, role);
 
-        BlackListToken blackListToken = BlackListToken.create(refreshToken, expiration);
-        blackListTokenRepository.save(blackListToken);
+        addBlacklist(refreshToken, expiration);
 
-        return new ReissueResponse(Long.valueOf(userId), userName, role, newAccessToken);
+        return new ReissueResponse(userId, userName, role, newAccessToken);
     }
 
     private boolean checkDuplicateUserName(String userName) {
@@ -109,5 +103,20 @@ public class AuthService {
 
     private boolean isAdmin(String role) {
         return "MASTER".equals(role) || "HUB".equals(role);
+    }
+
+    private void validateRefreshToken(String refreshToken) {
+        if (!refreshTokenProvider.validateToken(refreshToken)) {
+            throw new BusinessException(AuthErrorCode.INVALID_TOKEN);
+        }
+
+        if (blackListTokenRepository.existsByToken(refreshToken)) {
+            throw new BusinessException(AuthErrorCode.TOKEN_ALREADY_BLACKLISTED);
+        }
+    }
+
+    private void addBlacklist(String token, LocalDateTime expiration) {
+        BlackListToken blackListToken = BlackListToken.create(token, expiration);
+        blackListTokenRepository.save(blackListToken);
     }
 }

--- a/auth-service/src/main/java/com/klp/authservice/auth/application/AuthService.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/application/AuthService.java
@@ -1,6 +1,5 @@
 package com.klp.authservice.auth.application;
 
-import com.klp.authservice.auth.AuthErrorCode;
 import com.klp.authservice.auth.application.client.UserClient;
 import com.klp.authservice.auth.application.command.LoginCommand;
 import com.klp.authservice.auth.application.command.SignUpCommand;
@@ -8,6 +7,7 @@ import com.klp.authservice.auth.domain.entity.BlackListToken;
 import com.klp.authservice.auth.domain.repository.BlackListTokenRepository;
 import com.klp.authservice.auth.entrypoint.dto.response.LoginResponse;
 import com.klp.authservice.auth.entrypoint.dto.response.ReissueResponse;
+import com.klp.authservice.auth.exception.AuthErrorCode;
 import com.klp.authservice.auth.infrastructure.external.dto.request.UserCreateRequest;
 import com.klp.authservice.auth.infrastructure.external.dto.response.UserDataDTO;
 import com.klp.authservice.auth.infrastructure.jwt.TokenProvider;

--- a/auth-service/src/main/java/com/klp/authservice/auth/application/AuthService.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/application/AuthService.java
@@ -73,6 +73,7 @@ public class AuthService {
         }
     }
 
+    @Transactional
     public ReissueResponse reissue(String accessToken, String refreshToken) {
         validateRefreshToken(refreshToken);
 

--- a/auth-service/src/main/java/com/klp/authservice/auth/application/AuthService.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/application/AuthService.java
@@ -7,6 +7,7 @@ import com.klp.authservice.auth.application.command.SignUpCommand;
 import com.klp.authservice.auth.domain.entity.BlackListToken;
 import com.klp.authservice.auth.domain.repository.BlackListTokenRepository;
 import com.klp.authservice.auth.entrypoint.dto.response.LoginResponse;
+import com.klp.authservice.auth.entrypoint.dto.response.ReissueResponse;
 import com.klp.authservice.auth.infrastructure.external.dto.request.UserCreateRequest;
 import com.klp.authservice.auth.infrastructure.external.dto.response.UserDataDTO;
 import com.klp.authservice.auth.infrastructure.jwt.TokenProvider;
@@ -23,6 +24,7 @@ public class AuthService {
     private final UserClient userClient;
     private final PasswordEncoder passwordEncoder;
     private final TokenProvider accessTokenProvider;
+    private final TokenProvider refreshTokenProvider;
     private final BlackListTokenRepository blackListTokenRepository;
 
     /**
@@ -71,6 +73,28 @@ public class AuthService {
             BlackListToken blackListToken = BlackListToken.create(accessToken, expiration);
             blackListTokenRepository.save(blackListToken);
         }
+    }
+
+    public ReissueResponse reissue(String refreshToken) {
+        if (!refreshTokenProvider.validateToken(refreshToken)) {
+            throw new BusinessException(AuthErrorCode.INVALID_TOKEN);
+        }
+
+        if (blackListTokenRepository.existsByToken(refreshToken)) {
+            throw new BusinessException(AuthErrorCode.TOKEN_ALREADY_BLACKLISTED);
+        }
+
+        String userId = refreshTokenProvider.getUserId(refreshToken);
+        String userName = refreshTokenProvider.getUserName(refreshToken);
+        String role = refreshTokenProvider.getRole(refreshToken);
+        LocalDateTime expiration = refreshTokenProvider.getExpiration(refreshToken);
+
+        String newAccessToken = accessTokenProvider.generate(Long.valueOf(userId), userName, role);
+
+        BlackListToken blackListToken = BlackListToken.create(refreshToken, expiration);
+        blackListTokenRepository.save(blackListToken);
+
+        return new ReissueResponse(Long.valueOf(userId), userName, role, newAccessToken);
     }
 
     private boolean checkDuplicateUserName(String userName) {

--- a/auth-service/src/main/java/com/klp/authservice/auth/application/AuthService.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/application/AuthService.java
@@ -4,11 +4,14 @@ import com.klp.authservice.auth.AuthErrorCode;
 import com.klp.authservice.auth.application.client.UserClient;
 import com.klp.authservice.auth.application.command.LoginCommand;
 import com.klp.authservice.auth.application.command.SignUpCommand;
+import com.klp.authservice.auth.domain.entity.BlackListToken;
+import com.klp.authservice.auth.domain.repository.BlackListTokenRepository;
 import com.klp.authservice.auth.entrypoint.dto.response.LoginResponse;
 import com.klp.authservice.auth.infrastructure.external.dto.request.UserCreateRequest;
 import com.klp.authservice.auth.infrastructure.external.dto.response.UserDataDTO;
 import com.klp.authservice.auth.infrastructure.jwt.TokenProvider;
 import com.klp.common.exception.BusinessException;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -20,6 +23,7 @@ public class AuthService {
     private final UserClient userClient;
     private final PasswordEncoder passwordEncoder;
     private final TokenProvider accessTokenProvider;
+    private final BlackListTokenRepository blackListTokenRepository;
 
     /**
      * 회원가입: 유저 이름 중복 확인 요청 -> 패스워드 암호화 -> 유저 생성 요청
@@ -52,6 +56,23 @@ public class AuthService {
         return new LoginResponse(dto.userId(), dto.userName(), dto.role(), accessToken);
     }
 
+    public void logout(String accessToken) {
+        accessTokenProvider.validateToken(accessToken);
+
+        String role = accessTokenProvider.getRole(accessToken);
+
+        if (isAdmin(role)) {
+            if (blackListTokenRepository.existsByToken(accessToken)) {
+                throw new BusinessException(AuthErrorCode.TOKEN_ALREADY_BLACKLISTED);
+            }
+
+            LocalDateTime expiration = accessTokenProvider.getExpiration(accessToken);
+
+            BlackListToken blackListToken = BlackListToken.create(accessToken, expiration);
+            blackListTokenRepository.save(blackListToken);
+        }
+    }
+
     private boolean checkDuplicateUserName(String userName) {
         return userClient.checkUserNameAvailable(userName);
     }
@@ -60,5 +81,9 @@ public class AuthService {
         if (!passwordEncoder.matches(rawPassword, encodedPassword)) {
             throw new BusinessException(AuthErrorCode.INVALID_PASSWORD);
         }
+    }
+
+    private boolean isAdmin(String role) {
+        return "MASTER".equals(role) || "HUB".equals(role);
     }
 }

--- a/auth-service/src/main/java/com/klp/authservice/auth/application/AuthService.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/application/AuthService.java
@@ -45,9 +45,7 @@ public class AuthService {
     public LoginResponse login(LoginCommand command) {
         UserDataDTO dto = userClient.getUserByUserName(command.userName());
 
-        if (!passwordEncoder.matches(command.password(), dto.password())) {
-            throw new BusinessException(AuthErrorCode.INVALID_PASSWORD);
-        }
+        validatePassword(command.password(), dto.password());
 
         String accessToken = accessTokenProvider.generate(dto.userId(), dto.userName(), dto.role());
 
@@ -56,5 +54,11 @@ public class AuthService {
 
     private boolean checkDuplicateUserName(String userName) {
         return userClient.checkUserNameAvailable(userName);
+    }
+
+    private void validatePassword(String rawPassword, String encodedPassword) {
+        if (!passwordEncoder.matches(rawPassword, encodedPassword)) {
+            throw new BusinessException(AuthErrorCode.INVALID_PASSWORD);
+        }
     }
 }

--- a/auth-service/src/main/java/com/klp/authservice/auth/application/client/UserClient.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/application/client/UserClient.java
@@ -1,6 +1,7 @@
 package com.klp.authservice.auth.application.client;
 
 import com.klp.authservice.auth.infrastructure.external.dto.request.UserCreateRequest;
+import com.klp.authservice.auth.infrastructure.external.dto.response.UserDataDTO;
 
 public interface UserClient {
 
@@ -13,4 +14,9 @@ public interface UserClient {
      * 회원가입 이후 유저 생성 요청
      */
     void createUser(UserCreateRequest request);
+
+    /**
+     * userName으로 유저 정보를 가져오는 요청
+     */
+    UserDataDTO getUserByUserName(String userName);
 }

--- a/auth-service/src/main/java/com/klp/authservice/auth/application/command/LoginCommand.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/application/command/LoginCommand.java
@@ -1,0 +1,8 @@
+package com.klp.authservice.auth.application.command;
+
+public record LoginCommand(
+    String userName,
+    String password
+) {
+
+}

--- a/auth-service/src/main/java/com/klp/authservice/auth/domain/entity/BlackListToken.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/domain/entity/BlackListToken.java
@@ -1,7 +1,7 @@
 package com.klp.authservice.auth.domain.entity;
 
-import com.klp.authservice.auth.AuthErrorCode;
-import com.klp.authservice.auth.infrastructure.jpa.model.BaseEntity;
+import com.klp.authservice.auth.exception.AuthErrorCode;
+import com.klp.authservice.common.model.BaseEntity;
 import com.klp.common.exception.BusinessException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -38,7 +38,7 @@ public class BlackListToken extends BaseEntity {
 
     public static BlackListToken create(String token, LocalDateTime expiration) {
         validateBlackListToken(token, expiration);
-        
+
         return new BlackListToken(token, expiration);
     }
 

--- a/auth-service/src/main/java/com/klp/authservice/auth/domain/entity/BlackListToken.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/domain/entity/BlackListToken.java
@@ -38,11 +38,8 @@ public class BlackListToken extends BaseEntity {
 
     public static BlackListToken create(String token, LocalDateTime expiration) {
         validateBlackListToken(token, expiration);
-
-        BlackListToken blackListToken = new BlackListToken();
-        blackListToken.token = token;
-        blackListToken.expiration = expiration;
-        return blackListToken;
+        
+        return new BlackListToken(token, expiration);
     }
 
     private static void validateBlackListToken(String token, LocalDateTime expiration) {

--- a/auth-service/src/main/java/com/klp/authservice/auth/domain/entity/BlackListToken.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/domain/entity/BlackListToken.java
@@ -1,0 +1,57 @@
+package com.klp.authservice.auth.domain.entity;
+
+import com.klp.authservice.auth.AuthErrorCode;
+import com.klp.authservice.auth.infrastructure.jpa.model.BaseEntity;
+import com.klp.common.exception.BusinessException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "p_blacklist_token", schema = "auth_schema")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BlackListToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID blackListTokenId;
+
+    @Column(nullable = false)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiration;
+
+    private BlackListToken(String token, LocalDateTime expiration) {
+        this.token = token;
+        this.expiration = expiration;
+    }
+
+    public static BlackListToken create(String token, LocalDateTime expiration) {
+        validateBlackListToken(token, expiration);
+
+        BlackListToken blackListToken = new BlackListToken();
+        blackListToken.token = token;
+        blackListToken.expiration = expiration;
+        return blackListToken;
+    }
+
+    private static void validateBlackListToken(String token, LocalDateTime expiration) {
+        if (token == null || token.isBlank()) {
+            throw new BusinessException(AuthErrorCode.BLACKLIST_CREATE_ERROR);
+        }
+
+        if (expiration == null || expiration.isBefore(LocalDateTime.now())) {
+            throw new BusinessException(AuthErrorCode.BLACKLIST_CREATE_ERROR);
+        }
+    }
+}

--- a/auth-service/src/main/java/com/klp/authservice/auth/domain/repository/BlackListTokenRepository.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/domain/repository/BlackListTokenRepository.java
@@ -1,0 +1,10 @@
+package com.klp.authservice.auth.domain.repository;
+
+import com.klp.authservice.auth.domain.entity.BlackListToken;
+
+public interface BlackListTokenRepository {
+
+    BlackListToken save(BlackListToken token);
+
+    boolean existsByToken(String token);
+}

--- a/auth-service/src/main/java/com/klp/authservice/auth/entrypoint/controller/AuthController.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/entrypoint/controller/AuthController.java
@@ -1,7 +1,9 @@
 package com.klp.authservice.auth.entrypoint.controller;
 
 import com.klp.authservice.auth.application.AuthService;
+import com.klp.authservice.auth.entrypoint.dto.request.LoginRequest;
 import com.klp.authservice.auth.entrypoint.dto.request.SignUpRequest;
+import com.klp.authservice.auth.entrypoint.dto.response.LoginResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,5 +23,10 @@ public class AuthController {
     public ResponseEntity<Void> signUp(@Valid @RequestBody SignUpRequest request) {
         authService.signUp(request.toCommand());
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok().body(authService.login(request.toCommand()));
     }
 }

--- a/auth-service/src/main/java/com/klp/authservice/auth/entrypoint/controller/AuthController.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/entrypoint/controller/AuthController.java
@@ -1,11 +1,11 @@
 package com.klp.authservice.auth.entrypoint.controller;
 
-import com.klp.authservice.auth.AuthErrorCode;
 import com.klp.authservice.auth.application.AuthService;
 import com.klp.authservice.auth.entrypoint.dto.request.LoginRequest;
 import com.klp.authservice.auth.entrypoint.dto.request.SignUpRequest;
 import com.klp.authservice.auth.entrypoint.dto.response.LoginResponse;
 import com.klp.authservice.auth.entrypoint.dto.response.ReissueResponse;
+import com.klp.authservice.auth.exception.AuthErrorCode;
 import com.klp.authservice.auth.infrastructure.jwt.RefreshTokenCookieFactory;
 import com.klp.authservice.auth.infrastructure.jwt.TokenExtractor;
 import com.klp.authservice.auth.infrastructure.jwt.TokenProvider;

--- a/auth-service/src/main/java/com/klp/authservice/auth/entrypoint/controller/AuthController.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/entrypoint/controller/AuthController.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,6 +23,8 @@ public class AuthController {
 
     private final AuthService authService;
     private final TokenProvider refreshTokenProvider;
+
+    private static final int AUTHORIZATION_PREFIX_LENGTH = 7;
 
     @PostMapping("/signUp")
     public ResponseEntity<Void> signUp(@Valid @RequestBody SignUpRequest request) {
@@ -40,5 +43,18 @@ public class AuthController {
         return ResponseEntity.ok()
             .headers(headers)
             .body(response);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@RequestHeader("Authorization") String authorization) {
+        String accessToken = authorization.substring(AUTHORIZATION_PREFIX_LENGTH);
+        authService.logout(accessToken);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, RefreshTokenCookieFactory.invalidate().toString());
+
+        return ResponseEntity.ok()
+            .headers(headers)
+            .build();
     }
 }

--- a/auth-service/src/main/java/com/klp/authservice/auth/entrypoint/controller/AuthController.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/entrypoint/controller/AuthController.java
@@ -4,9 +4,13 @@ import com.klp.authservice.auth.application.AuthService;
 import com.klp.authservice.auth.entrypoint.dto.request.LoginRequest;
 import com.klp.authservice.auth.entrypoint.dto.request.SignUpRequest;
 import com.klp.authservice.auth.entrypoint.dto.response.LoginResponse;
+import com.klp.authservice.auth.entrypoint.dto.response.ReissueResponse;
 import com.klp.authservice.auth.infrastructure.jwt.RefreshTokenCookieFactory;
 import com.klp.authservice.auth.infrastructure.jwt.TokenProvider;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -56,5 +60,23 @@ public class AuthController {
         return ResponseEntity.ok()
             .headers(headers)
             .build();
+    }
+
+    @PostMapping("/token/reissue")
+    public ResponseEntity<ReissueResponse> reissue(HttpServletRequest request) {
+        String refreshToken = Arrays.stream(request.getCookies())
+            .filter(cookie -> "refreshToken".equals(cookie.getName()))
+            .findFirst()
+            .map(Cookie::getValue)
+            .orElse(null);
+
+        ReissueResponse response = authService.reissue(refreshToken);
+        String newRefreshToken = refreshTokenProvider.generate(response.userId(), response.userName(), response.role());
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, RefreshTokenCookieFactory.create(newRefreshToken).toString());
+
+        return ResponseEntity.ok()
+            .headers(headers)
+            .body(response);
     }
 }

--- a/auth-service/src/main/java/com/klp/authservice/auth/entrypoint/controller/AuthController.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/entrypoint/controller/AuthController.java
@@ -4,8 +4,11 @@ import com.klp.authservice.auth.application.AuthService;
 import com.klp.authservice.auth.entrypoint.dto.request.LoginRequest;
 import com.klp.authservice.auth.entrypoint.dto.request.SignUpRequest;
 import com.klp.authservice.auth.entrypoint.dto.response.LoginResponse;
+import com.klp.authservice.auth.infrastructure.jwt.RefreshTokenCookieFactory;
+import com.klp.authservice.auth.infrastructure.jwt.TokenProvider;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final TokenProvider refreshTokenProvider;
 
     @PostMapping("/signUp")
     public ResponseEntity<Void> signUp(@Valid @RequestBody SignUpRequest request) {
@@ -27,6 +31,14 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
-        return ResponseEntity.ok().body(authService.login(request.toCommand()));
+        LoginResponse response = authService.login(request.toCommand());
+
+        String refreshToken = refreshTokenProvider.generate(response.userId(), response.userName(), response.role());
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, RefreshTokenCookieFactory.create(refreshToken).toString());
+
+        return ResponseEntity.ok()
+            .headers(headers)
+            .body(response);
     }
 }

--- a/auth-service/src/main/java/com/klp/authservice/auth/entrypoint/controller/AuthController.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/entrypoint/controller/AuthController.java
@@ -6,7 +6,6 @@ import com.klp.authservice.auth.entrypoint.dto.request.LoginRequest;
 import com.klp.authservice.auth.entrypoint.dto.request.SignUpRequest;
 import com.klp.authservice.auth.entrypoint.dto.response.LoginResponse;
 import com.klp.authservice.auth.entrypoint.dto.response.ReissueResponse;
-import com.klp.authservice.auth.infrastructure.jwt.JwtParser;
 import com.klp.authservice.auth.infrastructure.jwt.RefreshTokenCookieFactory;
 import com.klp.authservice.auth.infrastructure.jwt.TokenExtractor;
 import com.klp.authservice.auth.infrastructure.jwt.TokenProvider;
@@ -19,7 +18,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -52,11 +50,13 @@ public class AuthController {
 
     @PostMapping("/logout")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<Void> logout(@RequestHeader("Authorization") String authorization) {
-        String accessToken = JwtParser.extractAccessToken(authorization)
+    public ResponseEntity<Void> logout(HttpServletRequest request) {
+        String accessToken = TokenExtractor.extractAccessToken(request)
             .orElseThrow(() -> new BusinessException(AuthErrorCode.TOKEN_NOT_FOUND));
+        String refreshToken = TokenExtractor.extractRefreshToken(request)
+            .orElse(null);
 
-        authService.logout(accessToken);
+        authService.logout(accessToken, refreshToken);
 
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.SET_COOKIE, RefreshTokenCookieFactory.invalidate().toString());
@@ -68,10 +68,13 @@ public class AuthController {
 
     @PostMapping("/token/reissue")
     public ResponseEntity<ReissueResponse> reissue(HttpServletRequest request) {
+        String accessToken = TokenExtractor.extractAccessToken(request)
+            .orElse(null);
         String refreshToken = TokenExtractor.extractRefreshToken(request)
             .orElseThrow(() -> new BusinessException(AuthErrorCode.TOKEN_NOT_FOUND));
 
-        ReissueResponse response = authService.reissue(refreshToken);
+        ReissueResponse response = authService.reissue(accessToken, refreshToken);
+
         String newRefreshToken = refreshTokenProvider.generate(response.userId(), response.userName(), response.role());
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.SET_COOKIE, RefreshTokenCookieFactory.create(newRefreshToken).toString());

--- a/auth-service/src/main/java/com/klp/authservice/auth/entrypoint/controller/AuthController.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/entrypoint/controller/AuthController.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -50,6 +51,7 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<Void> logout(@RequestHeader("Authorization") String authorization) {
         String accessToken = authorization.substring(AUTHORIZATION_PREFIX_LENGTH);
         authService.logout(accessToken);

--- a/auth-service/src/main/java/com/klp/authservice/auth/entrypoint/controller/AuthController.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/entrypoint/controller/AuthController.java
@@ -1,16 +1,18 @@
 package com.klp.authservice.auth.entrypoint.controller;
 
+import com.klp.authservice.auth.AuthErrorCode;
 import com.klp.authservice.auth.application.AuthService;
 import com.klp.authservice.auth.entrypoint.dto.request.LoginRequest;
 import com.klp.authservice.auth.entrypoint.dto.request.SignUpRequest;
 import com.klp.authservice.auth.entrypoint.dto.response.LoginResponse;
 import com.klp.authservice.auth.entrypoint.dto.response.ReissueResponse;
+import com.klp.authservice.auth.infrastructure.jwt.JwtParser;
 import com.klp.authservice.auth.infrastructure.jwt.RefreshTokenCookieFactory;
+import com.klp.authservice.auth.infrastructure.jwt.TokenExtractor;
 import com.klp.authservice.auth.infrastructure.jwt.TokenProvider;
-import jakarta.servlet.http.Cookie;
+import com.klp.common.exception.BusinessException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -28,8 +30,6 @@ public class AuthController {
 
     private final AuthService authService;
     private final TokenProvider refreshTokenProvider;
-
-    private static final int AUTHORIZATION_PREFIX_LENGTH = 7;
 
     @PostMapping("/signUp")
     public ResponseEntity<Void> signUp(@Valid @RequestBody SignUpRequest request) {
@@ -53,7 +53,9 @@ public class AuthController {
     @PostMapping("/logout")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<Void> logout(@RequestHeader("Authorization") String authorization) {
-        String accessToken = authorization.substring(AUTHORIZATION_PREFIX_LENGTH);
+        String accessToken = JwtParser.extractAccessToken(authorization)
+            .orElseThrow(() -> new BusinessException(AuthErrorCode.TOKEN_NOT_FOUND));
+
         authService.logout(accessToken);
 
         HttpHeaders headers = new HttpHeaders();
@@ -66,11 +68,8 @@ public class AuthController {
 
     @PostMapping("/token/reissue")
     public ResponseEntity<ReissueResponse> reissue(HttpServletRequest request) {
-        String refreshToken = Arrays.stream(request.getCookies())
-            .filter(cookie -> "refreshToken".equals(cookie.getName()))
-            .findFirst()
-            .map(Cookie::getValue)
-            .orElse(null);
+        String refreshToken = TokenExtractor.extractRefreshToken(request)
+            .orElseThrow(() -> new BusinessException(AuthErrorCode.TOKEN_NOT_FOUND));
 
         ReissueResponse response = authService.reissue(refreshToken);
         String newRefreshToken = refreshTokenProvider.generate(response.userId(), response.userName(), response.role());

--- a/auth-service/src/main/java/com/klp/authservice/auth/entrypoint/dto/request/LoginRequest.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/entrypoint/dto/request/LoginRequest.java
@@ -1,0 +1,19 @@
+package com.klp.authservice.auth.entrypoint.dto.request;
+
+import com.klp.authservice.auth.application.command.LoginCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record LoginRequest(
+    @NotBlank(message = "사용자 이름은 필수입니다")
+    @Pattern(regexp = "^[a-z0-9]{4,10}$", message = "유저 이름은 4자 이상, 10자 이하이며 알파벳 소문자, 숫자로만 구성 가능합니다")
+    String userName,
+
+    @NotBlank(message = "비밀번호는 필수입니다")
+    String password
+) {
+
+    public LoginCommand toCommand() {
+        return new LoginCommand(userName, password);
+    }
+}

--- a/auth-service/src/main/java/com/klp/authservice/auth/entrypoint/dto/response/LoginResponse.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/entrypoint/dto/response/LoginResponse.java
@@ -1,0 +1,10 @@
+package com.klp.authservice.auth.entrypoint.dto.response;
+
+public record LoginResponse(
+    Long userId,
+    String userName,
+    String role,
+    String accessToken
+) {
+
+}

--- a/auth-service/src/main/java/com/klp/authservice/auth/entrypoint/dto/response/ReissueResponse.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/entrypoint/dto/response/ReissueResponse.java
@@ -1,0 +1,10 @@
+package com.klp.authservice.auth.entrypoint.dto.response;
+
+public record ReissueResponse(
+    Long userId,
+    String userName,
+    String role,
+    String accessToken
+) {
+
+}

--- a/auth-service/src/main/java/com/klp/authservice/auth/exception/AuthErrorCode.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/exception/AuthErrorCode.java
@@ -1,4 +1,4 @@
-package com.klp.authservice.auth;
+package com.klp.authservice.auth.exception;
 
 import com.klp.common.exception.ErrorCode;
 import lombok.Getter;

--- a/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/external/UserClientImpl.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/external/UserClientImpl.java
@@ -3,6 +3,7 @@ package com.klp.authservice.auth.infrastructure.external;
 import com.klp.authservice.auth.AuthErrorCode;
 import com.klp.authservice.auth.application.client.UserClient;
 import com.klp.authservice.auth.infrastructure.external.dto.request.UserCreateRequest;
+import com.klp.authservice.auth.infrastructure.external.dto.response.UserDataDTO;
 import com.klp.common.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -56,6 +57,26 @@ public class UserClientImpl implements UserClient {
                 .toBodilessEntity();
         } catch (HttpClientErrorException e) {
             log.error("유저 생성 요청 실패: status: {}", e.getStatusCode());
+            throw new BusinessException(AuthErrorCode.USER_SERVICE_ERROR);
+
+        } catch (HttpServerErrorException e) {
+            log.error("유저 서비스 오류 발생: status: {}", e.getStatusCode());
+            throw new BusinessException(AuthErrorCode.USER_SERVICE_INTERNAL_ERROR);
+        }
+    }
+
+    @Override
+    public UserDataDTO getUserByUserName(String userName) {
+        try {
+            return userRestClient.get()
+                .uri(uriBuilder -> uriBuilder.path("/v1/users")
+                    .queryParam("username", userName)
+                    .build())
+                .retrieve()
+                .body(UserDataDTO.class);
+
+        } catch (HttpClientErrorException e) {
+            log.error("유저 정보 조회 요청 실패: status: {}", e.getStatusCode());
             throw new BusinessException(AuthErrorCode.USER_SERVICE_ERROR);
 
         } catch (HttpServerErrorException e) {

--- a/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/external/UserClientImpl.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/external/UserClientImpl.java
@@ -1,7 +1,7 @@
 package com.klp.authservice.auth.infrastructure.external;
 
-import com.klp.authservice.auth.AuthErrorCode;
 import com.klp.authservice.auth.application.client.UserClient;
+import com.klp.authservice.auth.exception.AuthErrorCode;
 import com.klp.authservice.auth.infrastructure.external.dto.request.UserCreateRequest;
 import com.klp.authservice.auth.infrastructure.external.dto.response.UserDataDTO;
 import com.klp.common.exception.BusinessException;

--- a/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/external/dto/response/UserDataDTO.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/external/dto/response/UserDataDTO.java
@@ -1,0 +1,10 @@
+package com.klp.authservice.auth.infrastructure.external.dto.response;
+
+public record UserDataDTO(
+    Long userId,
+    String userName,
+    String password,
+    String role
+) {
+
+}

--- a/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jpa/model/BaseEntity.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jpa/model/BaseEntity.java
@@ -1,0 +1,53 @@
+package com.klp.authservice.auth.infrastructure.jpa.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.hibernate.annotations.Comment;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    @Comment("생성 시간")
+    private LocalDateTime createdAt;
+
+    @CreatedBy
+    @Column(updatable = false)
+    @Comment("생성자")
+    private Long createdBy;
+
+    @LastModifiedDate
+    @Comment("수정 시간")
+    private LocalDateTime updatedAt;
+
+    @LastModifiedBy
+    @Comment("수정자")
+    private Long updatedBy;
+
+    @Comment("삭제 시간")
+    private LocalDateTime deletedAt;
+
+    @Comment("삭제자")
+    private Long deletedBy;
+
+    public void delete(Long deletedBy) {
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = deletedBy;
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+
+}

--- a/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/AccessTokenProvider.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/AccessTokenProvider.java
@@ -60,6 +60,28 @@ public class AccessTokenProvider implements TokenProvider {
     }
 
     @Override
+    public String getUserId(String token) {
+        return Jwts
+            .parser()
+            .verifyWith(accessSecretKey)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload()
+            .getSubject();
+    }
+
+    @Override
+    public String getUserName(String token) {
+        return Jwts
+            .parser()
+            .verifyWith(accessSecretKey)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload()
+            .get(JwtConstants.USERNAME_CLAIM, String.class);
+    }
+
+    @Override
     public String getRole(String token) {
         return Jwts
             .parser()

--- a/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/AccessTokenProvider.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/AccessTokenProvider.java
@@ -1,9 +1,12 @@
 package com.klp.authservice.auth.infrastructure.jwt;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 import javax.crypto.SecretKey;
 import org.springframework.beans.factory.annotation.Value;
@@ -40,5 +43,45 @@ public class AccessTokenProvider implements TokenProvider {
             .expiration(new Date(System.currentTimeMillis() + accessExpiration))
             .signWith(accessSecretKey)
             .compact();
+    }
+
+    @Override
+    public boolean validateToken(String token) {
+        try {
+            Jwts
+                .parser()
+                .verifyWith(accessSecretKey)
+                .build()
+                .parseSignedClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public String getRole(String token) {
+        return Jwts
+            .parser()
+            .verifyWith(accessSecretKey)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload()
+            .get(JwtConstants.ROLE_CLAIM, String.class);
+    }
+
+    @Override
+    public LocalDateTime getExpiration(String token) {
+        Claims claims = Jwts
+            .parser()
+            .verifyWith(accessSecretKey)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload();
+
+        return claims.getExpiration()
+            .toInstant()
+            .atZone(ZoneId.systemDefault())
+            .toLocalDateTime();
     }
 }

--- a/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/AccessTokenProvider.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/AccessTokenProvider.java
@@ -1,0 +1,44 @@
+package com.klp.authservice.auth.infrastructure.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AccessTokenProvider implements TokenProvider {
+
+    @Value("${jwt.access.secret}")
+    private String accessSecret;
+    @Value("${jwt.access.expiration}")
+    private Long accessExpiration;
+
+    private SecretKey accessSecretKey;
+
+    @PostConstruct
+    public void init() {
+        this.accessSecretKey = Keys.hmacShaKeyFor(accessSecret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public String generate(Long userId, String userName, String role) {
+        return Jwts
+            .builder()
+            .header()
+            .type(JwtConstants.HEADER_TYPE)
+            .and()
+            .issuer(JwtConstants.ISSUER)
+            .subject(userId.toString())
+            .claim(JwtConstants.TOKEN_TYPE_CLAIM, JwtConstants.ACCESS_TOKEN_TYPE)
+            .claim(JwtConstants.USERNAME_CLAIM, userName)
+            .claim(JwtConstants.ROLE_CLAIM, role)
+            .issuedAt(new Date())
+            .expiration(new Date(System.currentTimeMillis() + accessExpiration))
+            .signWith(accessSecretKey)
+            .compact();
+    }
+}

--- a/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/JwtConstants.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/JwtConstants.java
@@ -13,5 +13,5 @@ public final class JwtConstants {
     public static final String ROLE_CLAIM = "role";
     public static final String ACCESS_TOKEN_TYPE = "access";
     public static final String REFRESH_TOKEN_TYPE = "refresh";
-    
+    public static final String REFRESH_TOKEN_COOKIE_NAME = "Refresh-Token";
 }

--- a/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/JwtConstants.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/JwtConstants.java
@@ -14,4 +14,6 @@ public final class JwtConstants {
     public static final String ACCESS_TOKEN_TYPE = "access";
     public static final String REFRESH_TOKEN_TYPE = "refresh";
     public static final String REFRESH_TOKEN_COOKIE_NAME = "Refresh-Token";
+    public static final String TOKEN_PREFIX = "Bearer ";
+    public static final int TOKEN_PREFIX_LENGTH = 7;
 }

--- a/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/JwtConstants.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/JwtConstants.java
@@ -1,0 +1,17 @@
+package com.klp.authservice.auth.infrastructure.jwt;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class JwtConstants {
+
+    public static final String HEADER_TYPE = "JWT";
+    public static final String ISSUER = "KLP-BE";
+    public static final String TOKEN_TYPE_CLAIM = "tokenType";
+    public static final String USERNAME_CLAIM = "username";
+    public static final String ROLE_CLAIM = "role";
+    public static final String ACCESS_TOKEN_TYPE = "access";
+    public static final String REFRESH_TOKEN_TYPE = "refresh";
+    
+}

--- a/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/JwtParser.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/JwtParser.java
@@ -1,0 +1,25 @@
+package com.klp.authservice.auth.infrastructure.jwt;
+
+import java.util.Map;
+import java.util.Optional;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class JwtParser {
+
+    private static final String REFRESH_TOKEN_COOKIE_NAME = "Refresh-Token";
+
+    public static Optional<String> extractAccessToken(String authorizationHeader) {
+        return Optional.ofNullable(authorizationHeader)
+            .filter(header -> header.startsWith(JwtConstants.TOKEN_PREFIX))
+            .map(header -> header.substring(JwtConstants.TOKEN_PREFIX_LENGTH))
+            .filter(token -> !token.isEmpty());
+    }
+
+    public static Optional<String> extractRefreshToken(Map<String, String> cookies) {
+        return Optional.ofNullable(cookies)
+            .map(map -> map.get(REFRESH_TOKEN_COOKIE_NAME))
+            .filter(token -> !token.isEmpty());
+    }
+}

--- a/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/RefreshTokenCookieFactory.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/RefreshTokenCookieFactory.java
@@ -1,0 +1,31 @@
+package com.klp.authservice.auth.infrastructure.jwt;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.http.ResponseCookie;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RefreshTokenCookieFactory {
+
+    public static ResponseCookie create(String refreshToken) {
+        return ResponseCookie
+            .from(JwtConstants.REFRESH_TOKEN_COOKIE_NAME, refreshToken)
+            .httpOnly(true)
+            .secure(false)
+            .path("/")
+            .maxAge(60 * 60 * 24 * 7L)
+            .sameSite("Lax")
+            .build();
+    }
+
+    public static ResponseCookie invalidate() {
+        return ResponseCookie
+            .from(JwtConstants.REFRESH_TOKEN_COOKIE_NAME, "")
+            .httpOnly(true)
+            .secure(false)
+            .path("/")
+            .maxAge(0)
+            .sameSite("Lax")
+            .build();
+    }
+}

--- a/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/RefreshTokenProvider.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/RefreshTokenProvider.java
@@ -60,6 +60,28 @@ public class RefreshTokenProvider implements TokenProvider {
     }
 
     @Override
+    public String getUserId(String token) {
+        return Jwts
+            .parser()
+            .verifyWith(refreshSecretKey)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload()
+            .getSubject();
+    }
+
+    @Override
+    public String getUserName(String token) {
+        return Jwts
+            .parser()
+            .verifyWith(refreshSecretKey)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload()
+            .get(JwtConstants.USERNAME_CLAIM, String.class);
+    }
+
+    @Override
     public String getRole(String token) {
         return Jwts
             .parser()

--- a/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/RefreshTokenProvider.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/RefreshTokenProvider.java
@@ -1,9 +1,12 @@
 package com.klp.authservice.auth.infrastructure.jwt;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 import javax.crypto.SecretKey;
 import org.springframework.beans.factory.annotation.Value;
@@ -40,5 +43,45 @@ public class RefreshTokenProvider implements TokenProvider {
             .expiration(new Date(System.currentTimeMillis() + refreshExpiration))
             .signWith(refreshSecretKey)
             .compact();
+    }
+
+    @Override
+    public boolean validateToken(String token) {
+        try {
+            Jwts
+                .parser()
+                .verifyWith(refreshSecretKey)
+                .build()
+                .parseSignedClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public String getRole(String token) {
+        return Jwts
+            .parser()
+            .verifyWith(refreshSecretKey)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload()
+            .get(JwtConstants.ROLE_CLAIM, String.class);
+    }
+
+    @Override
+    public LocalDateTime getExpiration(String token) {
+        Claims claims = Jwts
+            .parser()
+            .verifyWith(refreshSecretKey)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload();
+
+        return claims.getExpiration()
+            .toInstant()
+            .atZone(ZoneId.systemDefault())
+            .toLocalDateTime();
     }
 }

--- a/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/RefreshTokenProvider.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/RefreshTokenProvider.java
@@ -1,0 +1,44 @@
+package com.klp.authservice.auth.infrastructure.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RefreshTokenProvider implements TokenProvider {
+
+    @Value("${jwt.refresh.secret}")
+    private String refreshSecret;
+    @Value("${jwt.refresh.expiration}")
+    private Long refreshExpiration;
+
+    private SecretKey refreshSecretKey;
+
+    @PostConstruct
+    public void init() {
+        this.refreshSecretKey = Keys.hmacShaKeyFor(refreshSecret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public String generate(Long userId, String userName, String role) {
+        return Jwts
+            .builder()
+            .header()
+            .type(JwtConstants.HEADER_TYPE)
+            .and()
+            .issuer(JwtConstants.ISSUER)
+            .subject(userId.toString())
+            .claim(JwtConstants.TOKEN_TYPE_CLAIM, JwtConstants.REFRESH_TOKEN_TYPE)
+            .claim(JwtConstants.USERNAME_CLAIM, userName)
+            .claim(JwtConstants.ROLE_CLAIM, role)
+            .issuedAt(new Date())
+            .expiration(new Date(System.currentTimeMillis() + refreshExpiration))
+            .signWith(refreshSecretKey)
+            .compact();
+    }
+}

--- a/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/TokenExtractor.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/TokenExtractor.java
@@ -1,0 +1,24 @@
+package com.klp.authservice.auth.infrastructure.jwt;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class TokenExtractor {
+    
+    public static Optional<String> extractRefreshToken(HttpServletRequest request) {
+        Map<String, String> cookies = Optional.ofNullable(request.getCookies())
+            .map(cookieArray -> Arrays.stream(cookieArray)
+                .collect(Collectors.toMap(Cookie::getName, Cookie::getValue)))
+            .orElse(Collections.emptyMap());
+
+        return JwtParser.extractRefreshToken(cookies);
+    }
+}

--- a/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/TokenExtractor.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/TokenExtractor.java
@@ -9,10 +9,16 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.http.HttpHeaders;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class TokenExtractor {
-    
+
+    public static Optional<String> extractAccessToken(HttpServletRequest request) {
+        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        return JwtParser.extractAccessToken(authorizationHeader);
+    }
+
     public static Optional<String> extractRefreshToken(HttpServletRequest request) {
         Map<String, String> cookies = Optional.ofNullable(request.getCookies())
             .map(cookieArray -> Arrays.stream(cookieArray)

--- a/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/TokenProvider.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/TokenProvider.java
@@ -1,6 +1,14 @@
 package com.klp.authservice.auth.infrastructure.jwt;
 
+import java.time.LocalDateTime;
+
 public interface TokenProvider {
 
     String generate(Long userId, String userName, String role);
+
+    boolean validateToken(String token);
+
+    String getRole(String token);
+
+    LocalDateTime getExpiration(String token);
 }

--- a/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/TokenProvider.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/TokenProvider.java
@@ -8,6 +8,10 @@ public interface TokenProvider {
 
     boolean validateToken(String token);
 
+    String getUserId(String token);
+
+    String getUserName(String token);
+
     String getRole(String token);
 
     LocalDateTime getExpiration(String token);

--- a/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/TokenProvider.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/jwt/TokenProvider.java
@@ -1,0 +1,6 @@
+package com.klp.authservice.auth.infrastructure.jwt;
+
+public interface TokenProvider {
+
+    String generate(Long userId, String userName, String role);
+}

--- a/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/repository/BlackListTokenJpaRepository.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/repository/BlackListTokenJpaRepository.java
@@ -1,0 +1,10 @@
+package com.klp.authservice.auth.infrastructure.repository;
+
+import com.klp.authservice.auth.domain.entity.BlackListToken;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlackListTokenJpaRepository extends JpaRepository<BlackListToken, UUID> {
+
+    boolean existsByToken(String token);
+}

--- a/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/repository/BlackListTokenRepositoryImpl.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/infrastructure/repository/BlackListTokenRepositoryImpl.java
@@ -1,0 +1,23 @@
+package com.klp.authservice.auth.infrastructure.repository;
+
+import com.klp.authservice.auth.domain.entity.BlackListToken;
+import com.klp.authservice.auth.domain.repository.BlackListTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BlackListTokenRepositoryImpl implements BlackListTokenRepository {
+
+    private final BlackListTokenJpaRepository blackListTokenJpaRepository;
+
+    @Override
+    public BlackListToken save(BlackListToken token) {
+        return blackListTokenJpaRepository.save(token);
+    }
+
+    @Override
+    public boolean existsByToken(String token) {
+        return blackListTokenJpaRepository.existsByToken(token);
+    }
+}

--- a/auth-service/src/main/java/com/klp/authservice/common/model/BaseEntity.java
+++ b/auth-service/src/main/java/com/klp/authservice/common/model/BaseEntity.java
@@ -1,4 +1,4 @@
-package com.klp.authservice.auth.infrastructure.jpa.model;
+package com.klp.authservice.common.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;

--- a/auth-service/src/main/java/com/klp/authservice/global/exception/GlobalExceptionHandler.java
+++ b/auth-service/src/main/java/com/klp/authservice/global/exception/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.klp.authservice.auth.infrastructure.exception;
+package com.klp.authservice.global.exception;
 
 import com.klp.common.exception.BusinessException;
 import com.klp.common.exception.ErrorResponse;

--- a/auth-service/src/main/java/com/klp/authservice/global/security/config/SecurityConfig.java
+++ b/auth-service/src/main/java/com/klp/authservice/global/security/config/SecurityConfig.java
@@ -1,6 +1,6 @@
-package com.klp.authservice.auth.infrastructure.security.config;
+package com.klp.authservice.global.security.config;
 
-import com.klp.authservice.auth.infrastructure.security.filter.AuthorizationFilter;
+import com.klp.authservice.global.security.filter.AuthorizationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/auth-service/src/main/java/com/klp/authservice/global/security/filter/AuthorizationFilter.java
+++ b/auth-service/src/main/java/com/klp/authservice/global/security/filter/AuthorizationFilter.java
@@ -1,6 +1,6 @@
-package com.klp.authservice.auth.infrastructure.security.filter;
+package com.klp.authservice.global.security.filter;
 
-import com.klp.authservice.auth.infrastructure.security.model.UserDetailsImpl;
+import com.klp.authservice.global.security.model.UserDetailsImpl;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/auth-service/src/main/java/com/klp/authservice/global/security/model/UserDetailsImpl.java
+++ b/auth-service/src/main/java/com/klp/authservice/global/security/model/UserDetailsImpl.java
@@ -1,4 +1,4 @@
-package com.klp.authservice.auth.infrastructure.security.model;
+package com.klp.authservice.global.security.model;
 
 import java.util.Collection;
 import java.util.List;

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -4,6 +4,18 @@ server:
 spring:
   application:
     name: auth-service
+  datasource:
+    url: jdbc:postgresql://localhost:5432/logistics
+    username: kimleepark
+    password: kimleepark
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create
+    open-in-view: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
 
 jwt:
   access:

--- a/auth-service/src/test/java/com/klp/authservice/auth/application/AuthServiceTest.java
+++ b/auth-service/src/test/java/com/klp/authservice/auth/application/AuthServiceTest.java
@@ -17,16 +17,17 @@ import com.klp.authservice.auth.domain.entity.BlackListToken;
 import com.klp.authservice.auth.domain.enums.AffiliationType;
 import com.klp.authservice.auth.domain.repository.BlackListTokenRepository;
 import com.klp.authservice.auth.entrypoint.dto.response.LoginResponse;
+import com.klp.authservice.auth.entrypoint.dto.response.ReissueResponse;
 import com.klp.authservice.auth.infrastructure.external.dto.request.UserCreateRequest;
 import com.klp.authservice.auth.infrastructure.external.dto.response.UserDataDTO;
 import com.klp.authservice.auth.infrastructure.jwt.TokenProvider;
 import com.klp.common.exception.BusinessException;
 import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -44,10 +45,24 @@ class AuthServiceTest {
     private TokenProvider accessTokenProvider;
 
     @Mock
+    private TokenProvider refreshTokenProvider;
+
+    @Mock
     private BlackListTokenRepository blackListTokenRepository;
 
-    @InjectMocks
     private AuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        authService = new AuthService(
+            userClient,
+            passwordEncoder,
+            accessTokenProvider,
+            refreshTokenProvider,
+            blackListTokenRepository
+        );
+    }
+
 
     @Nested
     @DisplayName("SignUp 메소드 실패 테스트")
@@ -312,6 +327,78 @@ class AuthServiceTest {
             assertThatThrownBy(() -> authService.logout(invalidToken))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(AuthErrorCode.INVALID_TOKEN.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("Reissue 메소드 테스트")
+    class ReissueTest {
+
+        @Test
+        @DisplayName("유효한 RT로 새 AT,RT 발급에 성공한다")
+        void reissue_success() {
+            // given
+            String refreshToken = "valid.refresh.token";
+            Long userId = 1L;
+            String userName = "testuser";
+            String role = "MASTER";
+            String newAccessToken = "new.access.token";
+
+            when(refreshTokenProvider.validateToken(refreshToken)).thenReturn(true);
+            when(blackListTokenRepository.existsByToken(refreshToken)).thenReturn(false);
+            when(refreshTokenProvider.getUserId(refreshToken)).thenReturn(String.valueOf(userId));
+            when(refreshTokenProvider.getUserName(refreshToken)).thenReturn(userName);
+            when(refreshTokenProvider.getRole(refreshToken)).thenReturn(role);
+            when(refreshTokenProvider.getExpiration(refreshToken)).thenReturn(LocalDateTime.now().plusDays(7));
+            when(accessTokenProvider.generate(userId, userName, role)).thenReturn(
+                newAccessToken);
+
+            // when
+            ReissueResponse response = authService.reissue(refreshToken);
+
+            // then
+            assertThat(response.userId()).isEqualTo(userId);
+            assertThat(response.userName()).isEqualTo(userName);
+            assertThat(response.role()).isEqualTo(role);
+            assertThat(response.accessToken()).isEqualTo(newAccessToken);
+
+            verify(refreshTokenProvider).validateToken(refreshToken);
+            verify(blackListTokenRepository).existsByToken(refreshToken);
+            verify(refreshTokenProvider).getUserId(refreshToken);
+            verify(refreshTokenProvider).getUserName(refreshToken);
+            verify(refreshTokenProvider).getRole(refreshToken);
+            verify(refreshTokenProvider).getExpiration(refreshToken);
+            verify(blackListTokenRepository).save(any(BlackListToken.class));
+            verify(accessTokenProvider).generate(userId, userName, role);
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 RT로는 새 토큰 발급에 실패한다")
+        void invalidRefreshToken_fail() {
+            // given
+            String invalidToken = "invalid.refresh.token";
+
+            when(refreshTokenProvider.validateToken(invalidToken)).thenReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> authService.reissue(invalidToken))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(AuthErrorCode.INVALID_TOKEN.getMessage());
+        }
+
+        @Test
+        @DisplayName("금지된 토큰이 존재한다면 새 토큰 발급에 실패한다")
+        void blackListTokenExist_fail() {
+            // given
+            String blacklistedToken = "blacklisted.refresh.token";
+
+            when(refreshTokenProvider.validateToken(blacklistedToken)).thenReturn(true);
+            when(blackListTokenRepository.existsByToken(blacklistedToken)).thenReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> authService.reissue(blacklistedToken))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(AuthErrorCode.TOKEN_ALREADY_BLACKLISTED.getMessage());
         }
     }
 }

--- a/auth-service/src/test/java/com/klp/authservice/auth/application/AuthServiceTest.java
+++ b/auth-service/src/test/java/com/klp/authservice/auth/application/AuthServiceTest.java
@@ -285,6 +285,7 @@ class AuthServiceTest {
             String accessToken = "valid.access.token";
             String role = "COMPANY";
 
+            when(accessTokenProvider.validateToken(accessToken)).thenReturn(true);
             when(accessTokenProvider.getRole(accessToken)).thenReturn(role);
 
             // when

--- a/auth-service/src/test/java/com/klp/authservice/auth/application/AuthServiceTest.java
+++ b/auth-service/src/test/java/com/klp/authservice/auth/application/AuthServiceTest.java
@@ -13,12 +13,15 @@ import com.klp.authservice.auth.AuthErrorCode;
 import com.klp.authservice.auth.application.client.UserClient;
 import com.klp.authservice.auth.application.command.LoginCommand;
 import com.klp.authservice.auth.application.command.SignUpCommand;
+import com.klp.authservice.auth.domain.entity.BlackListToken;
 import com.klp.authservice.auth.domain.enums.AffiliationType;
+import com.klp.authservice.auth.domain.repository.BlackListTokenRepository;
 import com.klp.authservice.auth.entrypoint.dto.response.LoginResponse;
 import com.klp.authservice.auth.infrastructure.external.dto.request.UserCreateRequest;
 import com.klp.authservice.auth.infrastructure.external.dto.response.UserDataDTO;
 import com.klp.authservice.auth.infrastructure.jwt.TokenProvider;
 import com.klp.common.exception.BusinessException;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -39,6 +42,9 @@ class AuthServiceTest {
 
     @Mock
     private TokenProvider accessTokenProvider;
+
+    @Mock
+    private BlackListTokenRepository blackListTokenRepository;
 
     @InjectMocks
     private AuthService authService;
@@ -209,6 +215,103 @@ class AuthServiceTest {
             verify(userClient).getUserByUserName(userName);
             verify(passwordEncoder).matches(password, encodedPassword);
             verify(accessTokenProvider, never()).generate(any(), any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("Logout 메소드 테스트")
+    class LogoutTest {
+
+        @Test
+        @DisplayName("로그아웃에 성공한다. MASTER 유저의 토큰은 블랙리스트 토큰으로 등록된다")
+        void logout_master_success() {
+            // given
+            String accessToken = "valid.access.token";
+            String role = "MASTER";
+            LocalDateTime expiration = LocalDateTime.now().plusHours(1);
+
+            when(accessTokenProvider.validateToken(accessToken)).thenReturn(true);
+            when(accessTokenProvider.getRole(accessToken)).thenReturn(role);
+            when(accessTokenProvider.getExpiration(accessToken)).thenReturn(expiration);
+
+            // when
+            authService.logout(accessToken);
+
+            // then
+            verify(accessTokenProvider).getRole(accessToken);
+            verify(accessTokenProvider).getExpiration(accessToken);
+            verify(blackListTokenRepository).save(any(BlackListToken.class));
+        }
+
+        @Test
+        @DisplayName("로그아웃에 성공한다. HUB 유저의 토큰은 블랙리스트 토큰으로 등록된다")
+        void logout_hub_success() {
+            // given
+            String accessToken = "valid.access.token";
+            String role = "HUB";
+            LocalDateTime expiration = LocalDateTime.now().plusHours(1);
+
+            when(accessTokenProvider.validateToken(accessToken)).thenReturn(true);
+            when(accessTokenProvider.getRole(accessToken)).thenReturn(role);
+            when(accessTokenProvider.getExpiration(accessToken)).thenReturn(expiration);
+
+            // when
+            authService.logout(accessToken);
+
+            // then
+            verify(blackListTokenRepository).save(any(BlackListToken.class));
+        }
+
+        @Test
+        @DisplayName("로그아웃에 성공한다. MASTER, HUB 권한이 아닌 유저의 토큰은 블랙리스트 토큰으로 등록되지 않는다")
+        void logout_normal_success() {
+            // given
+            String accessToken = "valid.access.token";
+            String role = "COMPANY";
+
+            when(accessTokenProvider.getRole(accessToken)).thenReturn(role);
+
+            // when
+            authService.logout(accessToken);
+
+            // then
+            verify(accessTokenProvider).getRole(accessToken);
+            verify(blackListTokenRepository, never()).save(any());
+            verify(accessTokenProvider, never()).getExpiration(any());
+        }
+
+        @Test
+        @DisplayName("이미 블랙리스트에 있는 토큰은 중복 저장하지 않는다")
+        void alreadyBlacklisted_fail() {
+            // given
+            String role = "MASTER";
+            String accessToken = "valid.access.token";
+
+            when(accessTokenProvider.validateToken(accessToken)).thenReturn(true);
+            when(accessTokenProvider.getRole(accessToken)).thenReturn(role);
+            when(blackListTokenRepository.existsByToken(accessToken)).thenReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> authService.logout(accessToken))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(AuthErrorCode.TOKEN_ALREADY_BLACKLISTED.getMessage());
+
+            verify(blackListTokenRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 토큰으로 로그아웃 실패")
+        void invalidToken_fail() {
+            // given
+            String invalidToken = "invalid.token";
+
+            when(accessTokenProvider.validateToken(invalidToken))
+                .thenThrow(new BusinessException(AuthErrorCode.INVALID_TOKEN));
+
+            // when & then
+            assertThatThrownBy(() -> authService.logout(invalidToken))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(AuthErrorCode.INVALID_TOKEN.getMessage());
         }
     }
 }

--- a/auth-service/src/test/java/com/klp/authservice/auth/application/AuthServiceTest.java
+++ b/auth-service/src/test/java/com/klp/authservice/auth/application/AuthServiceTest.java
@@ -247,6 +247,7 @@ class AuthServiceTest {
 
             when(accessTokenProvider.validateToken(accessToken)).thenReturn(true);
             when(accessTokenProvider.getRole(accessToken)).thenReturn(role);
+            when(blackListTokenRepository.existsByToken(accessToken)).thenReturn(false);
             when(accessTokenProvider.getExpiration(accessToken)).thenReturn(expiration);
 
             // when

--- a/auth-service/src/test/java/com/klp/authservice/auth/application/AuthServiceTest.java
+++ b/auth-service/src/test/java/com/klp/authservice/auth/application/AuthServiceTest.java
@@ -117,4 +117,95 @@ class AuthServiceTest {
             verify(userClient).createUser(request);
         }
     }
+
+    @Nested
+    @DisplayName("Login 메소드 테스트")
+    class LoginTest {
+
+        @Test
+        @DisplayName("로그인에 성공한다")
+        void login_success() {
+            // given
+            String userName = "testuser";
+            String password = "Password1!";
+            String encodedPassword = "encodedPassword";
+            String role = "MASTER";
+            String slackId = " slackId";
+            String affiliationName = "testCompany";
+            AffiliationType affiliationType = AffiliationType.COMPANY;
+            String accessToken = "access.token.data";
+
+            LoginCommand command = new LoginCommand(userName, password);
+            UserDataDTO dto = new UserDataDTO(userName, encodedPassword, role, slackId, affiliationName,
+                affiliationType, accessToken);
+
+            when(userClient.getUserByUserName()).thenReturn(dto);
+            when(passwordEncoder.matches(password, encodedPassword)).thenReturn(true);
+            when(accessTokenProvider.generate(userName, role)).thenReturn(accessToken);
+
+            // when
+            LoginResponse response = authService.login(userName, password);
+
+            // then
+            assertThat(response.userName()).isEqualTo(userName);
+            assertThat(response.role()).isEqualTo(role);
+            assertThat(response.slackId()).isEqualTo(slackId);
+            assertThat(response.affiliationName()).isEqualTo(affiliationName);
+            assertThat(response.affiliationType()).isEqualTo(affiliationType.name());
+            assertThat(response.accessToken()).isEqualTo(accessToken);
+
+            verify(userClient).getUserByUserName(userName);
+            verify(passwordEncoder).matches(password, encodedPassword);
+            verify(accessTokenProvider).generateAccessToken(userName, role);
+
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 사용자는 로그인에 실패한다")
+        void notExistUser_fail() {
+            // given
+            String userName = "notExistUser";
+            String password = "Password1!";
+            LoginCommand command = new LoginCommand(userName, password);
+
+            // when
+            when(userClient.getUserByUserName(userName))
+                .thenThrow(new BusinessException(AuthErrorCode.USER_NOT_FOUND));
+
+            // then
+            assertThatThrownBy(() -> authService.login(commnad))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(AuthErrorCode.USER_NOT_FOUND.getMessage());
+
+            verify(userClient).getUserByUserName(userName);
+            verify(passwordEncoder, never()).matches(any(), any());
+            verify(accessTokenProvider, never()).generateAccessToken(any(), any());
+        }
+
+        @Test
+        @DisplayName("비밀번호가 일치하지 않으면 로그인에 실패한다")
+        void passwordMismatch_fail() {
+            // given
+            String userName = "testuser";
+            String password = "WrongPassword!";
+            String encodedPassword = "encodedPassword";
+            String role = "MASTER";
+
+            LoginCommand command = new LoginCommand(userName, password);
+            UserDataDTO userResponse = new UserDataDTO(userName, encodedPassword, role);
+
+            // when
+            when(userClient.getUserByUserName(userName)).thenReturn(userResponse);
+            when(passwordEncoder.matches(password, encodedPassword)).thenReturn(false);
+
+            // then
+            assertThatThrownBy(() -> authService.login(command))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(AuthErrorCode.INVALID_PASSWORD.getMessage());
+
+            verify(userClient).getUserByUserName(userName);
+            verify(passwordEncoder).matches(password, encodedPassword);
+            verify(accessTokenProvide, never()).generateAccessToken(any(), any());
+        }
+    }
 }

--- a/auth-service/src/test/java/com/klp/authservice/auth/application/AuthServiceTest.java
+++ b/auth-service/src/test/java/com/klp/authservice/auth/application/AuthServiceTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.klp.authservice.auth.AuthErrorCode;
 import com.klp.authservice.auth.application.client.UserClient;
 import com.klp.authservice.auth.application.command.LoginCommand;
 import com.klp.authservice.auth.application.command.SignUpCommand;
@@ -19,6 +18,7 @@ import com.klp.authservice.auth.domain.enums.AffiliationType;
 import com.klp.authservice.auth.domain.repository.BlackListTokenRepository;
 import com.klp.authservice.auth.entrypoint.dto.response.LoginResponse;
 import com.klp.authservice.auth.entrypoint.dto.response.ReissueResponse;
+import com.klp.authservice.auth.exception.AuthErrorCode;
 import com.klp.authservice.auth.infrastructure.external.dto.request.UserCreateRequest;
 import com.klp.authservice.auth.infrastructure.external.dto.response.UserDataDTO;
 import com.klp.authservice.auth.infrastructure.jwt.TokenProvider;

--- a/auth-service/src/test/java/com/klp/authservice/auth/application/AuthServiceTest.java
+++ b/auth-service/src/test/java/com/klp/authservice/auth/application/AuthServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -238,44 +239,57 @@ class AuthServiceTest {
     class LogoutTest {
 
         @Test
-        @DisplayName("로그아웃에 성공한다. MASTER 유저의 토큰은 블랙리스트 토큰으로 등록된다")
+        @DisplayName("로그아웃에 성공한다. MASTER 유저의 AT, RT 모두 블랙리스트 토큰으로 등록된다")
         void logout_master_success() {
             // given
             String accessToken = "valid.access.token";
+            String refreshToken = "valid.refresh.token";
             String role = "MASTER";
-            LocalDateTime expiration = LocalDateTime.now().plusHours(1);
+            LocalDateTime accessExpiration = LocalDateTime.now().plusHours(1);
+            LocalDateTime refreshExpiration = LocalDateTime.now().plusDays(7);
 
             when(accessTokenProvider.validateToken(accessToken)).thenReturn(true);
             when(accessTokenProvider.getRole(accessToken)).thenReturn(role);
             when(blackListTokenRepository.existsByToken(accessToken)).thenReturn(false);
-            when(accessTokenProvider.getExpiration(accessToken)).thenReturn(expiration);
+            when(accessTokenProvider.getExpiration(accessToken)).thenReturn(accessExpiration);
+
+            when(blackListTokenRepository.existsByToken(refreshToken)).thenReturn(false);
+            when(refreshTokenProvider.getExpiration(refreshToken)).thenReturn(refreshExpiration);
 
             // when
-            authService.logout(accessToken);
+            authService.logout(accessToken, refreshToken);
 
             // then
+            verify(accessTokenProvider).validateToken(accessToken);
             verify(accessTokenProvider).getRole(accessToken);
             verify(accessTokenProvider).getExpiration(accessToken);
-            verify(blackListTokenRepository).save(any(BlackListToken.class));
+            verify(refreshTokenProvider).getExpiration(refreshToken);
+            verify(blackListTokenRepository, times(2)).save(any(BlackListToken.class));
         }
 
         @Test
-        @DisplayName("로그아웃에 성공한다. HUB 유저의 토큰은 블랙리스트 토큰으로 등록된다")
+        @DisplayName("로그아웃에 성공한다. HUB 유저의 AT, RT 모두 블랙리스트 토큰으로 등록된다")
         void logout_hub_success() {
             // given
             String accessToken = "valid.access.token";
+            String refreshToken = "valid.refresh.token";
             String role = "HUB";
-            LocalDateTime expiration = LocalDateTime.now().plusHours(1);
+            LocalDateTime accessExpiration = LocalDateTime.now().plusHours(1);
+            LocalDateTime refreshExpiration = LocalDateTime.now().plusDays(7);
 
             when(accessTokenProvider.validateToken(accessToken)).thenReturn(true);
             when(accessTokenProvider.getRole(accessToken)).thenReturn(role);
-            when(accessTokenProvider.getExpiration(accessToken)).thenReturn(expiration);
+            when(blackListTokenRepository.existsByToken(accessToken)).thenReturn(false);
+            when(accessTokenProvider.getExpiration(accessToken)).thenReturn(accessExpiration);
+
+            when(blackListTokenRepository.existsByToken(refreshToken)).thenReturn(false);
+            when(refreshTokenProvider.getExpiration(refreshToken)).thenReturn(refreshExpiration);
 
             // when
-            authService.logout(accessToken);
+            authService.logout(accessToken, refreshToken);
 
             // then
-            verify(blackListTokenRepository).save(any(BlackListToken.class));
+            verify(blackListTokenRepository, times(2)).save(any(BlackListToken.class));
         }
 
         @Test
@@ -283,36 +297,40 @@ class AuthServiceTest {
         void logout_normal_success() {
             // given
             String accessToken = "valid.access.token";
+            String refreshToken = "valid.refresh.token";
             String role = "COMPANY";
 
             when(accessTokenProvider.validateToken(accessToken)).thenReturn(true);
             when(accessTokenProvider.getRole(accessToken)).thenReturn(role);
 
             // when
-            authService.logout(accessToken);
+            authService.logout(accessToken, refreshToken);
 
             // then
+            verify(accessTokenProvider).validateToken(accessToken);
             verify(accessTokenProvider).getRole(accessToken);
             verify(blackListTokenRepository, never()).save(any());
             verify(accessTokenProvider, never()).getExpiration(any());
+            verify(refreshTokenProvider, never()).getExpiration(any());
         }
 
         @Test
         @DisplayName("이미 블랙리스트에 있는 토큰은 중복 저장하지 않는다")
-        void alreadyBlacklisted_fail() {
+        void alreadyBlacklisted_success() {
             // given
-            String role = "MASTER";
             String accessToken = "valid.access.token";
+            String refreshToken = "valid.refresh.token";
+            String role = "MASTER";
 
             when(accessTokenProvider.validateToken(accessToken)).thenReturn(true);
             when(accessTokenProvider.getRole(accessToken)).thenReturn(role);
             when(blackListTokenRepository.existsByToken(accessToken)).thenReturn(true);
+            when(blackListTokenRepository.existsByToken(refreshToken)).thenReturn(true);
 
-            // when & then
-            assertThatThrownBy(() -> authService.logout(accessToken))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage(AuthErrorCode.TOKEN_ALREADY_BLACKLISTED.getMessage());
+            // when
+            authService.logout(accessToken, refreshToken);
 
+            // then
             verify(blackListTokenRepository, never()).save(any());
         }
 
@@ -321,12 +339,12 @@ class AuthServiceTest {
         void invalidToken_fail() {
             // given
             String invalidToken = "invalid.token";
+            String refreshToken = "valid.refresh.token";
 
-            when(accessTokenProvider.validateToken(invalidToken))
-                .thenThrow(new BusinessException(AuthErrorCode.INVALID_TOKEN));
+            when(accessTokenProvider.validateToken(invalidToken)).thenReturn(false);
 
             // when & then
-            assertThatThrownBy(() -> authService.logout(invalidToken))
+            assertThatThrownBy(() -> authService.logout(invalidToken, refreshToken))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(AuthErrorCode.INVALID_TOKEN.getMessage());
         }
@@ -337,26 +355,31 @@ class AuthServiceTest {
     class ReissueTest {
 
         @Test
-        @DisplayName("유효한 RT로 새 AT,RT 발급에 성공한다")
-        void reissue_success() {
+        @DisplayName("유효한 AT, RT로 새 AT 발급에 성공한다. 기존 AT, RT 모두 블랙리스트 등록")
+        void reissue_with_both_tokens_success() {
             // given
+            String accessToken = "old.access.token";
             String refreshToken = "valid.refresh.token";
             Long userId = 1L;
             String userName = "testuser";
             String role = "MASTER";
             String newAccessToken = "new.access.token";
+            LocalDateTime refreshExpiration = LocalDateTime.now().plusDays(7);
+            LocalDateTime accessExpiration = LocalDateTime.now().plusHours(1);
 
             when(refreshTokenProvider.validateToken(refreshToken)).thenReturn(true);
             when(blackListTokenRepository.existsByToken(refreshToken)).thenReturn(false);
             when(refreshTokenProvider.getUserId(refreshToken)).thenReturn(String.valueOf(userId));
             when(refreshTokenProvider.getUserName(refreshToken)).thenReturn(userName);
             when(refreshTokenProvider.getRole(refreshToken)).thenReturn(role);
-            when(refreshTokenProvider.getExpiration(refreshToken)).thenReturn(LocalDateTime.now().plusDays(7));
-            when(accessTokenProvider.generate(userId, userName, role)).thenReturn(
-                newAccessToken);
+            when(refreshTokenProvider.getExpiration(refreshToken)).thenReturn(refreshExpiration);
+            when(accessTokenProvider.generate(userId, userName, role)).thenReturn(newAccessToken);
+
+            when(blackListTokenRepository.existsByToken(accessToken)).thenReturn(false);
+            when(accessTokenProvider.getExpiration(accessToken)).thenReturn(accessExpiration);
 
             // when
-            ReissueResponse response = authService.reissue(refreshToken);
+            ReissueResponse response = authService.reissue(accessToken, refreshToken);
 
             // then
             assertThat(response.userId()).isEqualTo(userId);
@@ -365,12 +388,52 @@ class AuthServiceTest {
             assertThat(response.accessToken()).isEqualTo(newAccessToken);
 
             verify(refreshTokenProvider).validateToken(refreshToken);
-            verify(blackListTokenRepository).existsByToken(refreshToken);
             verify(refreshTokenProvider).getUserId(refreshToken);
             verify(refreshTokenProvider).getUserName(refreshToken);
             verify(refreshTokenProvider).getRole(refreshToken);
             verify(refreshTokenProvider).getExpiration(refreshToken);
-            verify(blackListTokenRepository).save(any(BlackListToken.class));
+            verify(accessTokenProvider).getExpiration(accessToken);
+            verify(blackListTokenRepository, times(2)).existsByToken(refreshToken);
+            verify(blackListTokenRepository, times(1)).existsByToken(accessToken);
+            verify(blackListTokenRepository, times(2)).save(any(BlackListToken.class));
+            verify(accessTokenProvider).generate(userId, userName, role);
+        }
+
+        @Test
+        @DisplayName("AT 없이 RT만으로 새 AT 발급에 성공한다. RT만 블랙리스트 등록")
+        void reissue_without_accessToken_success() {
+            // given
+            String refreshToken = "valid.refresh.token";
+            Long userId = 1L;
+            String userName = "testuser";
+            String role = "MASTER";
+            String newAccessToken = "new.access.token";
+            LocalDateTime refreshExpiration = LocalDateTime.now().plusDays(7);
+
+            when(refreshTokenProvider.validateToken(refreshToken)).thenReturn(true);
+            when(blackListTokenRepository.existsByToken(refreshToken)).thenReturn(false);
+            when(refreshTokenProvider.getUserId(refreshToken)).thenReturn(String.valueOf(userId));
+            when(refreshTokenProvider.getUserName(refreshToken)).thenReturn(userName);
+            when(refreshTokenProvider.getRole(refreshToken)).thenReturn(role);
+            when(refreshTokenProvider.getExpiration(refreshToken)).thenReturn(refreshExpiration);
+            when(accessTokenProvider.generate(userId, userName, role)).thenReturn(newAccessToken);
+
+            // when
+            ReissueResponse response = authService.reissue(null, refreshToken);
+
+            // then
+            assertThat(response.userId()).isEqualTo(userId);
+            assertThat(response.userName()).isEqualTo(userName);
+            assertThat(response.role()).isEqualTo(role);
+            assertThat(response.accessToken()).isEqualTo(newAccessToken);
+
+            verify(refreshTokenProvider).validateToken(refreshToken);
+            verify(refreshTokenProvider).getUserId(refreshToken);
+            verify(refreshTokenProvider).getUserName(refreshToken);
+            verify(refreshTokenProvider).getRole(refreshToken);
+            verify(refreshTokenProvider).getExpiration(refreshToken);
+            verify(blackListTokenRepository, times(2)).existsByToken(refreshToken);
+            verify(blackListTokenRepository, times(1)).save(any(BlackListToken.class));
             verify(accessTokenProvider).generate(userId, userName, role);
         }
 
@@ -378,27 +441,29 @@ class AuthServiceTest {
         @DisplayName("유효하지 않은 RT로는 새 토큰 발급에 실패한다")
         void invalidRefreshToken_fail() {
             // given
+            String accessToken = "old.access.token";
             String invalidToken = "invalid.refresh.token";
 
             when(refreshTokenProvider.validateToken(invalidToken)).thenReturn(false);
 
             // when & then
-            assertThatThrownBy(() -> authService.reissue(invalidToken))
+            assertThatThrownBy(() -> authService.reissue(accessToken, invalidToken))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(AuthErrorCode.INVALID_TOKEN.getMessage());
         }
 
         @Test
-        @DisplayName("금지된 토큰이 존재한다면 새 토큰 발급에 실패한다")
+        @DisplayName("금지된 RT로는 새 토큰 발급에 실패한다")
         void blackListTokenExist_fail() {
             // given
+            String accessToken = "old.access.token";
             String blacklistedToken = "blacklisted.refresh.token";
 
             when(refreshTokenProvider.validateToken(blacklistedToken)).thenReturn(true);
             when(blackListTokenRepository.existsByToken(blacklistedToken)).thenReturn(true);
 
             // when & then
-            assertThatThrownBy(() -> authService.reissue(blacklistedToken))
+            assertThatThrownBy(() -> authService.reissue(accessToken, blacklistedToken))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(AuthErrorCode.TOKEN_ALREADY_BLACKLISTED.getMessage());
         }

--- a/auth-service/src/test/java/com/klp/authservice/auth/application/AuthServiceTest.java
+++ b/auth-service/src/test/java/com/klp/authservice/auth/application/AuthServiceTest.java
@@ -1,5 +1,6 @@
 package com.klp.authservice.auth.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
@@ -10,9 +11,13 @@ import static org.mockito.Mockito.when;
 
 import com.klp.authservice.auth.AuthErrorCode;
 import com.klp.authservice.auth.application.client.UserClient;
+import com.klp.authservice.auth.application.command.LoginCommand;
 import com.klp.authservice.auth.application.command.SignUpCommand;
 import com.klp.authservice.auth.domain.enums.AffiliationType;
+import com.klp.authservice.auth.entrypoint.dto.response.LoginResponse;
 import com.klp.authservice.auth.infrastructure.external.dto.request.UserCreateRequest;
+import com.klp.authservice.auth.infrastructure.external.dto.response.UserDataDTO;
+import com.klp.authservice.auth.infrastructure.jwt.TokenProvider;
 import com.klp.common.exception.BusinessException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -31,6 +36,9 @@ class AuthServiceTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private TokenProvider accessTokenProvider;
 
     @InjectMocks
     private AuthService authService;
@@ -130,33 +138,27 @@ class AuthServiceTest {
             String password = "Password1!";
             String encodedPassword = "encodedPassword";
             String role = "MASTER";
-            String slackId = " slackId";
-            String affiliationName = "testCompany";
-            AffiliationType affiliationType = AffiliationType.COMPANY;
             String accessToken = "access.token.data";
+            Long userId = 1L;
 
             LoginCommand command = new LoginCommand(userName, password);
-            UserDataDTO dto = new UserDataDTO(userName, encodedPassword, role, slackId, affiliationName,
-                affiliationType, accessToken);
+            UserDataDTO dto = new UserDataDTO(userId, userName, encodedPassword, role);
 
-            when(userClient.getUserByUserName()).thenReturn(dto);
+            when(userClient.getUserByUserName(userName)).thenReturn(dto);
             when(passwordEncoder.matches(password, encodedPassword)).thenReturn(true);
-            when(accessTokenProvider.generate(userName, role)).thenReturn(accessToken);
+            when(accessTokenProvider.generate(userId, userName, role)).thenReturn(accessToken);
 
             // when
-            LoginResponse response = authService.login(userName, password);
+            LoginResponse response = authService.login(command);
 
             // then
             assertThat(response.userName()).isEqualTo(userName);
             assertThat(response.role()).isEqualTo(role);
-            assertThat(response.slackId()).isEqualTo(slackId);
-            assertThat(response.affiliationName()).isEqualTo(affiliationName);
-            assertThat(response.affiliationType()).isEqualTo(affiliationType.name());
             assertThat(response.accessToken()).isEqualTo(accessToken);
 
             verify(userClient).getUserByUserName(userName);
             verify(passwordEncoder).matches(password, encodedPassword);
-            verify(accessTokenProvider).generateAccessToken(userName, role);
+            verify(accessTokenProvider).generate(userId, userName, role);
 
         }
 
@@ -173,26 +175,27 @@ class AuthServiceTest {
                 .thenThrow(new BusinessException(AuthErrorCode.USER_NOT_FOUND));
 
             // then
-            assertThatThrownBy(() -> authService.login(commnad))
+            assertThatThrownBy(() -> authService.login(command))
                 .isInstanceOf(BusinessException.class)
                 .hasMessage(AuthErrorCode.USER_NOT_FOUND.getMessage());
 
             verify(userClient).getUserByUserName(userName);
             verify(passwordEncoder, never()).matches(any(), any());
-            verify(accessTokenProvider, never()).generateAccessToken(any(), any());
+            verify(accessTokenProvider, never()).generate(any(), any(), any());
         }
 
         @Test
         @DisplayName("비밀번호가 일치하지 않으면 로그인에 실패한다")
         void passwordMismatch_fail() {
             // given
+            Long userId = 1L;
             String userName = "testuser";
             String password = "WrongPassword!";
             String encodedPassword = "encodedPassword";
             String role = "MASTER";
 
             LoginCommand command = new LoginCommand(userName, password);
-            UserDataDTO userResponse = new UserDataDTO(userName, encodedPassword, role);
+            UserDataDTO userResponse = new UserDataDTO(userId, userName, encodedPassword, role);
 
             // when
             when(userClient.getUserByUserName(userName)).thenReturn(userResponse);
@@ -205,7 +208,7 @@ class AuthServiceTest {
 
             verify(userClient).getUserByUserName(userName);
             verify(passwordEncoder).matches(password, encodedPassword);
-            verify(accessTokenProvide, never()).generateAccessToken(any(), any());
+            verify(accessTokenProvider, never()).generate(any(), any(), any());
         }
     }
 }

--- a/auth-service/src/test/java/com/klp/authservice/auth/domain/entity/BlackListTokenTest.java
+++ b/auth-service/src/test/java/com/klp/authservice/auth/domain/entity/BlackListTokenTest.java
@@ -1,5 +1,8 @@
 package com.klp.authservice.auth.domain.entity;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.klp.authservice.auth.AuthErrorCode;
 import com.klp.common.exception.BusinessException;
 import java.time.LocalDateTime;
@@ -20,7 +23,7 @@ class BlackListTokenTest {
 
         // then
         assertThat(blackListToken.getToken()).isEqualTo(token);
-        assertThat(blackListToken.getExpiration()).isEqalTo(expiration);
+        assertThat(blackListToken.getExpiration()).isEqualTo(expiration);
     }
 
     @Test

--- a/auth-service/src/test/java/com/klp/authservice/auth/domain/entity/BlackListTokenTest.java
+++ b/auth-service/src/test/java/com/klp/authservice/auth/domain/entity/BlackListTokenTest.java
@@ -8,33 +8,37 @@ import com.klp.common.exception.BusinessException;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class BlackListTokenTest {
+
+    private static final String VALID_TOKEN = "blackList.token.data";
+    private static final LocalDateTime VALID_EXPIRATION = LocalDateTime.now().plusHours(1);
+
 
     @Test
     @DisplayName("블랙리스트 토큰 생성 성공")
     void createBlackListToken_success() {
         // given
-        String token = "blackList.token.data";
-        LocalDateTime expiration = LocalDateTime.now().plusHours(1);
 
         // when
-        BlackListToken blackListToken = BlackListToken.create(token, expiration);
+        BlackListToken blackListToken = BlackListToken.create(VALID_TOKEN, VALID_EXPIRATION);
 
         // then
-        assertThat(blackListToken.getToken()).isEqualTo(token);
-        assertThat(blackListToken.getExpiration()).isEqualTo(expiration);
+        assertThat(blackListToken.getToken()).isEqualTo(VALID_TOKEN);
+        assertThat(blackListToken.getExpiration()).isEqualTo(VALID_EXPIRATION);
     }
 
     @Test
     @DisplayName("만료시간이 현재보다 이전이면 생성되지 않는다.")
     void createWithPastExpiration_fail() {
         // given
-        String token = "blackList.token.data";
-        LocalDateTime expiration = LocalDateTime.now().minusHours(1);
+        LocalDateTime invalidExpiration = LocalDateTime.now().minusHours(1);
 
         // when & then
-        assertThatThrownBy(() -> BlackListToken.create(token, expiration))
+        assertThatThrownBy(() -> BlackListToken.create(VALID_TOKEN, invalidExpiration))
             .isInstanceOf(BusinessException.class)
             .hasMessage(AuthErrorCode.BLACKLIST_CREATE_ERROR.getMessage());
     }
@@ -43,50 +47,22 @@ class BlackListTokenTest {
     @DisplayName("만료시간이 null이라면 생성 실패한다")
     void nullExpiration_fail() {
         // given
-        String token = "blackList.token.data";
-        LocalDateTime expiration = null;
 
         // when & then
-        assertThatThrownBy(() -> BlackListToken.create(token, expiration))
+        assertThatThrownBy(() -> BlackListToken.create(VALID_TOKEN, null))
             .isInstanceOf(BusinessException.class)
             .hasMessage(AuthErrorCode.BLACKLIST_CREATE_ERROR.getMessage());
     }
 
-    @Test
-    @DisplayName("토큰값이 null이라면 생성 실패한다.")
-    void nullToken_fail() {
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   "})
+    @DisplayName("토큰값이 null이거나 공백, 빈 문자열이면 생성에 실패한다.")
+    void invalidToken_fail(String token) {
         // given
-        String token = null;
-        LocalDateTime expiration = LocalDateTime.now().plusHours(1);
 
         // when & then
-        assertThatThrownBy(() -> BlackListToken.create(token, expiration))
-            .isInstanceOf(BusinessException.class)
-            .hasMessage(AuthErrorCode.BLACKLIST_CREATE_ERROR.getMessage());
-    }
-
-    @Test
-    @DisplayName("토큰이 빈 문자열이라면 생성 실패한다.")
-    void emptyToken_fail() {
-        // given
-        String token = "";
-        LocalDateTime expiration = LocalDateTime.now().plusHours(1);
-
-        // when & then
-        assertThatThrownBy(() -> BlackListToken.create(token, expiration))
-            .isInstanceOf(BusinessException.class)
-            .hasMessage(AuthErrorCode.BLACKLIST_CREATE_ERROR.getMessage());
-    }
-
-    @Test
-    @DisplayName("토큰이 공백이라면 생성 실패한다")
-    void whiteSpaceToken_fail() {
-        // given
-        String token = "   ";
-        LocalDateTime expiration = LocalDateTime.now().plusHours(1);
-
-        // when & then
-        assertThatThrownBy(() -> BlackListToken.create(token, expiration))
+        assertThatThrownBy(() -> BlackListToken.create(token, VALID_EXPIRATION))
             .isInstanceOf(BusinessException.class)
             .hasMessage(AuthErrorCode.BLACKLIST_CREATE_ERROR.getMessage());
     }

--- a/auth-service/src/test/java/com/klp/authservice/auth/domain/entity/BlackListTokenTest.java
+++ b/auth-service/src/test/java/com/klp/authservice/auth/domain/entity/BlackListTokenTest.java
@@ -1,0 +1,90 @@
+package com.klp.authservice.auth.domain.entity;
+
+import com.klp.authservice.auth.AuthErrorCode;
+import com.klp.common.exception.BusinessException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class BlackListTokenTest {
+
+    @Test
+    @DisplayName("블랙리스트 토큰 생성 성공")
+    void createBlackListToken_success() {
+        // given
+        String token = "blackList.token.data";
+        LocalDateTime expiration = LocalDateTime.now().plusHours(1);
+
+        // when
+        BlackListToken blackListToken = BlackListToken.create(token, expiration);
+
+        // then
+        assertThat(blackListToken.getToken()).isEqualTo(token);
+        assertThat(blackListToken.getExpiration()).isEqalTo(expiration);
+    }
+
+    @Test
+    @DisplayName("만료시간이 현재보다 이전이면 생성되지 않는다.")
+    void createWithPastExpiration_fail() {
+        // given
+        String token = "blackList.token.data";
+        LocalDateTime expiration = LocalDateTime.now().minusHours(1);
+
+        // when & then
+        assertThatThrownBy(() -> BlackListToken.create(token, expiration))
+            .isInstanceOf(BusinessException.class)
+            .hasMessage(AuthErrorCode.BLACKLIST_CREATE_ERROR.getMessage());
+    }
+
+    @Test
+    @DisplayName("만료시간이 null이라면 생성 실패한다")
+    void nullExpiration_fail() {
+        // given
+        String token = "blackList.token.data";
+        LocalDateTime expiration = null;
+
+        // when & then
+        assertThatThrownBy(() -> BlackListToken.create(token, expiration))
+            .isInstanceOf(BusinessException.class)
+            .hasMessage(AuthErrorCode.BLACKLIST_CREATE_ERROR.getMessage());
+    }
+
+    @Test
+    @DisplayName("토큰값이 null이라면 생성 실패한다.")
+    void nullToken_fail() {
+        // given
+        String token = null;
+        LocalDateTime expiration = LocalDateTime.now().plusHours(1);
+
+        // when & then
+        assertThatThrownBy(() -> BlackListToken.create(token, expiration))
+            .isInstanceOf(BusinessException.class)
+            .hasMessage(AuthErrorCode.BLACKLIST_CREATE_ERROR.getMessage());
+    }
+
+    @Test
+    @DisplayName("토큰이 빈 문자열이라면 생성 실패한다.")
+    void emptyToken_fail() {
+        // given
+        String token = "";
+        LocalDateTime expiration = LocalDateTime.now().plusHours(1);
+
+        // when & then
+        assertThatThrownBy(() -> BlackListToken.create(token, expiration))
+            .isInstanceOf(BusinessException.class)
+            .hasMessage(AuthErrorCode.BLACKLIST_CREATE_ERROR.getMessage());
+    }
+
+    @Test
+    @DisplayName("토큰이 공백이라면 생성 실패한다")
+    void whiteSpaceToken_fail() {
+        // given
+        String token = "   ";
+        LocalDateTime expiration = LocalDateTime.now().plusHours(1);
+
+        // when & then
+        assertThatThrownBy(() -> BlackListToken.create(token, expiration))
+            .isInstanceOf(BusinessException.class)
+            .hasMessage(AuthErrorCode.BLACKLIST_CREATE_ERROR.getMessage());
+    }
+}

--- a/auth-service/src/test/java/com/klp/authservice/auth/domain/entity/BlackListTokenTest.java
+++ b/auth-service/src/test/java/com/klp/authservice/auth/domain/entity/BlackListTokenTest.java
@@ -16,8 +16,7 @@ class BlackListTokenTest {
 
     private static final String VALID_TOKEN = "blackList.token.data";
     private static final LocalDateTime VALID_EXPIRATION = LocalDateTime.now().plusHours(1);
-
-
+    
     @Test
     @DisplayName("블랙리스트 토큰 생성 성공")
     void createBlackListToken_success() {

--- a/auth-service/src/test/java/com/klp/authservice/auth/domain/entity/BlackListTokenTest.java
+++ b/auth-service/src/test/java/com/klp/authservice/auth/domain/entity/BlackListTokenTest.java
@@ -3,7 +3,7 @@ package com.klp.authservice.auth.domain.entity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.klp.authservice.auth.AuthErrorCode;
+import com.klp.authservice.auth.exception.AuthErrorCode;
 import com.klp.common.exception.BusinessException;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
@@ -16,7 +16,7 @@ class BlackListTokenTest {
 
     private static final String VALID_TOKEN = "blackList.token.data";
     private static final LocalDateTime VALID_EXPIRATION = LocalDateTime.now().plusHours(1);
-    
+
     @Test
     @DisplayName("블랙리스트 토큰 생성 성공")
     void createBlackListToken_success() {

--- a/auth-service/src/test/java/com/klp/authservice/auth/entrypoint/AuthControllerTest.java
+++ b/auth-service/src/test/java/com/klp/authservice/auth/entrypoint/AuthControllerTest.java
@@ -2,12 +2,14 @@ package com.klp.authservice.auth.entrypoint;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.klp.authservice.auth.AuthErrorCode;
 import com.klp.authservice.auth.application.AuthService;
 import com.klp.authservice.auth.application.command.LoginCommand;
 import com.klp.authservice.auth.application.command.SignUpCommand;
@@ -21,12 +23,14 @@ import com.klp.authservice.auth.infrastructure.jwt.JwtConstants;
 import com.klp.authservice.auth.infrastructure.jwt.TokenProvider;
 import com.klp.authservice.auth.infrastructure.security.config.SecurityConfig;
 import com.klp.authservice.auth.infrastructure.security.filter.AuthorizationFilter;
+import com.klp.common.exception.BusinessException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -588,6 +592,49 @@ class AuthControllerTest {
                         .content(mapper.writeValueAsString(loginRequest)))
                     .andExpect(status().isBadRequest());
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("로그아웃 테스트")
+    class logoutTest {
+
+        @Test
+        @DisplayName("로그아웃에 성공하고 RefreshToken 쿠키가 무효화된다")
+        void logout_success() throws Exception {
+            // given
+            String accessToken = "valid.access.token";
+
+            doNothing().when(authService).logout(accessToken);
+
+            // when & then
+            mockMvc.perform(post("/v1/auth/logout")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(cookie().maxAge(JwtConstants.REFRESH_TOKEN_COOKIE_NAME, 0));
+        }
+
+        @Test
+        @DisplayName("Authorization 헤더가 없으면 실패한다")
+        void noAuthorizationHeader_fail() throws Exception {
+            // when & then
+            mockMvc.perform(post("/v1/auth/logout"))
+                .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 토큰으로 실패한다")
+        void invalidToken_fail() throws Exception {
+            // given
+            String invalidToken = "invalid.token";
+
+            doThrow(new BusinessException(AuthErrorCode.INVALID_TOKEN))
+                .when(authService).logout(invalidToken);
+
+            // when & then
+            mockMvc.perform(post("/v1/auth/logout")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + invalidToken))
+                .andExpect(status().isUnauthorized());
         }
     }
 }

--- a/auth-service/src/test/java/com/klp/authservice/auth/entrypoint/AuthControllerTest.java
+++ b/auth-service/src/test/java/com/klp/authservice/auth/entrypoint/AuthControllerTest.java
@@ -3,9 +3,11 @@ package com.klp.authservice.auth.entrypoint;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -18,12 +20,14 @@ import com.klp.authservice.auth.entrypoint.controller.AuthController;
 import com.klp.authservice.auth.entrypoint.dto.request.LoginRequest;
 import com.klp.authservice.auth.entrypoint.dto.request.SignUpRequest;
 import com.klp.authservice.auth.entrypoint.dto.response.LoginResponse;
+import com.klp.authservice.auth.entrypoint.dto.response.ReissueResponse;
 import com.klp.authservice.auth.infrastructure.exception.GlobalExceptionHandler;
 import com.klp.authservice.auth.infrastructure.jwt.JwtConstants;
 import com.klp.authservice.auth.infrastructure.jwt.TokenProvider;
 import com.klp.authservice.auth.infrastructure.security.config.SecurityConfig;
 import com.klp.authservice.auth.infrastructure.security.filter.AuthorizationFilter;
 import com.klp.common.exception.BusinessException;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -634,6 +638,79 @@ class AuthControllerTest {
             // when & then
             mockMvc.perform(post("/v1/auth/logout")
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + invalidToken))
+                .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 재발급 테스트")
+    class reissueTest {
+
+        @Test
+        @DisplayName("RefreshToken으로 새 AccessToken 발급에 성공한다")
+        void reissue_success() throws Exception {
+            // given
+            String refreshToken = "valid.refresh.token";
+            Long userId = 1L;
+            String userName = "testuser";
+            String role = "MASTER";
+            String newAccessToken = "new.access.token";
+            String newRefreshToken = "new.refresh.token";
+
+            ReissueResponse response = new ReissueResponse(userId, userName, role, newAccessToken);
+
+            when(authService.reissue(refreshToken)).thenReturn(response);
+            when(refreshTokenProvider.generate(userId, userName, role)).thenReturn(newRefreshToken);
+
+            // when & then
+            mockMvc.perform(post("/v1/auth/token/reissue")
+                    .cookie(new Cookie("refreshToken", refreshToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(userId))
+                .andExpect(jsonPath("$.userName").value(userName))
+                .andExpect(jsonPath("$.role").value(role))
+                .andExpect(jsonPath("$.accessToken").value(newAccessToken))
+                .andExpect(cookie().exists(JwtConstants.REFRESH_TOKEN_COOKIE_NAME));
+
+            verify(authService).reissue(refreshToken);
+            verify(refreshTokenProvider).generate(userId, userName, role);
+        }
+
+        @Test
+        @DisplayName("RefreshToken 쿠키가 없으면 실패한다")
+        void noRefreshTokenCookie_fail() throws Exception {
+            // when & then
+            mockMvc.perform(post("/v1/auth/token/reissue"))
+                .andExpect(status().isInternalServerError());  // NullPointerException 발생
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 RefreshToken으로 실패한다")
+        void invalidRefreshToken_fail() throws Exception {
+            // given
+            String invalidToken = "invalid.refresh.token";
+
+            when(authService.reissue(invalidToken))
+                .thenThrow(new BusinessException(AuthErrorCode.INVALID_TOKEN));
+
+            // when & then
+            mockMvc.perform(post("/v1/auth/token/reissue")
+                    .cookie(new Cookie("refreshToken", invalidToken)))
+                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("블랙리스트 토큰으로 실패한다")
+        void blacklistedToken_fail() throws Exception {
+            // given
+            String blacklistedToken = "blacklisted.refresh.token";
+
+            when(authService.reissue(blacklistedToken))
+                .thenThrow(new BusinessException(AuthErrorCode.TOKEN_ALREADY_BLACKLISTED));
+
+            // when & then
+            mockMvc.perform(post("/v1/auth/token/reissue")
+                    .cookie(new Cookie("refreshToken", blacklistedToken)))
                 .andExpect(status().isUnauthorized());
         }
     }

--- a/auth-service/src/test/java/com/klp/authservice/auth/entrypoint/AuthControllerTest.java
+++ b/auth-service/src/test/java/com/klp/authservice/auth/entrypoint/AuthControllerTest.java
@@ -36,6 +36,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -600,6 +601,7 @@ class AuthControllerTest {
     }
 
     @Nested
+    @WithMockUser
     @DisplayName("로그아웃 테스트")
     class logoutTest {
 

--- a/auth-service/src/test/java/com/klp/authservice/auth/entrypoint/AuthControllerTest.java
+++ b/auth-service/src/test/java/com/klp/authservice/auth/entrypoint/AuthControllerTest.java
@@ -666,7 +666,7 @@ class AuthControllerTest {
 
             // when & then
             mockMvc.perform(post("/v1/auth/token/reissue")
-                    .cookie(new Cookie("refreshToken", refreshToken)))
+                    .cookie(new Cookie(JwtConstants.REFRESH_TOKEN_COOKIE_NAME, refreshToken)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.userId").value(userId))
                 .andExpect(jsonPath("$.userName").value(userName))
@@ -683,7 +683,7 @@ class AuthControllerTest {
         void noRefreshTokenCookie_fail() throws Exception {
             // when & then
             mockMvc.perform(post("/v1/auth/token/reissue"))
-                .andExpect(status().isInternalServerError());  // NullPointerException 발생
+                .andExpect(status().isUnauthorized());
         }
 
         @Test

--- a/auth-service/src/test/java/com/klp/authservice/auth/entrypoint/AuthControllerTest.java
+++ b/auth-service/src/test/java/com/klp/authservice/auth/entrypoint/AuthControllerTest.java
@@ -606,18 +606,39 @@ class AuthControllerTest {
     class logoutTest {
 
         @Test
-        @DisplayName("로그아웃에 성공하고 RefreshToken 쿠키가 무효화된다")
-        void logout_success() throws Exception {
+        @DisplayName("AT, RT와 함께 로그아웃에 성공하고 RefreshToken 쿠키가 무효화된다")
+        void logout_with_both_tokens_success() throws Exception {
+            // given
+            String accessToken = "valid.access.token";
+            String refreshToken = "valid.refresh.token";
+
+            doNothing().when(authService).logout(accessToken, refreshToken);
+
+            // when & then
+            mockMvc.perform(post("/v1/auth/logout")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .cookie(new Cookie(JwtConstants.REFRESH_TOKEN_COOKIE_NAME, refreshToken)))
+                .andExpect(status().isOk())
+                .andExpect(cookie().maxAge(JwtConstants.REFRESH_TOKEN_COOKIE_NAME, 0));
+
+            verify(authService).logout(accessToken, refreshToken);
+        }
+
+        @Test
+        @DisplayName("RT 없이 AT만으로도 로그아웃에 성공한다")
+        void logout_without_refreshToken_success() throws Exception {
             // given
             String accessToken = "valid.access.token";
 
-            doNothing().when(authService).logout(accessToken);
+            doNothing().when(authService).logout(accessToken, null);
 
             // when & then
             mockMvc.perform(post("/v1/auth/logout")
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
                 .andExpect(status().isOk())
                 .andExpect(cookie().maxAge(JwtConstants.REFRESH_TOKEN_COOKIE_NAME, 0));
+
+            verify(authService).logout(accessToken, null);
         }
 
         @Test
@@ -625,7 +646,7 @@ class AuthControllerTest {
         void noAuthorizationHeader_fail() throws Exception {
             // when & then
             mockMvc.perform(post("/v1/auth/logout"))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isUnauthorized());
         }
 
         @Test
@@ -633,13 +654,15 @@ class AuthControllerTest {
         void invalidToken_fail() throws Exception {
             // given
             String invalidToken = "invalid.token";
+            String refreshToken = "valid.refresh.token";
 
             doThrow(new BusinessException(AuthErrorCode.INVALID_TOKEN))
-                .when(authService).logout(invalidToken);
+                .when(authService).logout(invalidToken, refreshToken);
 
             // when & then
             mockMvc.perform(post("/v1/auth/logout")
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + invalidToken))
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + invalidToken)
+                    .cookie(new Cookie(JwtConstants.REFRESH_TOKEN_COOKIE_NAME, refreshToken)))
                 .andExpect(status().isUnauthorized());
         }
     }
@@ -649,8 +672,40 @@ class AuthControllerTest {
     class reissueTest {
 
         @Test
-        @DisplayName("RefreshToken으로 새 AccessToken 발급에 성공한다")
-        void reissue_success() throws Exception {
+        @DisplayName("AT, RT로 새 AccessToken 발급에 성공한다")
+        void reissue_with_both_tokens_success() throws Exception {
+            // given
+            String accessToken = "old.access.token";
+            String refreshToken = "valid.refresh.token";
+            Long userId = 1L;
+            String userName = "testuser";
+            String role = "MASTER";
+            String newAccessToken = "new.access.token";
+            String newRefreshToken = "new.refresh.token";
+
+            ReissueResponse response = new ReissueResponse(userId, userName, role, newAccessToken);
+
+            when(authService.reissue(accessToken, refreshToken)).thenReturn(response);
+            when(refreshTokenProvider.generate(userId, userName, role)).thenReturn(newRefreshToken);
+
+            // when & then
+            mockMvc.perform(post("/v1/auth/token/reissue")
+                    .header("Authorization", "Bearer " + accessToken)
+                    .cookie(new Cookie(JwtConstants.REFRESH_TOKEN_COOKIE_NAME, refreshToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(userId))
+                .andExpect(jsonPath("$.userName").value(userName))
+                .andExpect(jsonPath("$.role").value(role))
+                .andExpect(jsonPath("$.accessToken").value(newAccessToken))
+                .andExpect(cookie().exists(JwtConstants.REFRESH_TOKEN_COOKIE_NAME));
+
+            verify(authService).reissue(accessToken, refreshToken);
+            verify(refreshTokenProvider).generate(userId, userName, role);
+        }
+
+        @Test
+        @DisplayName("AT 없이 RT만으로 새 AccessToken 발급에 성공한다")
+        void reissue_without_accessToken_success() throws Exception {
             // given
             String refreshToken = "valid.refresh.token";
             Long userId = 1L;
@@ -661,7 +716,7 @@ class AuthControllerTest {
 
             ReissueResponse response = new ReissueResponse(userId, userName, role, newAccessToken);
 
-            when(authService.reissue(refreshToken)).thenReturn(response);
+            when(authService.reissue(null, refreshToken)).thenReturn(response);
             when(refreshTokenProvider.generate(userId, userName, role)).thenReturn(newRefreshToken);
 
             // when & then
@@ -674,7 +729,7 @@ class AuthControllerTest {
                 .andExpect(jsonPath("$.accessToken").value(newAccessToken))
                 .andExpect(cookie().exists(JwtConstants.REFRESH_TOKEN_COOKIE_NAME));
 
-            verify(authService).reissue(refreshToken);
+            verify(authService).reissue(null, refreshToken);
             verify(refreshTokenProvider).generate(userId, userName, role);
         }
 
@@ -690,14 +745,16 @@ class AuthControllerTest {
         @DisplayName("유효하지 않은 RefreshToken으로 실패한다")
         void invalidRefreshToken_fail() throws Exception {
             // given
+            String accessToken = "old.access.token";
             String invalidToken = "invalid.refresh.token";
 
-            when(authService.reissue(invalidToken))
+            when(authService.reissue(accessToken, invalidToken))
                 .thenThrow(new BusinessException(AuthErrorCode.INVALID_TOKEN));
 
             // when & then
             mockMvc.perform(post("/v1/auth/token/reissue")
-                    .cookie(new Cookie("refreshToken", invalidToken)))
+                    .header("Authorization", "Bearer " + accessToken)
+                    .cookie(new Cookie(JwtConstants.REFRESH_TOKEN_COOKIE_NAME, invalidToken)))
                 .andExpect(status().isUnauthorized());
         }
 
@@ -705,14 +762,16 @@ class AuthControllerTest {
         @DisplayName("블랙리스트 토큰으로 실패한다")
         void blacklistedToken_fail() throws Exception {
             // given
+            String accessToken = "old.access.token";
             String blacklistedToken = "blacklisted.refresh.token";
 
-            when(authService.reissue(blacklistedToken))
+            when(authService.reissue(accessToken, blacklistedToken))
                 .thenThrow(new BusinessException(AuthErrorCode.TOKEN_ALREADY_BLACKLISTED));
 
             // when & then
             mockMvc.perform(post("/v1/auth/token/reissue")
-                    .cookie(new Cookie("refreshToken", blacklistedToken)))
+                    .header("Authorization", "Bearer " + accessToken)
+                    .cookie(new Cookie(JwtConstants.REFRESH_TOKEN_COOKIE_NAME, blacklistedToken)))
                 .andExpect(status().isUnauthorized());
         }
     }

--- a/auth-service/src/test/java/com/klp/authservice/auth/entrypoint/AuthControllerTest.java
+++ b/auth-service/src/test/java/com/klp/authservice/auth/entrypoint/AuthControllerTest.java
@@ -12,6 +12,7 @@ import com.klp.authservice.auth.application.command.LoginCommand;
 import com.klp.authservice.auth.application.command.SignUpCommand;
 import com.klp.authservice.auth.domain.enums.AffiliationType;
 import com.klp.authservice.auth.entrypoint.controller.AuthController;
+import com.klp.authservice.auth.entrypoint.dto.request.LoginRequest;
 import com.klp.authservice.auth.entrypoint.dto.request.SignUpRequest;
 import com.klp.authservice.auth.entrypoint.dto.response.LoginResponse;
 import com.klp.authservice.auth.infrastructure.exception.GlobalExceptionHandler;

--- a/auth-service/src/test/java/com/klp/authservice/auth/entrypoint/AuthControllerTest.java
+++ b/auth-service/src/test/java/com/klp/authservice/auth/entrypoint/AuthControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -16,6 +17,8 @@ import com.klp.authservice.auth.entrypoint.dto.request.LoginRequest;
 import com.klp.authservice.auth.entrypoint.dto.request.SignUpRequest;
 import com.klp.authservice.auth.entrypoint.dto.response.LoginResponse;
 import com.klp.authservice.auth.infrastructure.exception.GlobalExceptionHandler;
+import com.klp.authservice.auth.infrastructure.jwt.JwtConstants;
+import com.klp.authservice.auth.infrastructure.jwt.TokenProvider;
 import com.klp.authservice.auth.infrastructure.security.config.SecurityConfig;
 import com.klp.authservice.auth.infrastructure.security.filter.AuthorizationFilter;
 import org.junit.jupiter.api.DisplayName;
@@ -40,6 +43,9 @@ class AuthControllerTest {
 
     @MockitoBean
     private AuthService authService;
+
+    @MockitoBean
+    private TokenProvider refreshTokenProvider;
 
     @Nested
     @DisplayName("회원가입 실패 테스트")
@@ -465,7 +471,7 @@ class AuthControllerTest {
     class LoginSuccessTest {
 
         @Test
-        @DisplayName("유효한 요청일 경우 로그인에 성공한다")
+        @DisplayName("유효한 요청일 경우 로그인에 성공한다. 로그인 성공 시 쿠키로 RefreshToken이 발급된다.")
         void validRequest_success() throws Exception {
             // given
             Long userId = 1L;
@@ -473,18 +479,22 @@ class AuthControllerTest {
             String password = "Password1!";
             String role = "MASTER";
             String accessToken = "valid.access.token";
+            String refreshToken = "valid.refresh.token";
 
             LoginRequest request = new LoginRequest(userName, password);
             LoginResponse response = new LoginResponse(userId, userName, role, accessToken);
 
             // when
             when(authService.login(any(LoginCommand.class))).thenReturn(response);
+            when(refreshTokenProvider.generate(userId, userName, role)).thenReturn(refreshToken);
 
             // then
             mockMvc.perform(post("/v1/auth/login")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(mapper.writeValueAsString(request)))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(cookie().exists(JwtConstants.REFRESH_TOKEN_COOKIE_NAME))
+                .andExpect(cookie().value(JwtConstants.REFRESH_TOKEN_COOKIE_NAME, refreshToken));
         }
     }
 

--- a/auth-service/src/test/java/com/klp/authservice/auth/entrypoint/AuthControllerTest.java
+++ b/auth-service/src/test/java/com/klp/authservice/auth/entrypoint/AuthControllerTest.java
@@ -11,7 +11,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.klp.authservice.auth.AuthErrorCode;
 import com.klp.authservice.auth.application.AuthService;
 import com.klp.authservice.auth.application.command.LoginCommand;
 import com.klp.authservice.auth.application.command.SignUpCommand;
@@ -21,11 +20,12 @@ import com.klp.authservice.auth.entrypoint.dto.request.LoginRequest;
 import com.klp.authservice.auth.entrypoint.dto.request.SignUpRequest;
 import com.klp.authservice.auth.entrypoint.dto.response.LoginResponse;
 import com.klp.authservice.auth.entrypoint.dto.response.ReissueResponse;
-import com.klp.authservice.auth.infrastructure.exception.GlobalExceptionHandler;
+import com.klp.authservice.auth.exception.AuthErrorCode;
 import com.klp.authservice.auth.infrastructure.jwt.JwtConstants;
 import com.klp.authservice.auth.infrastructure.jwt.TokenProvider;
-import com.klp.authservice.auth.infrastructure.security.config.SecurityConfig;
-import com.klp.authservice.auth.infrastructure.security.filter.AuthorizationFilter;
+import com.klp.authservice.global.exception.GlobalExceptionHandler;
+import com.klp.authservice.global.security.config.SecurityConfig;
+import com.klp.authservice.global.security.filter.AuthorizationFilter;
 import com.klp.common.exception.BusinessException;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;

--- a/auth-service/src/test/java/com/klp/authservice/auth/entrypoint/AuthControllerTest.java
+++ b/auth-service/src/test/java/com/klp/authservice/auth/entrypoint/AuthControllerTest.java
@@ -2,15 +2,18 @@ package com.klp.authservice.auth.entrypoint;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.klp.authservice.auth.application.AuthService;
+import com.klp.authservice.auth.application.command.LoginCommand;
 import com.klp.authservice.auth.application.command.SignUpCommand;
 import com.klp.authservice.auth.domain.enums.AffiliationType;
 import com.klp.authservice.auth.entrypoint.controller.AuthController;
 import com.klp.authservice.auth.entrypoint.dto.request.SignUpRequest;
+import com.klp.authservice.auth.entrypoint.dto.response.LoginResponse;
 import com.klp.authservice.auth.infrastructure.exception.GlobalExceptionHandler;
 import com.klp.authservice.auth.infrastructure.security.config.SecurityConfig;
 import com.klp.authservice.auth.infrastructure.security.filter.AuthorizationFilter;
@@ -39,7 +42,7 @@ class AuthControllerTest {
 
     @Nested
     @DisplayName("회원가입 실패 테스트")
-    class failSignUp {
+    class FailSignUp {
 
         @Nested
         @DisplayName("username 실패 케이스")
@@ -431,7 +434,7 @@ class AuthControllerTest {
 
     @Nested
     @DisplayName("회원가입 성공 테스트")
-    class successSignUp {
+    class SuccessSignUp {
 
         @Test
         @DisplayName("유효한 요청일 경우 회원가입에 성공한다")
@@ -453,6 +456,127 @@ class AuthControllerTest {
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(mapper.writeValueAsString(signUpRequest)))
                 .andExpect(status().isOk());
+        }
+    }
+
+    @Nested
+    @DisplayName("로그인 성공 테스트")
+    class LoginSuccessTest {
+
+        @Test
+        @DisplayName("유효한 요청일 경우 로그인에 성공한다")
+        void validRequest_success() throws Exception {
+            // given
+            Long userId = 1L;
+            String userName = "testuser";
+            String password = "Password1!";
+            String role = "MASTER";
+            String accessToken = "valid.access.token";
+
+            LoginRequest request = new LoginRequest(userName, password);
+            LoginResponse response = new LoginResponse(userId, userName, role, accessToken);
+
+            // when
+            when(authService.login(any(LoginCommand.class))).thenReturn(response);
+
+            // then
+            mockMvc.perform(post("/v1/auth/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(mapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+        }
+    }
+
+    @Nested
+    @DisplayName("로그인 실패 테스트")
+    class LoginFailTest {
+
+        @Nested
+        @DisplayName("userName 실패 케이스")
+        class UsernameInvalid {
+
+            @Test
+            @DisplayName("null이면 실패한다")
+            void nullUsername_fail() throws Exception {
+                // given
+                LoginRequest loginRequest = new LoginRequest(null, "Password1!");
+
+                // when & then
+                mockMvc.perform(post("/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(loginRequest)))
+                    .andExpect(status().isBadRequest());
+            }
+
+            @Test
+            @DisplayName("빈 문자열이면 실패한다")
+            void emptyUsername_fail() throws Exception {
+                // given
+                LoginRequest loginRequest = new LoginRequest("", "Password1!");
+
+                // when & then
+                mockMvc.perform(post("/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(loginRequest)))
+                    .andExpect(status().isBadRequest());
+            }
+
+            @Test
+            @DisplayName("공백이면 실패한다")
+            void whiteSpaceUsername_fail() throws Exception {
+                // given
+                LoginRequest loginRequest = new LoginRequest("     ", "Password1!");
+
+                // when & then
+                mockMvc.perform(post("/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(loginRequest)))
+                    .andExpect(status().isBadRequest());
+            }
+        }
+
+        @Nested
+        @DisplayName("password 실패 케이스")
+        class PasswordInvalid {
+
+            @Test
+            @DisplayName("null이면 실패한다")
+            void nullPassword_fail() throws Exception {
+                // given
+                LoginRequest loginRequest = new LoginRequest("testuser", null);
+
+                // when & then
+                mockMvc.perform(post("/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(loginRequest)))
+                    .andExpect(status().isBadRequest());
+            }
+
+            @Test
+            @DisplayName("빈 문자열이면 실패한다")
+            void emptyPassword_fail() throws Exception {
+                // given
+                LoginRequest loginRequest = new LoginRequest("testuser", "");
+
+                // when & then
+                mockMvc.perform(post("/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(loginRequest)))
+                    .andExpect(status().isBadRequest());
+            }
+
+            @Test
+            @DisplayName("공백이면 실패한다")
+            void whiteSpacePassword_fail() throws Exception {
+                // given
+                LoginRequest loginRequest = new LoginRequest("testuser", "   ");
+
+                // when & then
+                mockMvc.perform(post("/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(loginRequest)))
+                    .andExpect(status().isBadRequest());
+            }
         }
     }
 }


### PR DESCRIPTION
## PR 내용
- 블랙리스트 토큰 도메인 모델, 로그인, 로그아웃, 토큰 재발급 기능을 TDD를 이용해 구성했습니다.
- 학습을 위해 TDD를 적용하며 커밋을 세분화하여 깔끔하지는 않게 작성됐습니다.
- auth 도메인의 경우, 직접 토큰을 디코딩 및 블랙리스트로 저장하는 등, 유저의 정보가 아닌 토큰의 정보가 필요합니다.
- 따라서 Gateway-Service에서 auth 도메인의 경우 AuthenticationFilter을 통해서 정보만 받는 것 이 아니라, 토큰 데이터 자체를 보내도록 변경할 예정입니다.

### BlackListToken 도메인
  - 토큰값과, 만료시간을 설정하고 토큰 및 만료시간이 존재하지 않거나 만료 시간이 현재 시간보다 이전일 경우 생성 오류가 발생합니다.
  - 만료시간의 경우, 추후 스케쥴러 등을 통해 현재 시간과 만료 시간을 비교해 이미 지난 토큰은 삭제하기 위해 적용했습니다.

### 로그인 기능 구현
- `UserClient`를 통해, 요청으로 들어온 userName을 가지고 있는 유저의 이름과 패스워드를 가져와 PasswordEncoder을 통해 비교했습니다.'
- 로그인에 성공 시 응답 body로 AccessToken, 쿠키 값으로 RefreshToken을 발급했습니다.
- UserClientImpl 쪽에서 try-catch 구문을 통해 200 응답이 아닐 경우, 예외 처리를 분기해뒀습니다.

### 로그아웃 기능 구현
- 로그아웃 시 현재 사용중인 액세스 토큰과 리프레쉬 토큰을 BlackList 토큰으로 등록합니다.
- B2B 특성 상, 유저 생성,수정,삭제 등을 진행할 수 있는 마스터 관리자와 허브 관리자만 블랙리스트로 등록하도록 설정했습니다.
- 현재는 DB에만 저장하지만 추후 Redis에도 캐시로 저장해 Gateway-service에서 Redis를 통해 블랙리스트 여부를 판별할 수 있도록 진행할 예정입니다.

### 토큰 재발급 기능 구현
- 유효한 RefreshToken으로 재발급 요청이 들어올 경우, 새로운 AccessToken과 RefreshToken을 발급하고 기존의 토큰을 블랙리스트로 등록합니다.
- AT가 존재하지 않는 경우에도 RT가 유효하다면 새로운 토큰을 발급합니다.