### PR TITLE
허브 삭제 기능 구현

### DIFF
--- a/delivery/build.gradle
+++ b/delivery/build.gradle
@@ -64,6 +64,10 @@ dependencies {
 
     // REST Assured for E2E testing
     testImplementation 'io.rest-assured:rest-assured:5.4.0'
+
+    // security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 dependencyManagement {

--- a/delivery/src/main/java/com/klp/delivery/common/entity/BaseEntity.java
+++ b/delivery/src/main/java/com/klp/delivery/common/entity/BaseEntity.java
@@ -5,6 +5,7 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import lombok.Getter;
+import lombok.Setter;
 import org.hibernate.annotations.Comment;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -36,9 +37,11 @@ public abstract class BaseEntity {
     private Long updatedBy;
 
     @Comment("삭제 시간")
+    @Setter
     private LocalDateTime deletedAt;
 
     @Comment("삭제자")
+    @Setter
     private Long deletedBy;
 
     public void delete(Long deletedBy) {

--- a/delivery/src/main/java/com/klp/delivery/common/entity/UserDetailsImpl.java
+++ b/delivery/src/main/java/com/klp/delivery/common/entity/UserDetailsImpl.java
@@ -1,0 +1,32 @@
+package com.klp.delivery.common.entity;
+
+import java.util.Collection;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+@AllArgsConstructor
+public class UserDetailsImpl implements UserDetails {
+
+    private final Long userId;
+    private final String username;
+    private final String role;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(() -> "ROLE_" + role);
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+}

--- a/delivery/src/main/java/com/klp/delivery/common/enums/RoutePlanStatus.java
+++ b/delivery/src/main/java/com/klp/delivery/common/enums/RoutePlanStatus.java
@@ -1,0 +1,19 @@
+package com.klp.delivery.common.enums;
+
+public enum RoutePlanStatus {
+    ACTIVE,
+    PENDING_DELETE,
+    DELETED;
+
+    public boolean isActive() {
+        return this == ACTIVE;
+    }
+
+    public boolean isPendingDelete() {
+        return this == PENDING_DELETE;
+    }
+
+    public boolean isDeleted() {
+        return this == DELETED;
+    }
+}

--- a/delivery/src/main/java/com/klp/delivery/global/config/SchedulingConfig.java
+++ b/delivery/src/main/java/com/klp/delivery/global/config/SchedulingConfig.java
@@ -1,0 +1,10 @@
+package com.klp.delivery.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+
+}

--- a/delivery/src/main/java/com/klp/delivery/global/config/SecurityConfig.java
+++ b/delivery/src/main/java/com/klp/delivery/global/config/SecurityConfig.java
@@ -1,0 +1,35 @@
+package com.klp.delivery.global.config;
+
+import com.klp.delivery.global.filter.AuthorizationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final AuthorizationFilter authorizationFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .logout(AbstractHttpConfigurer::disable)
+            .sessionManagement(sessionManagement ->
+                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .addFilterBefore(authorizationFilter, UsernamePasswordAuthenticationFilter.class)
+        ;
+        return http.build();
+    }
+}

--- a/delivery/src/main/java/com/klp/delivery/global/filter/AuthorizationFilter.java
+++ b/delivery/src/main/java/com/klp/delivery/global/filter/AuthorizationFilter.java
@@ -1,0 +1,47 @@
+package com.klp.delivery.global.filter;
+
+import com.klp.delivery.common.entity.UserDetailsImpl;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class AuthorizationFilter extends OncePerRequestFilter {
+
+    private static final String USER_ID_HEADER = "X-User-Id";
+    private static final String USER_NAME_HEADER = "X-User-Name";
+    private static final String USER_ROLE_HEADER = "X-User-Role";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain)
+        throws ServletException, IOException {
+
+        String userId = request.getHeader(USER_ID_HEADER);
+        String userName = request.getHeader(USER_NAME_HEADER);
+        String role = request.getHeader(USER_ROLE_HEADER);
+
+        if (userId == null || userName == null || role == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        UserDetailsImpl userDetails = new UserDetailsImpl(Long.valueOf(userId), userName, role);
+
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+            userDetails, null, userDetails.getAuthorities()
+        );
+
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/delivery/src/main/java/com/klp/delivery/routeplan/application/command/HubInfo.java
+++ b/delivery/src/main/java/com/klp/delivery/routeplan/application/command/HubInfo.java
@@ -11,4 +11,7 @@ public record HubInfo(
     String status
 ) {
 
+    public boolean isActive() {
+        return this.status.equals("ACTIVE");
+    }
 }

--- a/delivery/src/main/java/com/klp/delivery/routeplan/application/scheduler/RoutePlanDeleteScheduler.java
+++ b/delivery/src/main/java/com/klp/delivery/routeplan/application/scheduler/RoutePlanDeleteScheduler.java
@@ -1,0 +1,55 @@
+package com.klp.delivery.routeplan.application.scheduler;
+
+import com.klp.delivery.common.enums.RoutePlanStatus;
+import com.klp.delivery.routeplan.application.service.DeliveryClientService;
+import com.klp.delivery.routeplan.domain.model.RoutePlan;
+import com.klp.delivery.routeplan.domain.repository.RoutePlanRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RoutePlanDeleteScheduler {
+
+    private final RoutePlanRepository routePlanRepository;
+    private final DeliveryClientService deliveryClientService;
+
+    /*
+     * 삭제 대기인 RoutePlan 중에서 진행중인 배송이 없는 것들을 정리
+     * 3시간 주기로 실행
+     */
+    @Scheduled(
+        fixedRateString = "${scheduler.route-plan-delete.fixed-rate}",
+        initialDelayString = "${scheduler.route-plan-delete.initial-delay}"
+    )
+    @Transactional
+    public void cleanPendingDeleteRoutePlans() {
+        log.info("[RoutePlanPendingDeleteScheduler] 시작 - PENDING_DELETE RoutePlan 정리");
+
+        List<RoutePlan> pendingDeleteRoutePlans =
+            routePlanRepository.findAllByStatus(RoutePlanStatus.PENDING_DELETE);
+
+        for (RoutePlan routePlan : pendingDeleteRoutePlans) {
+            UUID routePlanId = routePlan.getRoutePlanId();
+
+            boolean hasActiveDeliveries =
+                deliveryClientService.hasActiveDeliveries(routePlanId);
+
+            if (hasActiveDeliveries) {
+                log.info("[RoutePlanPendingDeleteScheduler] 아직 사용 중인 RoutePlan, 보류 routePlanId={}",
+                    routePlanId);
+                continue;
+            }
+
+            routePlan.softDelete();
+        }
+
+        log.info("[RoutePlanPendingDeleteScheduler] 종료 - PENDING_DELETE RoutePlan 정리");
+    }
+}

--- a/delivery/src/main/java/com/klp/delivery/routeplan/application/service/DeliveryClientService.java
+++ b/delivery/src/main/java/com/klp/delivery/routeplan/application/service/DeliveryClientService.java
@@ -1,0 +1,8 @@
+package com.klp.delivery.routeplan.application.service;
+
+import java.util.UUID;
+
+public interface DeliveryClientService {
+
+    boolean hasActiveDeliveries(UUID routePlanId);
+}

--- a/delivery/src/main/java/com/klp/delivery/routeplan/application/service/RoutePlanService.java
+++ b/delivery/src/main/java/com/klp/delivery/routeplan/application/service/RoutePlanService.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -52,7 +53,7 @@ public class RoutePlanService {
 
         //출발 허브 조회
         HubInfo departureHub = hubClientService.getHubById(command.departureId());
-        if (departureHub == null) {
+        if (departureHub == null || !departureHub.isActive()) {
             log.warn("[RoutePlanService] 허브 조회 실패 - hubId: {} 존재하지 않음",
                 command.departureId());
             throw new BusinessException(RoutePlanErrorCode.HUB_NOT_FOUND);
@@ -60,7 +61,7 @@ public class RoutePlanService {
 
         //도착 허브 조회
         HubInfo arrivalHub = hubClientService.getHubById(command.arrivalId());
-        if (arrivalHub == null) {
+        if (arrivalHub == null || !arrivalHub.isActive()) {
             log.warn("[RoutePlanService] 허브 조회 실패 - hubId: {} 존재하지 않음",
                 command.arrivalId());
             throw new BusinessException(RoutePlanErrorCode.HUB_NOT_FOUND);
@@ -131,6 +132,7 @@ public class RoutePlanService {
 
     //경로 계획 삭제
     @Transactional
+    @CacheEvict(cacheNames = CACHE_NAME, key = "#routePlanId")
     public void deleteRoutePlan(UUID routePlanId) {
         RoutePlan routePlan = getRoutePlanById(routePlanId);
 

--- a/delivery/src/main/java/com/klp/delivery/routeplan/application/service/RoutePlanService.java
+++ b/delivery/src/main/java/com/klp/delivery/routeplan/application/service/RoutePlanService.java
@@ -5,11 +5,14 @@ import com.klp.delivery.routeplan.application.command.CreateRoutePlanCommand;
 import com.klp.delivery.routeplan.application.command.HubInfo;
 import com.klp.delivery.routeplan.application.command.HubRouteInfo;
 import com.klp.delivery.routeplan.domain.model.RoutePlan;
+import com.klp.delivery.routeplan.domain.model.RoutePlanItem;
 import com.klp.delivery.routeplan.domain.policy.RoutePlanPolicy;
 import com.klp.delivery.routeplan.domain.repository.RoutePlanRepository;
 import com.klp.delivery.routeplan.exception.RoutePlanErrorCode;
+import com.klp.delivery.routeplan.exception.RoutePlanItemErrorCode;
 import com.klp.delivery.routeplan.presentation.dto.response.CreateRoutePlanResponse;
 import com.klp.delivery.routeplan.presentation.dto.response.GetRoutePlanDetailResponse;
+import com.klp.delivery.routeplan.presentation.dto.response.GetRoutePlanItemDetailResponse;
 import com.klp.delivery.routeplan.presentation.dto.response.GetRoutePlanListResponse;
 import java.util.List;
 import java.util.UUID;
@@ -143,6 +146,23 @@ public class RoutePlanService {
             .orElseThrow(() -> {
                 log.warn("[RoutePlanService] 경로 계획 조회 실패 - routPlanId: {} 존재하지 않음", routePlanId);
                 return new BusinessException(RoutePlanErrorCode.NO_ROUTE_PLAN_FOUND);
+            });
+    }
+
+    //경로 계획 구간 정보 ID로 조회
+    @Transactional(readOnly = true)
+    public GetRoutePlanItemDetailResponse getRoutePlanItem(UUID planId, UUID routePlanItemId) {
+        return GetRoutePlanItemDetailResponse.from(getRoutePlanItemById(routePlanItemId), planId);
+    }
+
+    //경로 계획 구간 정보 조회 서비스 내부용
+    @Transactional(readOnly = true)
+    public RoutePlanItem getRoutePlanItemById(UUID routePlanItemId) {
+        return routePlanRepository.findRoutePlanItemById(routePlanItemId)
+            .orElseThrow(() -> {
+                log.warn("[RoutePlanService] 경로 계획 구간 정보 조회 실패 - routPlanItemId: {} 존재하지 않음",
+                    routePlanItemId);
+                return new BusinessException(RoutePlanItemErrorCode.NO_ROUTE_PLAN_ITEM_FOUND);
             });
     }
 }

--- a/delivery/src/main/java/com/klp/delivery/routeplan/application/service/RoutePlanService.java
+++ b/delivery/src/main/java/com/klp/delivery/routeplan/application/service/RoutePlanService.java
@@ -5,14 +5,11 @@ import com.klp.delivery.routeplan.application.command.CreateRoutePlanCommand;
 import com.klp.delivery.routeplan.application.command.HubInfo;
 import com.klp.delivery.routeplan.application.command.HubRouteInfo;
 import com.klp.delivery.routeplan.domain.model.RoutePlan;
-import com.klp.delivery.routeplan.domain.model.RoutePlanItem;
 import com.klp.delivery.routeplan.domain.policy.RoutePlanPolicy;
 import com.klp.delivery.routeplan.domain.repository.RoutePlanRepository;
 import com.klp.delivery.routeplan.exception.RoutePlanErrorCode;
-import com.klp.delivery.routeplan.exception.RoutePlanItemErrorCode;
 import com.klp.delivery.routeplan.presentation.dto.response.CreateRoutePlanResponse;
 import com.klp.delivery.routeplan.presentation.dto.response.GetRoutePlanDetailResponse;
-import com.klp.delivery.routeplan.presentation.dto.response.GetRoutePlanItemDetailResponse;
 import com.klp.delivery.routeplan.presentation.dto.response.GetRoutePlanListResponse;
 import java.util.List;
 import java.util.UUID;
@@ -146,23 +143,6 @@ public class RoutePlanService {
             .orElseThrow(() -> {
                 log.warn("[RoutePlanService] 경로 계획 조회 실패 - routPlanId: {} 존재하지 않음", routePlanId);
                 return new BusinessException(RoutePlanErrorCode.NO_ROUTE_PLAN_FOUND);
-            });
-    }
-
-    //경로 계획 구간 정보 ID로 조회
-    @Transactional(readOnly = true)
-    public GetRoutePlanItemDetailResponse getRoutePlanItem(UUID planId, UUID routePlanItemId) {
-        return GetRoutePlanItemDetailResponse.from(getRoutePlanItemById(routePlanItemId), planId);
-    }
-
-    //경로 계획 구간 정보 조회 서비스 내부용
-    @Transactional(readOnly = true)
-    public RoutePlanItem getRoutePlanItemById(UUID routePlanItemId) {
-        return routePlanRepository.findRoutePlanItemById(routePlanItemId)
-            .orElseThrow(() -> {
-                log.warn("[RoutePlanService] 경로 계획 구간 정보 조회 실패 - routPlanItemId: {} 존재하지 않음",
-                    routePlanItemId);
-                return new BusinessException(RoutePlanItemErrorCode.NO_ROUTE_PLAN_ITEM_FOUND);
             });
     }
 }

--- a/delivery/src/main/java/com/klp/delivery/routeplan/application/service/RoutePlanService.java
+++ b/delivery/src/main/java/com/klp/delivery/routeplan/application/service/RoutePlanService.java
@@ -1,6 +1,7 @@
 package com.klp.delivery.routeplan.application.service;
 
 import com.klp.common.exception.BusinessException;
+import com.klp.delivery.common.entity.UserDetailsImpl;
 import com.klp.delivery.routeplan.application.command.CreateRoutePlanCommand;
 import com.klp.delivery.routeplan.application.command.HubInfo;
 import com.klp.delivery.routeplan.application.command.HubRouteInfo;
@@ -133,12 +134,18 @@ public class RoutePlanService {
     //경로 계획 삭제
     @Transactional
     @CacheEvict(cacheNames = CACHE_NAME, key = "#routePlanId")
-    public void deleteRoutePlan(UUID routePlanId) {
+    public void deleteRoutePlan(UUID routePlanId, UserDetailsImpl userDetails) {
         RoutePlan routePlan = getRoutePlanById(routePlanId);
+        routePlan.pendingDelete(userDetails.getUserId());
+    }
 
-        //TODO: 유저 ID 수정하기
-        routePlan.getRoutePlanItems().forEach(item -> item.delete(0L));
-        routePlan.delete(0L);
+    //hubId와 관련된 경로 계획 삭제
+    @Transactional
+    @CacheEvict(cacheNames = CACHE_NAME, key = "#routePlan")
+    public void markRoutePlansPendingDeleteByHubId(UUID hubId, UserDetailsImpl userDetails) {
+        List<RoutePlan> plans = routePlanRepository.findByHubId(hubId);
+
+        plans.forEach(plan -> plan.pendingDelete(userDetails.getUserId()));
     }
 
     //경로 계획 ID로 조회 서비스 내부용

--- a/delivery/src/main/java/com/klp/delivery/routeplan/domain/model/RoutePlan.java
+++ b/delivery/src/main/java/com/klp/delivery/routeplan/domain/model/RoutePlan.java
@@ -2,6 +2,7 @@ package com.klp.delivery.routeplan.domain.model;
 
 import com.klp.common.exception.BusinessException;
 import com.klp.delivery.common.entity.BaseEntity;
+import com.klp.delivery.common.enums.RoutePlanStatus;
 import com.klp.delivery.routeplan.domain.vo.PlanDetailVo;
 import com.klp.delivery.routeplan.domain.vo.RouteInfoVo;
 import com.klp.delivery.routeplan.exception.RoutePlanErrorCode;
@@ -17,6 +18,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -210,5 +212,22 @@ public class RoutePlan extends BaseEntity {
         if (routeInfos == null || routeInfos.isEmpty()) {
             throw new BusinessException(RoutePlanErrorCode.ROUTE_INFOS_NEEDED);
         }
+    }
+
+    public void pendingDelete(Long userId) {
+        this.status = RoutePlanStatus.PENDING_DELETE;
+        this.setDeletedBy(userId);
+    }
+
+    public void softDelete() {
+        if (!this.status.isPendingDelete()) {
+            return;
+        }
+
+        this.status = RoutePlanStatus.DELETED;
+        this.setDeletedAt(LocalDateTime.now());
+        this.getRoutePlanItems().forEach(routePlanItem -> {
+            routePlanItem.delete(0L);
+        });
     }
 }

--- a/delivery/src/main/java/com/klp/delivery/routeplan/domain/model/RoutePlan.java
+++ b/delivery/src/main/java/com/klp/delivery/routeplan/domain/model/RoutePlan.java
@@ -8,6 +8,8 @@ import com.klp.delivery.routeplan.exception.RoutePlanErrorCode;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -41,6 +43,7 @@ import lombok.extern.slf4j.Slf4j;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Slf4j
 public class RoutePlan extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID routePlanId;
@@ -55,81 +58,106 @@ public class RoutePlan extends BaseEntity {
     @Column(nullable = false)
     private Double totalDistanceKm;
 
-    @OneToMany(mappedBy = "routePlan",fetch = FetchType.LAZY, cascade = CascadeType.ALL,orphanRemoval = true)
-    private List<RoutePlanItem> routePlanItems=new ArrayList<>();
+    @OneToMany(mappedBy = "routePlan", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RoutePlanItem> routePlanItems = new ArrayList<>();
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private RoutePlanStatus status;
 
     //직행 경로 계획
-    public static RoutePlan create(UUID departureId, UUID arrivalId, long totalDurationMin, double totalDistanceKm) {
-        validateCreateParam(departureId,arrivalId,totalDurationMin,totalDistanceKm);
-        RoutePlan routePlan=new RoutePlan();
+    public static RoutePlan create(UUID departureId, UUID arrivalId, long totalDurationMin,
+        double totalDistanceKm) {
+        validateCreateParam(departureId, arrivalId, totalDurationMin, totalDistanceKm);
+        RoutePlan routePlan = new RoutePlan();
         routePlan.departureId = departureId;
         routePlan.arrivalId = arrivalId;
         routePlan.totalDurationMin = totalDurationMin;
         routePlan.totalDistanceKm = totalDistanceKm;
-        routePlan.routePlanItems.add(RoutePlanItem.create(departureId,arrivalId,totalDurationMin,totalDistanceKm,1,routePlan));
+        routePlan.routePlanItems.add(
+            RoutePlanItem.create(departureId, arrivalId, totalDurationMin, totalDistanceKm, 1,
+                routePlan));
+        routePlan.status = RoutePlanStatus.ACTIVE;
         return routePlan;
     }
 
-    private static void validateCreateParam(UUID departureId, UUID arrivalId, long totalDurationMin, double totalDistanceKm) {
-        if (departureId == null) throw new BusinessException(RoutePlanErrorCode.DEPARTURE_ID_REQUIRED);
-        if (arrivalId == null) throw new BusinessException(RoutePlanErrorCode.ARRIVAL_ID_REQUIRED);
-        if (totalDurationMin <= 0) throw new BusinessException(RoutePlanErrorCode.DURATION_INVALID);
-        if (totalDistanceKm <= 0) throw new BusinessException(RoutePlanErrorCode.DISTANCE_INVALID);
+    private static void validateCreateParam(UUID departureId, UUID arrivalId, long totalDurationMin,
+        double totalDistanceKm) {
+        if (departureId == null) {
+            throw new BusinessException(RoutePlanErrorCode.DEPARTURE_ID_REQUIRED);
+        }
+        if (arrivalId == null) {
+            throw new BusinessException(RoutePlanErrorCode.ARRIVAL_ID_REQUIRED);
+        }
+        if (totalDurationMin <= 0) {
+            throw new BusinessException(RoutePlanErrorCode.DURATION_INVALID);
+        }
+        if (totalDistanceKm <= 0) {
+            throw new BusinessException(RoutePlanErrorCode.DISTANCE_INVALID);
+        }
     }
 
     //경유 경로 계획
-    public static RoutePlan plan(UUID originId, UUID destinationId,RouteInfoVo directRoute,List<RouteInfoVo> routeInfos) {
-        validatePlanParam(originId,destinationId,routeInfos);
+    public static RoutePlan plan(UUID originId, UUID destinationId, RouteInfoVo directRoute,
+        List<RouteInfoVo> routeInfos) {
+        validatePlanParam(originId, destinationId, routeInfos);
         /*
             키: 출발허브ID, 값: 출발 허브ID인 이동 정보
             출발 허브의 도착 가능한 모든 허브 이동 정보
         * */
-        Map<UUID,List<RouteInfoVo>> routeInfoMap=new HashMap<>();
-        Set<UUID> hubIdSet=new HashSet<>();
+        Map<UUID, List<RouteInfoVo>> routeInfoMap = new HashMap<>();
+        Set<UUID> hubIdSet = new HashSet<>();
         routeInfos.forEach(routeInfo -> {
-            if(routeInfo.equals(directRoute)) return;
-            routeInfoMap.computeIfAbsent(routeInfo.departureId(),k->new ArrayList<>()).add(routeInfo);
+            if (routeInfo.equals(directRoute)) {
+                return;
+            }
+            routeInfoMap.computeIfAbsent(routeInfo.departureId(), k -> new ArrayList<>())
+                .add(routeInfo);
             hubIdSet.add(routeInfo.departureId());
             hubIdSet.add(routeInfo.arrivalId());
         });
 
         /*
-        * 키: 도착허브ID, 값: 경로 계획 요약 정보
-        * {경로 구간 정보 list, 총 시간, 총 거리}
-        * */
-        Map<UUID, PlanDetailVo> planDetailMap=new HashMap<>();
+         * 키: 도착허브ID, 값: 경로 계획 요약 정보
+         * {경로 구간 정보 list, 총 시간, 총 거리}
+         * */
+        Map<UUID, PlanDetailVo> planDetailMap = new HashMap<>();
         hubIdSet.forEach(hubId -> {
-            planDetailMap.put(hubId,new PlanDetailVo(hubId,new ArrayList<>(),Long.MAX_VALUE,0.));
+            planDetailMap.put(hubId,
+                new PlanDetailVo(hubId, new ArrayList<>(), Long.MAX_VALUE, 0.));
         });
         planDetailMap.put(originId, new PlanDetailVo(originId, new ArrayList<>(), 0L, 0.));
 
-        PriorityQueue<PlanDetailVo> planPriorityQ=new PriorityQueue<>();
+        PriorityQueue<PlanDetailVo> planPriorityQ = new PriorityQueue<>();
         planPriorityQ.add(planDetailMap.get(originId));
 
-        while (!planPriorityQ.isEmpty()){
-            PlanDetailVo now=planPriorityQ.poll();
-            if(now.totalDurationMin()> planDetailMap.get(now.hubId()).totalDurationMin())continue;
+        while (!planPriorityQ.isEmpty()) {
+            PlanDetailVo now = planPriorityQ.poll();
+            if (now.totalDurationMin() > planDetailMap.get(now.hubId()).totalDurationMin()) {
+                continue;
+            }
 
             List<RouteInfoVo> nextRoutes = routeInfoMap.get(now.hubId());
-            if (nextRoutes == null) continue;
+            if (nextRoutes == null) {
+                continue;
+            }
 
-            for(RouteInfoVo next:nextRoutes){
-                PlanDetailVo bestPlan=planDetailMap.get(next.arrivalId());
-                Long duration= now.totalDurationMin()+next.durationMin();
-                Double distance= now.totalDistanceKm()+next.distanceKm();
-                if(bestPlan.totalDurationMin()>duration){
-                    renewBestPlan(planDetailMap,planPriorityQ,now,next,duration,distance);
-                }
-                else if(bestPlan.totalDurationMin().equals(duration)){
-                    if(bestPlan.totalDistanceKm()>distance){
-                        renewBestPlan(planDetailMap,planPriorityQ,now,next,duration,distance);
+            for (RouteInfoVo next : nextRoutes) {
+                PlanDetailVo bestPlan = planDetailMap.get(next.arrivalId());
+                Long duration = now.totalDurationMin() + next.durationMin();
+                Double distance = now.totalDistanceKm() + next.distanceKm();
+                if (bestPlan.totalDurationMin() > duration) {
+                    renewBestPlan(planDetailMap, planPriorityQ, now, next, duration, distance);
+                } else if (bestPlan.totalDurationMin().equals(duration)) {
+                    if (bestPlan.totalDistanceKm() > distance) {
+                        renewBestPlan(planDetailMap, planPriorityQ, now, next, duration, distance);
                     }
                 }
             }
         }
 
-        PlanDetailVo bestPlan=planDetailMap.get(destinationId);
-        if(bestPlan==null){
+        PlanDetailVo bestPlan = planDetailMap.get(destinationId);
+        if (bestPlan == null) {
             log.warn(
                 "경로 계획에 실패했습니다. 출발지(originId)={}, 도착지(destinationId)={}",
                 originId,
@@ -138,24 +166,27 @@ public class RoutePlan extends BaseEntity {
             throw new BusinessException(RoutePlanErrorCode.NO_ROUTE_PLAN_FOUND);
         }
 
-        RoutePlan routePlan=new RoutePlan();
-        routePlan.departureId=originId;
-        routePlan.arrivalId=destinationId;
-        routePlan.totalDurationMin=bestPlan.totalDurationMin();
-        routePlan.totalDistanceKm=bestPlan.totalDistanceKm();
+        RoutePlan routePlan = new RoutePlan();
+        routePlan.departureId = originId;
+        routePlan.arrivalId = destinationId;
+        routePlan.totalDurationMin = bestPlan.totalDurationMin();
+        routePlan.totalDistanceKm = bestPlan.totalDistanceKm();
+        routePlan.status = RoutePlanStatus.ACTIVE;
 
         //경로 계획 구간 정보들
-        List<RouteInfoVo> planItemVos= bestPlan.planItems();
-        for(int i=0;i<planItemVos.size();i++){
-            RouteInfoVo info=planItemVos.get(i);
-            RoutePlanItem routePlanItem=RoutePlanItem.from(info,i+1,routePlan);
+        List<RouteInfoVo> planItemVos = bestPlan.planItems();
+        for (int i = 0; i < planItemVos.size(); i++) {
+            RouteInfoVo info = planItemVos.get(i);
+            RoutePlanItem routePlanItem = RoutePlanItem.from(info, i + 1, routePlan);
             routePlan.routePlanItems.add(routePlanItem);
         }
 
         return routePlan;
     }
 
-    private static void renewBestPlan(Map<UUID, PlanDetailVo> planDetailMap, PriorityQueue<PlanDetailVo> planPriorityQ, PlanDetailVo now, RouteInfoVo next, Long duration, Double distance) {
+    private static void renewBestPlan(Map<UUID, PlanDetailVo> planDetailMap,
+        PriorityQueue<PlanDetailVo> planPriorityQ, PlanDetailVo now, RouteInfoVo next,
+        Long duration, Double distance) {
         List<RouteInfoVo> planItems = new ArrayList<>(now.planItems());
         planItems.add(next);
 
@@ -164,13 +195,20 @@ public class RoutePlan extends BaseEntity {
             duration,
             distance);
 
-        planDetailMap.put(next.arrivalId(),newBestPlan);
+        planDetailMap.put(next.arrivalId(), newBestPlan);
         planPriorityQ.add(newBestPlan);
     }
 
-    private static void validatePlanParam(UUID originId, UUID destinationId,List<RouteInfoVo> routeInfos) {
-        if (originId == null) throw new BusinessException(RoutePlanErrorCode.DEPARTURE_ID_REQUIRED);
-        if (destinationId == null) throw new BusinessException(RoutePlanErrorCode.ARRIVAL_ID_REQUIRED);
-        if (routeInfos == null || routeInfos.isEmpty()) throw new BusinessException(RoutePlanErrorCode.ROUTE_INFOS_NEEDED);
+    private static void validatePlanParam(UUID originId, UUID destinationId,
+        List<RouteInfoVo> routeInfos) {
+        if (originId == null) {
+            throw new BusinessException(RoutePlanErrorCode.DEPARTURE_ID_REQUIRED);
+        }
+        if (destinationId == null) {
+            throw new BusinessException(RoutePlanErrorCode.ARRIVAL_ID_REQUIRED);
+        }
+        if (routeInfos == null || routeInfos.isEmpty()) {
+            throw new BusinessException(RoutePlanErrorCode.ROUTE_INFOS_NEEDED);
+        }
     }
 }

--- a/delivery/src/main/java/com/klp/delivery/routeplan/domain/model/RoutePlanStatus.java
+++ b/delivery/src/main/java/com/klp/delivery/routeplan/domain/model/RoutePlanStatus.java
@@ -1,7 +1,0 @@
-package com.klp.delivery.routeplan.domain.model;
-
-public enum RoutePlanStatus {
-    ACTIVE,
-    PENDING_DELETE,
-    DELETED
-}

--- a/delivery/src/main/java/com/klp/delivery/routeplan/domain/model/RoutePlanStatus.java
+++ b/delivery/src/main/java/com/klp/delivery/routeplan/domain/model/RoutePlanStatus.java
@@ -1,0 +1,7 @@
+package com.klp.delivery.routeplan.domain.model;
+
+public enum RoutePlanStatus {
+    ACTIVE,
+    PENDING_DELETE,
+    DELETED
+}

--- a/delivery/src/main/java/com/klp/delivery/routeplan/domain/repository/RoutePlanRepository.java
+++ b/delivery/src/main/java/com/klp/delivery/routeplan/domain/repository/RoutePlanRepository.java
@@ -1,7 +1,9 @@
 package com.klp.delivery.routeplan.domain.repository;
 
+import com.klp.delivery.common.enums.RoutePlanStatus;
 import com.klp.delivery.routeplan.domain.model.RoutePlan;
 import com.klp.delivery.routeplan.domain.model.RoutePlanItem;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -25,4 +27,8 @@ public interface RoutePlanRepository {
     Page<RoutePlan> findAll(UUID depId, UUID arrId, Pageable pageable);
 
     Optional<RoutePlanItem> findRoutePlanItemById(UUID routePlanId);
+
+    List<RoutePlan> findByHubId(UUID hubId);
+
+    List<RoutePlan> findAllByStatus(RoutePlanStatus routePlanStatus);
 }

--- a/delivery/src/main/java/com/klp/delivery/routeplan/domain/repository/RoutePlanRepository.java
+++ b/delivery/src/main/java/com/klp/delivery/routeplan/domain/repository/RoutePlanRepository.java
@@ -1,6 +1,7 @@
 package com.klp.delivery.routeplan.domain.repository;
 
 import com.klp.delivery.routeplan.domain.model.RoutePlan;
+import com.klp.delivery.routeplan.domain.model.RoutePlanItem;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -22,4 +23,6 @@ public interface RoutePlanRepository {
     Optional<RoutePlan> findByRoutePlanIdAndDeletedAtIsNull(UUID routePlanId);
 
     Page<RoutePlan> findAll(UUID depId, UUID arrId, Pageable pageable);
+
+    Optional<RoutePlanItem> findRoutePlanItemById(UUID routePlanId);
 }

--- a/delivery/src/main/java/com/klp/delivery/routeplan/domain/repository/RoutePlanRepository.java
+++ b/delivery/src/main/java/com/klp/delivery/routeplan/domain/repository/RoutePlanRepository.java
@@ -1,7 +1,6 @@
 package com.klp.delivery.routeplan.domain.repository;
 
 import com.klp.delivery.routeplan.domain.model.RoutePlan;
-import com.klp.delivery.routeplan.domain.model.RoutePlanItem;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -23,6 +22,4 @@ public interface RoutePlanRepository {
     Optional<RoutePlan> findByRoutePlanIdAndDeletedAtIsNull(UUID routePlanId);
 
     Page<RoutePlan> findAll(UUID depId, UUID arrId, Pageable pageable);
-
-    Optional<RoutePlanItem> findRoutePlanItemById(UUID routePlanId);
 }

--- a/delivery/src/main/java/com/klp/delivery/routeplan/infrastructure/client/DeliveryClientServiceImpl.java
+++ b/delivery/src/main/java/com/klp/delivery/routeplan/infrastructure/client/DeliveryClientServiceImpl.java
@@ -1,0 +1,20 @@
+package com.klp.delivery.routeplan.infrastructure.client;
+
+import com.klp.delivery.delivery.application.facade.DeliveryFacade;
+import com.klp.delivery.routeplan.application.service.DeliveryClientService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryClientServiceImpl implements DeliveryClientService {
+
+    private final DeliveryFacade deliveryFacade;
+
+    @Override
+    public boolean hasActiveDeliveries(UUID routePlanId) {
+        //TODO: 배송에서 구현되면 수정
+        return true;
+    }
+}

--- a/delivery/src/main/java/com/klp/delivery/routeplan/infrastructure/repository/RoutePlanJpaRepository.java
+++ b/delivery/src/main/java/com/klp/delivery/routeplan/infrastructure/repository/RoutePlanJpaRepository.java
@@ -1,6 +1,8 @@
 package com.klp.delivery.routeplan.infrastructure.repository;
 
+import com.klp.delivery.common.enums.RoutePlanStatus;
 import com.klp.delivery.routeplan.domain.model.RoutePlan;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -11,16 +13,20 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface RoutePlanJpaRepository extends JpaRepository<RoutePlan, UUID> {
+
     @Modifying
     @Query("update RoutePlan r set r.deletedAt = CURRENT_TIMESTAMP " +
         "where r.departureId = :dep and r.arrivalId = :arr")
     void softDeleteByDepartureAndArrival(@Param("dep") UUID dep, @Param("arr") UUID arr);
 
-    Optional<RoutePlan> findByDepartureIdAndArrivalIdAndDeletedAtIsNull(UUID departureId, UUID arrivalId);
+    Optional<RoutePlan> findByDepartureIdAndArrivalIdAndDeletedAtIsNull(UUID departureId,
+        UUID arrivalId);
 
     boolean existsByDepartureIdAndArrivalId(UUID dep, UUID arr);
 
     Optional<RoutePlan> findByRoutePlanIdAndDeletedAtIsNull(UUID id);
 
     Page<RoutePlan> findAllByDeletedAtIsNull(Pageable pageable);
+
+    List<RoutePlan> findAllByStatus(RoutePlanStatus status);
 }

--- a/delivery/src/main/java/com/klp/delivery/routeplan/infrastructure/repository/RoutePlanRepositoryImpl.java
+++ b/delivery/src/main/java/com/klp/delivery/routeplan/infrastructure/repository/RoutePlanRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.klp.delivery.routeplan.infrastructure.repository;
 import com.klp.delivery.routeplan.domain.model.QRoutePlan;
 import com.klp.delivery.routeplan.domain.model.RoutePlan;
 import com.klp.delivery.routeplan.domain.model.RoutePlanItem;
+import com.klp.delivery.routeplan.domain.model.RoutePlanStatus;
 import com.klp.delivery.routeplan.domain.repository.RoutePlanRepository;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -67,7 +68,8 @@ public class RoutePlanRepositoryImpl implements RoutePlanRepository {
             .where(
                 depId != null ? qRoutePlan.departureId.eq(depId) : null,
                 arrId != null ? qRoutePlan.arrivalId.eq(arrId) : null,
-                qRoutePlan.deletedAt.isNull()
+                qRoutePlan.deletedAt.isNull(),
+                qRoutePlan.status.eq(RoutePlanStatus.ACTIVE)
             );
 
         if (pageable.getSort().isSorted()) {

--- a/delivery/src/main/java/com/klp/delivery/routeplan/infrastructure/repository/RoutePlanRepositoryImpl.java
+++ b/delivery/src/main/java/com/klp/delivery/routeplan/infrastructure/repository/RoutePlanRepositoryImpl.java
@@ -1,12 +1,14 @@
 package com.klp.delivery.routeplan.infrastructure.repository;
 
+import com.klp.delivery.common.enums.RoutePlanStatus;
 import com.klp.delivery.routeplan.domain.model.QRoutePlan;
+import com.klp.delivery.routeplan.domain.model.QRoutePlanItem;
 import com.klp.delivery.routeplan.domain.model.RoutePlan;
 import com.klp.delivery.routeplan.domain.model.RoutePlanItem;
-import com.klp.delivery.routeplan.domain.model.RoutePlanStatus;
 import com.klp.delivery.routeplan.domain.repository.RoutePlanRepository;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -97,5 +99,31 @@ public class RoutePlanRepositoryImpl implements RoutePlanRepository {
     @Override
     public Optional<RoutePlanItem> findRoutePlanItemById(UUID routePlanId) {
         return routePlanItemJpaRepository.findByRoutePlanItemIdAndDeletedAtIsNull(routePlanId);
+    }
+
+    @Override
+    public List<RoutePlan> findByHubId(UUID hubId) {
+        QRoutePlan qRoutePlan = QRoutePlan.routePlan;
+        QRoutePlanItem qRoutePlanItem = QRoutePlanItem.routePlanItem;
+
+        BooleanExpression hubMatched =
+            qRoutePlan.departureId.eq(hubId)
+                .or(qRoutePlan.arrivalId.eq(hubId))
+                .or(qRoutePlanItem.departureId.eq(hubId))
+                .or(qRoutePlanItem.arrivalId.eq(hubId));
+
+        return queryFactory
+            .selectDistinct(qRoutePlan)
+            .from(qRoutePlan)
+            .leftJoin(qRoutePlan.routePlanItems, qRoutePlanItem).fetchJoin()
+            .where(
+                hubMatched.and(qRoutePlan.status.ne(RoutePlanStatus.DELETED))
+            )
+            .fetch();
+    }
+
+    @Override
+    public List<RoutePlan> findAllByStatus(RoutePlanStatus routePlanStatus) {
+        return routePlanJpaRepository.findAllByStatus(routePlanStatus);
     }
 }

--- a/delivery/src/main/java/com/klp/delivery/routeplan/presentation/controller/RoutePlanController.java
+++ b/delivery/src/main/java/com/klp/delivery/routeplan/presentation/controller/RoutePlanController.java
@@ -4,7 +4,6 @@ import com.klp.delivery.routeplan.application.service.RoutePlanService;
 import com.klp.delivery.routeplan.presentation.dto.request.CreateRoutePlanRequest;
 import com.klp.delivery.routeplan.presentation.dto.response.CreateRoutePlanResponse;
 import com.klp.delivery.routeplan.presentation.dto.response.GetRoutePlanDetailResponse;
-import com.klp.delivery.routeplan.presentation.dto.response.GetRoutePlanItemDetailResponse;
 import com.klp.delivery.routeplan.presentation.dto.response.GetRoutePlanListResponse;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -65,13 +64,5 @@ public class RoutePlanController {
     public ResponseEntity<Void> deleteRoutePlan(@PathVariable UUID routePlanId) {
         routePlanService.deleteRoutePlan(routePlanId);
         return ResponseEntity.ok().build();
-    }
-
-    //경로 계획 구간 정보 조회
-    @GetMapping("{planId}/items/{planItemId}")
-    public ResponseEntity<GetRoutePlanItemDetailResponse> getRoutePlanItem(
-        @PathVariable UUID planId,
-        @PathVariable UUID planItemId) {
-        return ResponseEntity.ok().body(routePlanService.getRoutePlanItem(planId, planItemId));
     }
 }

--- a/delivery/src/main/java/com/klp/delivery/routeplan/presentation/controller/RoutePlanController.java
+++ b/delivery/src/main/java/com/klp/delivery/routeplan/presentation/controller/RoutePlanController.java
@@ -1,5 +1,6 @@
 package com.klp.delivery.routeplan.presentation.controller;
 
+import com.klp.delivery.common.entity.UserDetailsImpl;
 import com.klp.delivery.routeplan.application.service.RoutePlanService;
 import com.klp.delivery.routeplan.presentation.dto.request.CreateRoutePlanRequest;
 import com.klp.delivery.routeplan.presentation.dto.response.CreateRoutePlanResponse;
@@ -12,6 +13,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -62,8 +64,19 @@ public class RoutePlanController {
 
     //경로 계획 삭제
     @DeleteMapping("/{routePlanId}")
-    public ResponseEntity<Void> deleteRoutePlan(@PathVariable UUID routePlanId) {
-        routePlanService.deleteRoutePlan(routePlanId);
+    public ResponseEntity<Void> deleteRoutePlan(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @PathVariable UUID routePlanId) {
+        routePlanService.deleteRoutePlan(routePlanId, userDetails);
+        return ResponseEntity.ok().build();
+    }
+
+    //hubId와 관련된 경로 계획 삭제
+    @DeleteMapping("/delete/{hubId}")
+    public ResponseEntity<Void> deleteRoutePlansByHubId(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @PathVariable UUID hubId) {
+        routePlanService.markRoutePlansPendingDeleteByHubId(hubId, userDetails);
         return ResponseEntity.ok().build();
     }
 

--- a/delivery/src/main/java/com/klp/delivery/routeplan/presentation/controller/RoutePlanController.java
+++ b/delivery/src/main/java/com/klp/delivery/routeplan/presentation/controller/RoutePlanController.java
@@ -4,6 +4,7 @@ import com.klp.delivery.routeplan.application.service.RoutePlanService;
 import com.klp.delivery.routeplan.presentation.dto.request.CreateRoutePlanRequest;
 import com.klp.delivery.routeplan.presentation.dto.response.CreateRoutePlanResponse;
 import com.klp.delivery.routeplan.presentation.dto.response.GetRoutePlanDetailResponse;
+import com.klp.delivery.routeplan.presentation.dto.response.GetRoutePlanItemDetailResponse;
 import com.klp.delivery.routeplan.presentation.dto.response.GetRoutePlanListResponse;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -64,5 +65,13 @@ public class RoutePlanController {
     public ResponseEntity<Void> deleteRoutePlan(@PathVariable UUID routePlanId) {
         routePlanService.deleteRoutePlan(routePlanId);
         return ResponseEntity.ok().build();
+    }
+
+    //경로 계획 구간 정보 조회
+    @GetMapping("{planId}/items/{planItemId}")
+    public ResponseEntity<GetRoutePlanItemDetailResponse> getRoutePlanItem(
+        @PathVariable UUID planId,
+        @PathVariable UUID planItemId) {
+        return ResponseEntity.ok().body(routePlanService.getRoutePlanItem(planId, planItemId));
     }
 }

--- a/delivery/src/main/java/com/klp/delivery/routeplan/presentation/dto/response/GetRoutePlanDetailResponse.java
+++ b/delivery/src/main/java/com/klp/delivery/routeplan/presentation/dto/response/GetRoutePlanDetailResponse.java
@@ -11,7 +11,8 @@ public record GetRoutePlanDetailResponse(
     UUID arrivalId,
     Long totalDurationMin,
     Double totalDistanceKm,
-    List<PlanItem> planItems
+    List<PlanItem> planItems,
+    String status
 ) {
 
     public record PlanItem(
@@ -45,7 +46,8 @@ public record GetRoutePlanDetailResponse(
             routePlan.getTotalDurationMin(),
             routePlan.getTotalDistanceKm(),
             routePlan.getRoutePlanItems().stream()
-                .map(item -> PlanItem.from(item, routePlan.getRoutePlanId())).toList()
+                .map(item -> PlanItem.from(item, routePlan.getRoutePlanId())).toList(),
+            routePlan.getStatus().name()
         );
     }
 }

--- a/delivery/src/main/resources/application.yml
+++ b/delivery/src/main/resources/application.yml
@@ -26,3 +26,8 @@ logging:
   level:
     root: INFO
     com.klp.delivery: DEBUG
+
+scheduler:
+  route-plan-delete:
+    fixed-rate: ${SCHEDULER_ROUTE_PLAN_DELETE_FIXED_RATE:PT3H}
+    initial-delay: ${SCHEDULER_ROUTE_PLAN_DELETE_INITIAL_DELAY:PT0S}

--- a/delivery/src/test/java/com/klp/delivery/routeplan/presentation/RoutePlanControllerTest.java
+++ b/delivery/src/test/java/com/klp/delivery/routeplan/presentation/RoutePlanControllerTest.java
@@ -63,6 +63,8 @@ public class RoutePlanControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
             .andExpect(status().isCreated())
+            .andExpect(
+                header().string("Location", "/v1/routes/plans/" + RoutePlanFixture.ROUTE_PLAN_ID))
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.routePlanId").value(RoutePlanFixture.ROUTE_PLAN_ID.toString()));
     }

--- a/delivery/src/test/resources/application-test.yml
+++ b/delivery/src/test/resources/application-test.yml
@@ -21,4 +21,3 @@ spring:
     init:
       mode: always
       schema-locations: classpath:schema.sql
-

--- a/delivery/src/test/resources/schema.sql
+++ b/delivery/src/test/resources/schema.sql
@@ -1,2 +1,1 @@
 CREATE SCHEMA IF NOT EXISTS delivery_schema;
-

--- a/hub/build.gradle
+++ b/hub/build.gradle
@@ -67,6 +67,9 @@ dependencies {
     // security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    //openfeign
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 }
 
 dependencyManagement {

--- a/hub/src/main/java/com/klp/hub/HubApplication.java
+++ b/hub/src/main/java/com/klp/hub/HubApplication.java
@@ -3,13 +3,15 @@ package com.klp.hub;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
 @EnableDiscoveryClient
+@EnableFeignClients
 public class HubApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(HubApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(HubApplication.class, args);
+    }
 
 }

--- a/hub/src/main/java/com/klp/hub/common/entity/BaseEntity.java
+++ b/hub/src/main/java/com/klp/hub/common/entity/BaseEntity.java
@@ -5,6 +5,7 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import lombok.Getter;
+import lombok.Setter;
 import org.hibernate.annotations.Comment;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -36,9 +37,11 @@ public abstract class BaseEntity {
     private Long updatedBy;
 
     @Comment("삭제 시간")
+    @Setter
     private LocalDateTime deletedAt;
 
     @Comment("삭제자")
+    @Setter
     private Long deletedBy;
 
     public void delete(Long deletedBy) {

--- a/hub/src/main/java/com/klp/hub/common/exception/ExternalApiErrorCode.java
+++ b/hub/src/main/java/com/klp/hub/common/exception/ExternalApiErrorCode.java
@@ -1,0 +1,34 @@
+package com.klp.hub.common.exception;
+
+import com.klp.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum ExternalApiErrorCode implements ErrorCode {
+    DELIVERY_SERVICE_UNAVAILABLE(HttpStatus.BAD_GATEWAY, "배송 서비스 호출 중 오류가 발생했습니다."),
+    DELIVERY_SERVICE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "배송 서비스 호출 에러 BAD_REQUEST"),
+    DELIVERY_SERVICE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "배송 서비스 호출 에러 인증 실패"),
+    DELIVERY_SERVICE_FORBIDDEN(HttpStatus.FORBIDDEN, "배송 서비스 호출 에러 인가 실패"),
+    ORDER_SERVICE_UNAVAILABLE(HttpStatus.BAD_GATEWAY, "주문 서비스 호출 중 오류가 발생했습니다."),
+    ORDER_SERVICE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "주문 서비스 호출 에러 BAD_REQUEST"),
+    ORDER_SERVICE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "주문 서비스 호출 에러 인증 실패"),
+    ORDER_SERVICE_FORBIDDEN(HttpStatus.FORBIDDEN, "주문 서비스 호출 에러 인가 실패");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    public String getErrorCode() {
+        return this.name();
+    }
+}

--- a/hub/src/main/java/com/klp/hub/common/exception/ExternalApiException.java
+++ b/hub/src/main/java/com/klp/hub/common/exception/ExternalApiException.java
@@ -1,0 +1,15 @@
+package com.klp.hub.common.exception;
+
+import com.klp.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class ExternalApiException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public ExternalApiException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/hub/src/main/java/com/klp/hub/global/config/DeliveryFeignClientConfig.java
+++ b/hub/src/main/java/com/klp/hub/global/config/DeliveryFeignClientConfig.java
@@ -1,0 +1,15 @@
+package com.klp.hub.global.config;
+
+import com.klp.hub.global.exception.DeliveryFeignErrorDecoder;
+import feign.codec.ErrorDecoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DeliveryFeignClientConfig {
+
+    @Bean
+    public ErrorDecoder deliveryFeignErrorDecoder() {
+        return new DeliveryFeignErrorDecoder();
+    }
+}

--- a/hub/src/main/java/com/klp/hub/global/config/OrderFeignClientConfig.java
+++ b/hub/src/main/java/com/klp/hub/global/config/OrderFeignClientConfig.java
@@ -1,0 +1,15 @@
+package com.klp.hub.global.config;
+
+import com.klp.hub.global.exception.OrderFeignErrorDecoder;
+import feign.codec.ErrorDecoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OrderFeignClientConfig {
+
+    @Bean
+    public ErrorDecoder orderFeignErrorDecoder() {
+        return new OrderFeignErrorDecoder();
+    }
+}

--- a/hub/src/main/java/com/klp/hub/global/exception/DeliveryFeignErrorDecoder.java
+++ b/hub/src/main/java/com/klp/hub/global/exception/DeliveryFeignErrorDecoder.java
@@ -1,0 +1,51 @@
+package com.klp.hub.global.exception;
+
+import com.klp.hub.common.exception.ExternalApiErrorCode;
+import com.klp.hub.common.exception.ExternalApiException;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class DeliveryFeignErrorDecoder implements ErrorDecoder {
+
+    private final ErrorDecoder errorDecoder = new Default();
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        int status = response.status();
+
+        return switch (status) {
+
+            // 5xx - 외부 서비스 장애
+            case 500, 502, 503, 504 -> {
+                log.error("[DeliveryFeignErrorDecoder] 외부 서비스 장애 발생. status={}", status);
+                yield new ExternalApiException(ExternalApiErrorCode.DELIVERY_SERVICE_UNAVAILABLE);
+            }
+            case 400 -> {
+                log.warn("[DeliveryFeignErrorDecoder] 잘못된 요청. status=400");
+                yield new ExternalApiException(ExternalApiErrorCode.DELIVERY_SERVICE_BAD_REQUEST);
+            }
+            case 401 -> {
+                log.warn("[DeliveryFeignErrorDecoder] 인증 실패. status=401");
+                yield new ExternalApiException(ExternalApiErrorCode.DELIVERY_SERVICE_UNAUTHORIZED);
+            }
+            case 403 -> {
+                log.warn("[DeliveryFeignErrorDecoder] 인가 거부. status=403");
+                yield new ExternalApiException(ExternalApiErrorCode.DELIVERY_SERVICE_FORBIDDEN);
+            }
+            case 404 -> {
+                log.warn("[DeliveryFeignErrorDecoder] 리소스 없음(404). 기본 decoder 처리 적용");
+                yield errorDecoder.decode(methodKey, response);
+            }
+            default -> {
+                if (status >= 400 && status < 500) {
+                    log.warn("[DeliveryFeignErrorDecoder] 기타 4xx 오류. status={}", status);
+                    yield new ExternalApiException(
+                        ExternalApiErrorCode.DELIVERY_SERVICE_BAD_REQUEST);
+                }
+                yield errorDecoder.decode(methodKey, response);
+            }
+        };
+    }
+}

--- a/hub/src/main/java/com/klp/hub/global/exception/OrderFeignErrorDecoder.java
+++ b/hub/src/main/java/com/klp/hub/global/exception/OrderFeignErrorDecoder.java
@@ -1,0 +1,51 @@
+package com.klp.hub.global.exception;
+
+import com.klp.hub.common.exception.ExternalApiErrorCode;
+import com.klp.hub.common.exception.ExternalApiException;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class OrderFeignErrorDecoder implements ErrorDecoder {
+
+    private final ErrorDecoder errorDecoder = new Default();
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        int status = response.status();
+
+        return switch (status) {
+
+            // 5xx - 외부 서비스 장애
+            case 500, 502, 503, 504 -> {
+                log.error("[OrderFeignErrorDecoder] 외부 서비스 장애 발생. status={}", status);
+                yield new ExternalApiException(ExternalApiErrorCode.ORDER_SERVICE_UNAVAILABLE);
+            }
+            case 400 -> {
+                log.warn("[OrderFeignErrorDecoder] 잘못된 요청. status=400");
+                yield new ExternalApiException(ExternalApiErrorCode.ORDER_SERVICE_BAD_REQUEST);
+            }
+            case 401 -> {
+                log.warn("[OrderFeignErrorDecoder] 인증 실패. status=401");
+                yield new ExternalApiException(ExternalApiErrorCode.ORDER_SERVICE_UNAUTHORIZED);
+            }
+            case 403 -> {
+                log.warn("[OrderFeignErrorDecoder] 인가 거부. status=403");
+                yield new ExternalApiException(ExternalApiErrorCode.ORDER_SERVICE_FORBIDDEN);
+            }
+            case 404 -> {
+                log.warn("[OrderFeignErrorDecoder] 리소스 없음(404). 기본 decoder 처리 적용");
+                yield errorDecoder.decode(methodKey, response);
+            }
+            default -> {
+                if (status >= 400 && status < 500) {
+                    log.warn("[OrderFeignErrorDecoder] 기타 4xx 오류. status={}", status);
+                    yield new ExternalApiException(
+                        ExternalApiErrorCode.ORDER_SERVICE_BAD_REQUEST);
+                }
+                yield errorDecoder.decode(methodKey, response);
+            }
+        };
+    }
+}

--- a/hub/src/main/java/com/klp/hub/hub/application/facade/HubFacade.java
+++ b/hub/src/main/java/com/klp/hub/hub/application/facade/HubFacade.java
@@ -1,0 +1,28 @@
+package com.klp.hub.hub.application.facade;
+
+import com.klp.hub.common.model.UserDetailsImpl;
+import com.klp.hub.hub.application.service.HubRouteInfoService;
+import com.klp.hub.hub.application.service.HubService;
+import com.klp.hub.hub.infrastructure.client.DeliveryFeignClient;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class HubFacade {
+
+    private final HubService hubService;
+    private final HubRouteInfoService hubRouteInfoService;
+    private final DeliveryFeignClient deliveryFeignClient;
+
+    //허브 삭제 대기
+    public void markPendingDelete(UUID hubId, UserDetailsImpl userDetails) {
+        //허브 삭제 대기 상태 변경
+        hubService.markPendingDelete(hubId, userDetails);
+        //허브간 이동 정보 삭제
+        hubRouteInfoService.deleteHubRouteInfoByHubId(hubId, userDetails);
+        //경로 계획 삭제
+        deliveryFeignClient.deleteRoutePlansByHubId(hubId);
+    }
+}

--- a/hub/src/main/java/com/klp/hub/hub/application/facade/HubFacade.java
+++ b/hub/src/main/java/com/klp/hub/hub/application/facade/HubFacade.java
@@ -7,6 +7,7 @@ import com.klp.hub.hub.infrastructure.client.DeliveryFeignClient;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,12 +18,14 @@ public class HubFacade {
     private final DeliveryFeignClient deliveryFeignClient;
 
     //허브 삭제 대기
+    @Transactional
     public void markPendingDelete(UUID hubId, UserDetailsImpl userDetails) {
         //허브 삭제 대기 상태 변경
         hubService.markPendingDelete(hubId, userDetails);
         //허브간 이동 정보 삭제
         hubRouteInfoService.deleteHubRouteInfoByHubId(hubId, userDetails);
         //경로 계획 삭제
+        //TODO: 이벤트로 변경하기
         deliveryFeignClient.deleteRoutePlansByHubId(hubId);
     }
 }

--- a/hub/src/main/java/com/klp/hub/hub/application/scheduler/HubDeleteScheduler.java
+++ b/hub/src/main/java/com/klp/hub/hub/application/scheduler/HubDeleteScheduler.java
@@ -1,0 +1,55 @@
+package com.klp.hub.hub.application.scheduler;
+
+import com.klp.hub.hub.application.service.OrderClientService;
+import com.klp.hub.hub.domain.model.Hub;
+import com.klp.hub.hub.domain.model.HubStatus;
+import com.klp.hub.hub.domain.repository.HubRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HubDeleteScheduler {
+
+    private final HubRepository hubRepository;
+    private final OrderClientService orderClientService;
+
+    /*
+     * 삭제 대기인 Hub 중에서 진행중인 주문이 없는 것들을 정리
+     * 3시간 주기로 실행
+     */
+    @Scheduled(
+        fixedRateString = "${scheduler.hub-delete.fixed-rate}",
+        initialDelayString = "${scheduler.hub-delete.initial-delay}"
+    )
+    @Transactional
+    public void cleanPendingDeleteHubs() {
+        log.info("[HubDeleteScheduler] 시작 - PENDING_DELETE Hub 정리");
+
+        List<Hub> pendingDeleteHubs =
+            hubRepository.findAllByStatus(HubStatus.PENDING_DELETE);
+
+        for (Hub hub : pendingDeleteHubs) {
+            UUID hubId = hub.getHubId();
+
+            boolean hasProgressingOrders = orderClientService.hasProgressingOrders(hubId);
+
+            if (hasProgressingOrders) {
+                log.info("[HubDeleteScheduler] 아직 사용 중인 Hub, 보류 hubId={}",
+                    hubId);
+                continue;
+            }
+
+            hub.softDelete();
+        }
+
+        log.info("[HubDeleteScheduler] 종료 - PENDING_DELETE Hub 정리");
+    }
+
+}

--- a/hub/src/main/java/com/klp/hub/hub/application/service/DeliveryClientService.java
+++ b/hub/src/main/java/com/klp/hub/hub/application/service/DeliveryClientService.java
@@ -1,0 +1,8 @@
+package com.klp.hub.hub.application.service;
+
+import java.util.UUID;
+
+public interface DeliveryClientService {
+
+    void deleteRoutePlansByHubId(UUID hubId);
+}

--- a/hub/src/main/java/com/klp/hub/hub/application/service/HubRouteInfoService.java
+++ b/hub/src/main/java/com/klp/hub/hub/application/service/HubRouteInfoService.java
@@ -1,7 +1,7 @@
 package com.klp.hub.hub.application.service;
 
 import com.klp.common.exception.BusinessException;
-import com.klp.hub.hub.util.DistanceTimeUtil;
+import com.klp.hub.common.model.UserDetailsImpl;
 import com.klp.hub.hub.application.command.hubRouteInfo.RegisterHubRouteInfoCommand;
 import com.klp.hub.hub.application.command.hubRouteInfo.UpdateHubRouteInfoCommand;
 import com.klp.hub.hub.domain.model.Hub;
@@ -12,6 +12,7 @@ import com.klp.hub.hub.presentation.dto.response.hubrouteinfo.GetHubRouteInfoDet
 import com.klp.hub.hub.presentation.dto.response.hubrouteinfo.GetHubRouteInfoListResponse;
 import com.klp.hub.hub.presentation.dto.response.hubrouteinfo.RegisterHubRouteInfoResponse;
 import com.klp.hub.hub.presentation.dto.response.hubrouteinfo.UpdatedHubRouteInfoResponse;
+import com.klp.hub.hub.util.DistanceTimeUtil;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -25,22 +26,27 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 public class HubRouteInfoService {
+
     private final HubRouteInfoRepository hubRouteInfoRepository;
     private final HubService hubService;
 
     //허브간 이동 정보 생성
     @Transactional
-    public RegisterHubRouteInfoResponse registerHubRouteInfo(RegisterHubRouteInfoCommand request){
-        Hub departureHub=hubService.getHubById(request.departureId());
-        Hub arrivalHub=hubService.getHubById(request.arrivalId());
+    public RegisterHubRouteInfoResponse registerHubRouteInfo(RegisterHubRouteInfoCommand request) {
+        Hub departureHub = hubService.getHubById(request.departureId());
+        Hub arrivalHub = hubService.getHubById(request.arrivalId());
 
-        if(hubRouteInfoRepository.existsByDepartureIdAndArrivalId(request.departureId(), request.arrivalId())) {
-            log.warn("ALREADY_EXISTS_HUB_ROUTE_INFO Error departureId: {}, arrivalId: {}", request.departureId(), request.arrivalId());
+        if (hubRouteInfoRepository.existsByDepartureIdAndArrivalId(request.departureId(),
+            request.arrivalId())) {
+            log.warn("ALREADY_EXISTS_HUB_ROUTE_INFO Error departureId: {}, arrivalId: {}",
+                request.departureId(), request.arrivalId());
             throw new BusinessException(HubRouteInfoErrorCode.ALREADY_EXISTS_HUB_ROUTE_INFO);
         }
 
-        Long durationMin=DistanceTimeUtil.estimateDurationMinutes(departureHub.getLatitude(),departureHub.getLongitude(),arrivalHub.getLatitude(),arrivalHub.getLongitude());
-        Double distanceKm=DistanceTimeUtil.calculateDistanceKm(departureHub.getLatitude(),departureHub.getLongitude(),arrivalHub.getLatitude(),arrivalHub.getLongitude());
+        Long durationMin = DistanceTimeUtil.estimateDurationMinutes(departureHub.getLatitude(),
+            departureHub.getLongitude(), arrivalHub.getLatitude(), arrivalHub.getLongitude());
+        Double distanceKm = DistanceTimeUtil.calculateDistanceKm(departureHub.getLatitude(),
+            departureHub.getLongitude(), arrivalHub.getLatitude(), arrivalHub.getLongitude());
 
         HubRouteInfo info = HubRouteInfo.create(
             departureHub.getHubId(),
@@ -54,39 +60,50 @@ public class HubRouteInfoService {
 
     //허브간 이동 정보 단일 조회
     @Transactional(readOnly = true)
-    public GetHubRouteInfoDetailResponse getHubRouteInfoDetail(UUID hubRouteInfoId){
-        HubRouteInfo routeInfo= getHubRouteInfoById(hubRouteInfoId);
+    public GetHubRouteInfoDetailResponse getHubRouteInfoDetail(UUID hubRouteInfoId) {
+        HubRouteInfo routeInfo = getHubRouteInfoById(hubRouteInfoId);
         return GetHubRouteInfoDetailResponse.from(routeInfo);
     }
 
     //허브간 이동 정보 목록 조회
     @Transactional(readOnly = true)
-    public GetHubRouteInfoListResponse getHubRouteInfos(UUID departureId,UUID arrivalId,Pageable pageable){
-        Page<HubRouteInfo> routeInfos = hubRouteInfoRepository.getHubRoutes(departureId, arrivalId, pageable);
+    public GetHubRouteInfoListResponse getHubRouteInfos(UUID departureId, UUID arrivalId,
+        Pageable pageable) {
+        Page<HubRouteInfo> routeInfos = hubRouteInfoRepository.getHubRoutes(departureId, arrivalId,
+            pageable);
         return GetHubRouteInfoListResponse.from(routeInfos);
     }
 
     //허브간 이동 정보 수정
     @Transactional
-    public UpdatedHubRouteInfoResponse updateHubRouteInfo(UUID hubRouteInfoId, UpdateHubRouteInfoCommand request){
-        HubRouteInfo hubRouteInfo=getHubRouteInfoById(hubRouteInfoId);
-        hubRouteInfo.update(request.durationMin(),request.distanceKm());
+    public UpdatedHubRouteInfoResponse updateHubRouteInfo(UUID hubRouteInfoId,
+        UpdateHubRouteInfoCommand request) {
+        HubRouteInfo hubRouteInfo = getHubRouteInfoById(hubRouteInfoId);
+        hubRouteInfo.update(request.durationMin(), request.distanceKm());
         return UpdatedHubRouteInfoResponse.from(hubRouteInfo);
     }
 
     //허브간 이동 정보 삭제
     @Transactional
-    public void deleteHubRouteInfo(UUID hubRouteInfoId){
-        HubRouteInfo routeInfo=getHubRouteInfoById(hubRouteInfoId);
-        routeInfo.delete(0L); //TODO: 인증 객체 생기면 수정하기
+    public void deleteHubRouteInfo(UUID hubRouteInfoId, UserDetailsImpl userDetails) {
+        HubRouteInfo routeInfo = getHubRouteInfoById(hubRouteInfoId);
+        routeInfo.delete(userDetails.getUserId());
+    }
+
+    //hubId와 관련된 허브간 이동 정보 삭제
+    public void deleteHubRouteInfoByHubId(UUID hubId, UserDetailsImpl userDetails) {
+        List<HubRouteInfo> infos = hubRouteInfoRepository.findAllByHubId(hubId);
+        infos.forEach(info -> {
+            info.delete(userDetails.getUserId());
+        });
     }
 
     //허브간 이동 정보 ID로 조회
     @Transactional(readOnly = true)
-    public HubRouteInfo getHubRouteInfoById(UUID hubRouteInfoId){
+    public HubRouteInfo getHubRouteInfoById(UUID hubRouteInfoId) {
         return hubRouteInfoRepository.getHubRouteInfoById(hubRouteInfoId)
-            .orElseThrow(()->{
-                log.warn("HUB ROUTE INFO NOT_EXISTS hubRouteInfoId: {}",hubRouteInfoId);
+            .orElseThrow(() -> {
+                log.warn("HUB ROUTE INFO NOT_EXISTS hubRouteInfoId: {}", hubRouteInfoId);
                 return new BusinessException(HubRouteInfoErrorCode.NOT_EXISTS);
             });
     }
@@ -94,8 +111,8 @@ public class HubRouteInfoService {
     //모든 허브간 이동 정보 조회
     @Transactional(readOnly = true)
     public GetHubRouteInfoListResponse getAllHubRouteInfos() {
-        List<HubRouteInfo> routeInfos=hubRouteInfoRepository.getAllHubRouteInfos();
-        log.debug("모든 허브 이동 정보 조회 리스트 사이즈: {}",routeInfos.size());
+        List<HubRouteInfo> routeInfos = hubRouteInfoRepository.getAllHubRouteInfos();
+        log.debug("모든 허브 이동 정보 조회 리스트 사이즈: {}", routeInfos.size());
         return GetHubRouteInfoListResponse.from(routeInfos);
     }
 }

--- a/hub/src/main/java/com/klp/hub/hub/application/service/HubRouteInfoService.java
+++ b/hub/src/main/java/com/klp/hub/hub/application/service/HubRouteInfoService.java
@@ -20,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -91,6 +92,7 @@ public class HubRouteInfoService {
     }
 
     //hubId와 관련된 허브간 이동 정보 삭제
+    @Transactional(propagation = Propagation.MANDATORY)
     public void deleteHubRouteInfoByHubId(UUID hubId, UserDetailsImpl userDetails) {
         List<HubRouteInfo> infos = hubRouteInfoRepository.findAllByHubId(hubId);
         infos.forEach(info -> {

--- a/hub/src/main/java/com/klp/hub/hub/application/service/HubService.java
+++ b/hub/src/main/java/com/klp/hub/hub/application/service/HubService.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -84,7 +85,7 @@ public class HubService {
     }
 
     //허브 삭제
-    @Transactional
+    @Transactional(propagation = Propagation.MANDATORY)
     @CacheEvict(cacheNames = CACHE_NAME, key = "#hubId")
     public void markPendingDelete(UUID hubId, UserDetailsImpl userDetails) {
         Hub hub = getHubById(hubId);

--- a/hub/src/main/java/com/klp/hub/hub/application/service/HubService.java
+++ b/hub/src/main/java/com/klp/hub/hub/application/service/HubService.java
@@ -1,6 +1,7 @@
 package com.klp.hub.hub.application.service;
 
 import com.klp.common.exception.BusinessException;
+import com.klp.hub.common.model.UserDetailsImpl;
 import com.klp.hub.hub.application.command.hub.RegisterHubCommand;
 import com.klp.hub.hub.application.command.hub.UpdateHubCommand;
 import com.klp.hub.hub.domain.model.Hub;
@@ -13,7 +14,7 @@ import com.klp.hub.hub.presentation.dto.response.hub.UpdatedHubResponse;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -64,7 +65,7 @@ public class HubService {
     }
 
     //허브 수정
-    @CachePut(cacheNames = CACHE_NAME, key = "#hubId")
+    @CacheEvict(cacheNames = CACHE_NAME, key = "#hubId")
     @Transactional
     public UpdatedHubResponse updateHub(UUID hubId, UpdateHubCommand request,
         UserDetails userDetails) {
@@ -84,8 +85,10 @@ public class HubService {
 
     //허브 삭제
     @Transactional
-    public void deleteHub(UUID hubId) {
-
+    @CacheEvict(cacheNames = CACHE_NAME, key = "#hubId")
+    public void markPendingDelete(UUID hubId, UserDetailsImpl userDetails) {
+        Hub hub = getHubById(hubId);
+        hub.pendingDelete(userDetails.getUserId());
     }
 
     //허브 ID로 조회

--- a/hub/src/main/java/com/klp/hub/hub/application/service/OrderClientService.java
+++ b/hub/src/main/java/com/klp/hub/hub/application/service/OrderClientService.java
@@ -1,0 +1,8 @@
+package com.klp.hub.hub.application.service;
+
+import java.util.UUID;
+
+public interface OrderClientService {
+
+    boolean hasProgressingOrders(UUID hubId);
+}

--- a/hub/src/main/java/com/klp/hub/hub/domain/model/Hub.java
+++ b/hub/src/main/java/com/klp/hub/hub/domain/model/Hub.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -54,26 +55,36 @@ public class Hub extends BaseEntity {
 
     public static Hub create(String name, Double latitude, Double longitude, String address) {
         Hub hub = new Hub();
-        hub.name= name;
+        hub.name = name;
         hub.latitude = latitude;
         hub.longitude = longitude;
         hub.address = address;
-        hub.status=HubStatus.ACTIVE;
+        hub.status = HubStatus.ACTIVE;
         return hub;
     }
 
     public void update(String name, Double latitude, Double longitude, String address) {
-        if(name != null){
+        if (name != null) {
             this.name = name;
         }
-        if(latitude != null){
+        if (latitude != null) {
             this.latitude = latitude;
         }
-        if(longitude != null){
+        if (longitude != null) {
             this.longitude = longitude;
         }
-        if(address != null){
+        if (address != null) {
             this.address = address;
         }
+    }
+
+    public void softDelete() {
+        this.setDeletedAt(LocalDateTime.now());
+        this.status = HubStatus.DELETED;
+    }
+
+    public void pendingDelete(Long userId) {
+        this.status = HubStatus.PENDING_DELETE;
+        setDeletedBy(userId);
     }
 }

--- a/hub/src/main/java/com/klp/hub/hub/domain/repository/HubRepository.java
+++ b/hub/src/main/java/com/klp/hub/hub/domain/repository/HubRepository.java
@@ -1,6 +1,7 @@
 package com.klp.hub.hub.domain.repository;
 
 import com.klp.hub.hub.domain.model.Hub;
+import com.klp.hub.hub.domain.model.HubStatus;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -8,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface HubRepository {
+
     Hub save(Hub hub);
 
     boolean existsByName(String name);
@@ -21,4 +23,6 @@ public interface HubRepository {
     List<UUID> getActiveHubIds();
 
     List<Hub> getHubsByIds(List<UUID> hubIds);
+
+    List<Hub> findAllByStatus(HubStatus hubStatus);
 }

--- a/hub/src/main/java/com/klp/hub/hub/domain/repository/HubRouteInfoRepository.java
+++ b/hub/src/main/java/com/klp/hub/hub/domain/repository/HubRouteInfoRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface HubRouteInfoRepository {
+
     HubRouteInfo save(HubRouteInfo hubRouteInfo);
 
     Optional<HubRouteInfo> getHubRouteInfoById(UUID hubRouteInfoId);
@@ -20,4 +21,6 @@ public interface HubRouteInfoRepository {
     boolean existsByDepartureIdAndArrivalId(UUID departureId, UUID arrivalId);
 
     List<HubRouteInfo> getAllHubRouteInfos();
+
+    List<HubRouteInfo> findAllByHubId(UUID hubId);
 }

--- a/hub/src/main/java/com/klp/hub/hub/infrastructure/client/DeliveryClientServiceImpl.java
+++ b/hub/src/main/java/com/klp/hub/hub/infrastructure/client/DeliveryClientServiceImpl.java
@@ -1,0 +1,18 @@
+package com.klp.hub.hub.infrastructure.client;
+
+import com.klp.hub.hub.application.service.DeliveryClientService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DeliveryClientServiceImpl implements DeliveryClientService {
+
+    private final DeliveryFeignClient deliveryFeignClient;
+
+    @Override
+    public void deleteRoutePlansByHubId(UUID hubId) {
+        deliveryFeignClient.deleteRoutePlansByHubId(hubId);
+    }
+}

--- a/hub/src/main/java/com/klp/hub/hub/infrastructure/client/DeliveryFeignClient.java
+++ b/hub/src/main/java/com/klp/hub/hub/infrastructure/client/DeliveryFeignClient.java
@@ -1,0 +1,16 @@
+package com.klp.hub.hub.infrastructure.client;
+
+import com.klp.hub.global.config.DeliveryFeignClientConfig;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Component
+@FeignClient(name = "delivery-service", configuration = DeliveryFeignClientConfig.class)
+public interface DeliveryFeignClient {
+
+    @DeleteMapping("/v1/routes/plans/delete/{hubId}")
+    void deleteRoutePlansByHubId(@PathVariable("hubId") UUID hubId);
+}

--- a/hub/src/main/java/com/klp/hub/hub/infrastructure/client/OrderClientServiceImpl.java
+++ b/hub/src/main/java/com/klp/hub/hub/infrastructure/client/OrderClientServiceImpl.java
@@ -1,0 +1,18 @@
+package com.klp.hub.hub.infrastructure.client;
+
+import com.klp.hub.hub.application.service.OrderClientService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OrderClientServiceImpl implements OrderClientService {
+
+    private final OrderFeignClient orderFeignClient;
+
+    @Override
+    public boolean hasProgressingOrders(UUID hubId) {
+        return orderFeignClient.hasProgressingOrder(hubId);
+    }
+}

--- a/hub/src/main/java/com/klp/hub/hub/infrastructure/client/OrderFeignClient.java
+++ b/hub/src/main/java/com/klp/hub/hub/infrastructure/client/OrderFeignClient.java
@@ -1,0 +1,16 @@
+package com.klp.hub.hub.infrastructure.client;
+
+import com.klp.hub.global.config.OrderFeignClientConfig;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Component
+@FeignClient(name = "order-service", configuration = OrderFeignClientConfig.class)
+public interface OrderFeignClient {
+
+    @GetMapping("/v1/orders/progressing")
+    boolean hasProgressingOrder(@RequestParam UUID hubId);
+}

--- a/hub/src/main/java/com/klp/hub/hub/infrastructure/repository/HubJpaRepository.java
+++ b/hub/src/main/java/com/klp/hub/hub/infrastructure/repository/HubJpaRepository.java
@@ -1,6 +1,8 @@
 package com.klp.hub.hub.infrastructure.repository;
 
 import com.klp.hub.hub.domain.model.Hub;
+import com.klp.hub.hub.domain.model.HubStatus;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +11,6 @@ public interface HubJpaRepository extends JpaRepository<Hub, UUID> {
     boolean existsByName(String name);
 
     boolean existsByAddress(String address);
+
+    List<Hub> findAllByStatus(HubStatus hubStatus);
 }

--- a/hub/src/main/java/com/klp/hub/hub/infrastructure/repository/HubRepositoryImpl.java
+++ b/hub/src/main/java/com/klp/hub/hub/infrastructure/repository/HubRepositoryImpl.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class HubRepositoryImpl implements HubRepository {
+
     private final HubJpaRepository hubJpaRepository;
     private final JPAQueryFactory queryFactory;
 
@@ -62,5 +63,10 @@ public class HubRepositoryImpl implements HubRepository {
             .selectFrom(qHub)
             .where(qHub.hubId.in(hubIds))
             .fetch();
+    }
+
+    @Override
+    public List<Hub> findAllByStatus(HubStatus hubStatus) {
+        return hubJpaRepository.findAllByStatus(hubStatus);
     }
 }

--- a/hub/src/main/java/com/klp/hub/hub/infrastructure/repository/HubRouteInfoRepositoryImpl.java
+++ b/hub/src/main/java/com/klp/hub/hub/infrastructure/repository/HubRouteInfoRepositoryImpl.java
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class HubRouteInfoRepositoryImpl implements HubRouteInfoRepository {
+
     private final HubRouteInfoJpaRepository hubRouteInfoJpaRepository;
     private final JPAQueryFactory queryFactory;
 
@@ -48,11 +49,13 @@ public class HubRouteInfoRepositoryImpl implements HubRouteInfoRepository {
             );
 
         if (pageable.getSort().isSorted()) {
-            PathBuilder<QHubRouteInfo> entityPath = new PathBuilder<>(QHubRouteInfo.class, qRouteInfo.getMetadata());
+            PathBuilder<QHubRouteInfo> entityPath = new PathBuilder<>(QHubRouteInfo.class,
+                qRouteInfo.getMetadata());
             for (Sort.Order order : pageable.getSort()) {
                 String property = order.getProperty();
                 Order direction = order.isAscending() ? Order.ASC : Order.DESC;
-                base.orderBy(new OrderSpecifier<>(direction, entityPath.getComparable(property, Comparable.class)));
+                base.orderBy(new OrderSpecifier<>(direction,
+                    entityPath.getComparable(property, Comparable.class)));
             }
         } else {
             base.orderBy(qRouteInfo.createdAt.desc());
@@ -72,7 +75,8 @@ public class HubRouteInfoRepositoryImpl implements HubRouteInfoRepository {
         QHubRouteInfo qRouteInfo = QHubRouteInfo.hubRouteInfo;
 
         return queryFactory
-            .select(Projections.constructor(RoutePairDto.class, qRouteInfo.departureId, qRouteInfo.arrivalId))
+            .select(Projections.constructor(RoutePairDto.class, qRouteInfo.departureId,
+                qRouteInfo.arrivalId))
             .from(qRouteInfo)
             .where(
                 qRouteInfo.deletedAt.isNull(),
@@ -91,5 +95,16 @@ public class HubRouteInfoRepositoryImpl implements HubRouteInfoRepository {
     @Override
     public List<HubRouteInfo> getAllHubRouteInfos() {
         return hubRouteInfoJpaRepository.findByDeletedAtIsNull();
+    }
+
+    @Override
+    public List<HubRouteInfo> findAllByHubId(UUID hubId) {
+        QHubRouteInfo qRouteInfo = QHubRouteInfo.hubRouteInfo;
+        return queryFactory
+            .selectDistinct(qRouteInfo)
+            .from(qRouteInfo)
+            .where(qRouteInfo.departureId.eq(hubId)
+                .or(qRouteInfo.arrivalId.eq(hubId)))
+            .fetch();
     }
 }

--- a/hub/src/main/java/com/klp/hub/hub/presentation/controller/HubController.java
+++ b/hub/src/main/java/com/klp/hub/hub/presentation/controller/HubController.java
@@ -1,6 +1,7 @@
 package com.klp.hub.hub.presentation.controller;
 
 import com.klp.hub.common.model.UserDetailsImpl;
+import com.klp.hub.hub.application.facade.HubFacade;
 import com.klp.hub.hub.application.service.HubService;
 import com.klp.hub.hub.presentation.dto.request.hub.RegisterHubRequest;
 import com.klp.hub.hub.presentation.dto.request.hub.UpdateHubRequest;
@@ -30,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class HubController {
 
+    private final HubFacade hubFacade;
     private final HubService hubService;
 
     //허브 등록
@@ -72,6 +74,7 @@ public class HubController {
     public ResponseEntity<Void> deleteHub(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @PathVariable UUID hubId) {
+        hubFacade.markPendingDelete(hubId, userDetails);
         return ResponseEntity.ok().build();
     }
 }

--- a/hub/src/main/java/com/klp/hub/hub/presentation/controller/HubRouteInfoController.java
+++ b/hub/src/main/java/com/klp/hub/hub/presentation/controller/HubRouteInfoController.java
@@ -1,5 +1,6 @@
 package com.klp.hub.hub.presentation.controller;
 
+import com.klp.hub.common.model.UserDetailsImpl;
 import com.klp.hub.hub.application.service.HubRouteInfoService;
 import com.klp.hub.hub.presentation.dto.request.hubrouteinfo.RegisterHubRouteInfoRequest;
 import com.klp.hub.hub.presentation.dto.request.hubrouteinfo.UpdateHubRouteInfoRequest;
@@ -13,6 +14,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -27,21 +29,24 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/v1/hubs/routes/info")
 public class HubRouteInfoController {
+
     private final HubRouteInfoService hubRouteInfoService;
 
     //허브간 이동 정보 생성
     @PostMapping("")
     public ResponseEntity<RegisterHubRouteInfoResponse> registerHubRouteInfo(
         @Valid @RequestBody RegisterHubRouteInfoRequest request
-    ){
-        RegisterHubRouteInfoResponse response=hubRouteInfoService.registerHubRouteInfo(request.toCommand());
-        URI location=URI.create("/v1/hubs/routes/info/"+response.hubRouteInfoId());
+    ) {
+        RegisterHubRouteInfoResponse response = hubRouteInfoService.registerHubRouteInfo(
+            request.toCommand());
+        URI location = URI.create("/v1/hubs/routes/info/" + response.hubRouteInfoId());
         return ResponseEntity.created(location).body(response);
     }
 
     //허브간 이동 정보 단일 조회
     @GetMapping("/{routeInfoId}")
-    public ResponseEntity<GetHubRouteInfoDetailResponse> getHubRouteInfoDetail(@PathVariable UUID routeInfoId){
+    public ResponseEntity<GetHubRouteInfoDetailResponse> getHubRouteInfoDetail(
+        @PathVariable UUID routeInfoId) {
         return ResponseEntity.ok(hubRouteInfoService.getHubRouteInfoDetail(routeInfoId));
     }
 
@@ -50,28 +55,33 @@ public class HubRouteInfoController {
     public ResponseEntity<GetHubRouteInfoListResponse> getHubRouteInfos(
         @RequestParam(required = false) UUID departureId,
         @RequestParam(required = false) UUID arrivalId,
-        Pageable pageable){
-        return ResponseEntity.ok(hubRouteInfoService.getHubRouteInfos(departureId,arrivalId,pageable));
+        Pageable pageable) {
+        return ResponseEntity.ok(
+            hubRouteInfoService.getHubRouteInfos(departureId, arrivalId, pageable));
     }
 
     //허브간 이동 정보 수정
     @PatchMapping("/{routeInfoId}")
-    public ResponseEntity<UpdatedHubRouteInfoResponse> updateHubRouteInfo(@PathVariable UUID routeInfoId,
-        @RequestBody UpdateHubRouteInfoRequest request){
-        return ResponseEntity.ok(hubRouteInfoService.updateHubRouteInfo(routeInfoId, request.toCommand()));
+    public ResponseEntity<UpdatedHubRouteInfoResponse> updateHubRouteInfo(
+        @PathVariable UUID routeInfoId,
+        @RequestBody UpdateHubRouteInfoRequest request) {
+        return ResponseEntity.ok(
+            hubRouteInfoService.updateHubRouteInfo(routeInfoId, request.toCommand()));
     }
 
     //허브간 이동 정보 삭제
     @DeleteMapping("/{routeInfoId}")
-    public ResponseEntity<Void> deleteHub(@PathVariable UUID routeInfoId){
-        hubRouteInfoService.deleteHubRouteInfo(routeInfoId);
+    public ResponseEntity<Void> deleteHub(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @PathVariable UUID routeInfoId) {
+        hubRouteInfoService.deleteHubRouteInfo(routeInfoId, userDetails);
         return ResponseEntity.ok().build();
     }
 
     //모든 허브간 이동 정보 조회 ( 페이지네이션 X )
     //TODO: MASTER 권한
     @GetMapping("/all")
-    public ResponseEntity<GetHubRouteInfoListResponse> getHubRouteInfos(){
+    public ResponseEntity<GetHubRouteInfoListResponse> getHubRouteInfos() {
         return ResponseEntity.ok(hubRouteInfoService.getAllHubRouteInfos());
     }
 }

--- a/hub/src/main/resources/application.yml
+++ b/hub/src/main/resources/application.yml
@@ -33,6 +33,9 @@ scheduler:
   route-infos:
     fixed-rate: ${SCHEDULER_ROUTE_INFOS_FIXED_RATE:PT2H}        # 2시간마다 실행 (ISO-8601 표기: PT2H = 2 Hours)
     initial-delay: ${SCHEDULER_ROUTE_INFOS_INITIAL_DELAY:PT0S}     # 앱 실행 직후 바로 실행, 필요 시 PT5M 등으로 지연 가능
+  hub-delete:
+    fixed-rate: ${SCHEDULER_HUB_DELETE_FIXED_RATE:PT3H}
+    initial-delay: ${SCHEDULER_HUB_DELETE_INITIAL_DELAY:PT0S}
 
 shedlock:
   route-infos:


### PR DESCRIPTION
1. 경로 계획 삭제 API 구현
   - 삭제된 허브와 관련된 경로 계획을 삭제 대기 상태로 변경합니다.
2. 경로 계획 삭제 스케줄러 구현
   - 진행중인 배송이 없는 삭제 대기 상태의 경로 계획들을 삭제합니다. 
   - 실행 주기 3시간
3. 허브 삭제 API 구현
   - 허브를 삭제 대기 상태로 변경합니다.
   - 해당 허브와 관련된 허브간 이동 정보를 삭제하고, Delivery Service에 관련된 경로 계획 삭제 요청을 보냅니다.
   - 허브 삭제 대기 변경, 허브간 이동 정보 삭제, 경로계획 삭제 요청을  같이 처리하기 위해 Facade 계층을 추가했습니다.
5. 허브 삭제 스케줄러 구현
   - 진행중인 주문이 없는 삭제 대기 상태의 허브들을 삭제합니다.
   - 실행 주기 3시간

- 새로 추가된 환경 변수
```
Delivery Service
SCHEDULER_ROUTE_PLAN_DELETE_FIXED_RATE=PT3H
SCHEDULER_ROUTE_PLAN_DELETE_INITIAL_DELAY=PT0S
```
```
Hub Service
SCHEDULER_HUB_DELETE_FIXED_RATE=PT3H
SCHEDULER_HUB_DELETE_INITIAL_DELAY=PT0S
```