### PR TITLE
Config: Kafka 초기 설정 docker-compose.yml 작성

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - ./init-sql:/docker-entrypoint-initdb.d
     ports:
       - "5432:5432"
+
   redis:
     image: redis
     container_name: redis-klp
@@ -20,6 +21,58 @@ services:
     ports:
       - "6379:6379"
 
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.9.4
+    container_name: zookeeper-klp
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - "2181:2181"
+    volumes:
+      - klp-zookeeper-data:/var/lib/zookeeper/data
+      - klp-zookeeper-logs:/var/lib/zookeeper/log
+
+  kafka:
+    image: confluentinc/cp-kafka:7.9.4
+    container_name: kafka-klp
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+      - "29092:29092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:29092,PLAINTEXT_HOST://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_MIN_INSYNC_REPLICAS: 1
+      KAFKA_DEFAULT_REPLICATION_FACTOR: 1
+    volumes:
+      - klp-kafka-data:/var/lib/kafka/data
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:v0.7.2
+    container_name: kafka-ui-klp
+    depends_on:
+      - kafka
+      - zookeeper
+    ports:
+      - "8989:8080"
+    environment:
+      DYNAMIC_CONFIG_ENABLED: 'true'
+      KAFKA_CLUSTERS_0_NAME: klp-local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092
+      KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
+
 volumes:
   klp_postgres_data:
   klp_redis_data:
+  klp-zookeeper-data:
+  klp-zookeeper-logs:
+  klp-kafka-data:


### PR DESCRIPTION
## PR 내용
- [config: zookeeper 및 kafka 브로커 설정](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/e8d8a8ae12317748a87c8a0978b9c238e931777f)
  - kafka 최신 버전인 `8.1.0` 버전의 경우에는 Kraft 모드를 사용합니다. Kraft 모드는 기본적으로 3대의 브로커를 권장하기 때문에 zookeeper을 이용하기 위해 `7.9.4` 버전을 적용했습니다
  - kafka의 UI 화면을 이용하기 위해 kafka-ui도 설정했습니다.
  - 임시로 브로커를 1대만 구성하였으며, 필요에 따라 2대로 설정하여 사용하셔도 됩니다.
  - Docker 환경이기 때문에 내부 통신용, 외부 접속용 포트를 구분했습니다.