### PR TITLE
refactor: 회원 서비스 외부 및 내부 API 분리

### DIFF
--- a/gateway-service/src/main/java/com/sparta/klp/gatewayservice/filter/InternalApiBlockFilter.java
+++ b/gateway-service/src/main/java/com/sparta/klp/gatewayservice/filter/InternalApiBlockFilter.java
@@ -1,0 +1,62 @@
+package com.sparta.klp.gatewayservice.filter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class InternalApiBlockFilter implements GlobalFilter, Ordered {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        ServerHttpRequest request = exchange.getRequest();
+        String path = request.getURI().getPath();
+
+        if (path.startsWith("/v1/internal/")) {
+            log.warn("Blocked external access to internal API: {}", path);
+            return blockRequest(exchange, "접근할 수 없는 주소입니다.");
+        }
+
+        return chain.filter(exchange);
+    }
+
+    @Override
+    public int getOrder() {
+        return -1;
+    }
+
+    private Mono<Void> blockRequest(ServerWebExchange exchange, String message) {
+        ServerHttpResponse response = exchange.getResponse();
+        response.setStatusCode(HttpStatus.FORBIDDEN);
+        response.getHeaders().setContentType(
+            new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8)
+        );
+
+        try {
+            byte[] bytes = objectMapper.writeValueAsBytes(message);
+            DataBuffer buffer = response.bufferFactory().wrap(bytes);
+            return response.writeWith(Flux.just(buffer));
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize error response", e);
+            return response.setComplete();
+        }
+    }
+}

--- a/user/src/main/java/com/klp/user/presentation/UserController.java
+++ b/user/src/main/java/com/klp/user/presentation/UserController.java
@@ -6,16 +6,12 @@ import com.klp.user.application.UserService;
 import com.klp.user.presentation.dto.request.UserCreateRequest;
 import com.klp.user.presentation.dto.request.UserUpdateRequest;
 import com.klp.user.presentation.dto.request.ValidateUserRequest;
-import com.klp.user.presentation.dto.response.DriverDetailResponse;
-import com.klp.user.presentation.dto.response.HubDriverListResponse;
-import com.klp.user.presentation.dto.response.LogisticsDriverListResponse;
 import com.klp.user.presentation.dto.response.UserDataResponse;
 import com.klp.user.presentation.dto.response.UserDetailResponse;
 import com.klp.user.presentation.dto.response.UserInfoResponse;
 import com.klp.user.presentation.dto.response.UsernameCheckResponse;
 import jakarta.validation.Valid;
 import java.net.URI;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -113,23 +109,5 @@ public class UserController {
         userService.rejectPendingUser(userId);
 
         return ResponseEntity.ok().build();
-    }
-
-    @GetMapping("/driver/logistics")
-    public ResponseEntity<LogisticsDriverListResponse> getDriversByLogistics() {
-        LogisticsDriverListResponse response = userService.getDriversByLogistics();
-        return ResponseEntity.ok().body(response);
-    }
-
-    @GetMapping("/driver/{hubId}")
-    public ResponseEntity<HubDriverListResponse> getDriversByHubId(@PathVariable UUID hubId) {
-        HubDriverListResponse response = userService.getDriversByHubId(hubId);
-        return ResponseEntity.ok().body(response);
-    }
-
-    @GetMapping("/driver")
-    public ResponseEntity<DriverDetailResponse> getDriverById(@RequestParam("id") Long driverId) {
-        DriverDetailResponse response = userService.getDriverById(driverId);
-        return ResponseEntity.ok().body(response);
     }
 }

--- a/user/src/main/java/com/klp/user/presentation/UserInternalController.java
+++ b/user/src/main/java/com/klp/user/presentation/UserInternalController.java
@@ -1,0 +1,50 @@
+package com.klp.user.presentation;
+
+import com.klp.user.application.UserService;
+import com.klp.user.presentation.dto.response.DriverDetailResponse;
+import com.klp.user.presentation.dto.response.HubDriverListResponse;
+import com.klp.user.presentation.dto.response.LogisticsDriverListResponse;
+import com.klp.user.presentation.dto.response.UserDetailResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/internal/users")
+@RequiredArgsConstructor
+public class UserInternalController {
+
+    private final UserService userService;
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<UserDetailResponse> getUserDetails(
+        @PathVariable Long userId
+    ) {
+        UserDetailResponse response = userService.getUserDetails(userId);
+        return ResponseEntity.ok().body(response);
+    }
+
+
+    @GetMapping("/driver/logistics")
+    public ResponseEntity<LogisticsDriverListResponse> getDriversByLogistics() {
+        LogisticsDriverListResponse response = userService.getDriversByLogistics();
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/driver/{hubId}")
+    public ResponseEntity<HubDriverListResponse> getDriversByHubId(@PathVariable UUID hubId) {
+        HubDriverListResponse response = userService.getDriversByHubId(hubId);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping("/driver")
+    public ResponseEntity<DriverDetailResponse> getDriverById(@RequestParam("id") Long driverId) {
+        DriverDetailResponse response = userService.getDriverById(driverId);
+        return ResponseEntity.ok().body(response);
+    }
+}


### PR DESCRIPTION
## PR 내용
- [refactor: 회원 서비스 외부 및 내부 API 분리](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/4ddef6072709d82b6b361d02dadd6d0eeaba29d5)
  - FeignClient 통신용 내부 API를 분리했습니다.

- [feat: 내부 API 접근 방지를 위한 Gateway 필터 적용](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/27a88ae28fb3a090cc9f67ca71697f118655e5ef)
  - Gateway 서비스에서 내부 API로 접근을 막는 필터를 작성했습니다.
  - `application.yml`로 구성하여 차단을 진행하려 했지만, 라우팅 이전에 `JwtAuthenticationFilter`을 거치기 때문에 순서가 올바르지 않다고 생각했습니다.
  - 따라서 `Ordered`를 적용하여 `InternalApiBlockFilter` -> `JwtAuthenticationFilter` -> 라우팅 진행의 순서가 되도록 설정했습니다.