### PR TITLE
feat: 배송 실패 시 보상 트랜잭션 추가

### DIFF
--- a/delivery/src/main/java/com/klp/delivery/delivery/application/facade/DeliveryFacade.java
+++ b/delivery/src/main/java/com/klp/delivery/delivery/application/facade/DeliveryFacade.java
@@ -1,5 +1,7 @@
 package com.klp.delivery.delivery.application.facade;
 
+import static com.klp.delivery.delivery.exception.DeliveryErrorCode.DELIVERY_CREATION_FAILED;
+
 import com.klp.common.exception.BusinessException;
 import com.klp.delivery.common.enums.IdempotencyStatus;
 import com.klp.delivery.delivery.application.command.DeliveryCommand;
@@ -77,7 +79,15 @@ public class DeliveryFacade {
             return new DeliveryResponse(orderCommand.orderId(), deliveryItems);
         } catch (Exception e) {
             log.error("배송 생성 실패: orderId={}, error={}", orderCommand.orderId(), e.getMessage(), e);
-            throw e;
+            try {
+                // 실패 시 멱등키 삭제하여 재시도 가능하도록 처리
+                idempotencyKeyService.deleteIdempotencyKey(idempotencyCommand.idempotencyKey());
+                log.info("배송 생성 실패로 인한 멱등키 삭제 완료: idempotencyKey={}", idempotencyCommand.idempotencyKey());
+            } catch (Exception deleteException) {
+                log.error("배송 생성 실패로 인한  멱등키 삭제 실패: idempotencyKey={}, error={}",
+                    idempotencyCommand.idempotencyKey(), deleteException.getMessage(), deleteException);
+            }
+            throw new BusinessException(DELIVERY_CREATION_FAILED);
         }
     }
 

--- a/delivery/src/main/java/com/klp/delivery/delivery/application/service/IdempotencyKeyService.java
+++ b/delivery/src/main/java/com/klp/delivery/delivery/application/service/IdempotencyKeyService.java
@@ -41,4 +41,10 @@ public class IdempotencyKeyService {
             .ifPresent(k -> k.updateStatus(command.status()));
 
     }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void deleteIdempotencyKey(String idempotencyKey) {
+        log.info("멱등키 삭제: idempotencyKey={}", idempotencyKey);
+        idempotencyKeyRepository.deleteByIdempotencyKey(idempotencyKey);
+    }
 }

--- a/delivery/src/main/java/com/klp/delivery/delivery/domain/repository/IdempotencyKeyRepository.java
+++ b/delivery/src/main/java/com/klp/delivery/delivery/domain/repository/IdempotencyKeyRepository.java
@@ -9,4 +9,5 @@ public interface IdempotencyKeyRepository {
 
     Optional<IdempotencyKey> findByIdempotencyKey(String key);
 
+    void deleteByIdempotencyKey(String idempotencyKey);
 }

--- a/delivery/src/main/java/com/klp/delivery/delivery/infrastructure/repository/IdempotencyKeyRepositoryImpl.java
+++ b/delivery/src/main/java/com/klp/delivery/delivery/infrastructure/repository/IdempotencyKeyRepositoryImpl.java
@@ -22,4 +22,10 @@ public class IdempotencyKeyRepositoryImpl implements IdempotencyKeyRepository {
     public Optional<IdempotencyKey> findByIdempotencyKey(String key) {
         return idempotencyKeyJpaRepository.findByIdempotencyKey(key);
     }
+
+    @Override
+    public void deleteByIdempotencyKey(String key) {
+        idempotencyKeyJpaRepository.findByIdempotencyKey(key)
+            .ifPresent(idempotencyKeyJpaRepository::delete);
+    }
 }

--- a/delivery/src/test/java/com/klp/delivery/delivery/application/facade/DeliveryFacadeTest.java
+++ b/delivery/src/test/java/com/klp/delivery/delivery/application/facade/DeliveryFacadeTest.java
@@ -18,9 +18,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -41,6 +43,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.context.ApplicationEventPublisher;
 
 public class DeliveryFacadeTest extends MockTest {
 
@@ -58,6 +61,9 @@ public class DeliveryFacadeTest extends MockTest {
 
     @Mock
     CompanyService companyService;
+
+    @Mock
+    ApplicationEventPublisher eventPublisher;
 
     @Test
     void 배송생성_성공_단일아이템() {
@@ -330,6 +336,34 @@ public class DeliveryFacadeTest extends MockTest {
             any(IdempotencyCommand.class));
         verify(idempotencyKeyService, times(1)).deleteIdempotencyKey(idempotencyKey);
         verify(deliveryService, never()).registerDelivery(any(DeliveryCommand.class), anyList());
+    }
+
+
+    @Test
+    void 배송생성_실패후_보상트랜잭션으로_멱등키삭제_후_동일멱등키_재요청_성공() {
+        // given
+        DeliveryCreateRequest request = createDeliveryRequest(createOrderItemListWithDeliveryId());
+        IdempotencyCommand idempotencyCommand = request.toIdempotencyCommand();
+
+        // Step 1: 업체 조회 실패 → 멱등키 삭제 (보상 트랜잭션)
+        doNothing().when(idempotencyKeyService).registerIdempotencyKey(idempotencyCommand);
+        when(companyService.findCompany(DEFAULT_CUSTOMER_ID.toString()))
+            .thenThrow(new BusinessException(DeliveryErrorCode.EXTERNAL_API_ERROR));
+        doNothing().when(idempotencyKeyService).deleteIdempotencyKey(idempotencyCommand.idempotencyKey());
+
+        assertThatThrownBy(() -> deliveryFacade.createDelivery(
+            request.toOrderToDeliveryCommand(), idempotencyCommand))
+            .isInstanceOf(BusinessException.class);
+
+        verify(idempotencyKeyService, times(1)).deleteIdempotencyKey(idempotencyCommand.idempotencyKey());
+
+        // Step 2: 멱등키 삭제 후 재등록 성공
+        reset(idempotencyKeyService);
+        doNothing().when(idempotencyKeyService).registerIdempotencyKey(idempotencyCommand);
+
+        idempotencyKeyService.registerIdempotencyKey(idempotencyCommand);
+
+        verify(idempotencyKeyService, times(1)).registerIdempotencyKey(idempotencyCommand);
     }
 
 

--- a/delivery/src/test/java/com/klp/delivery/delivery/application/facade/DeliveryFacadeTest.java
+++ b/delivery/src/test/java/com/klp/delivery/delivery/application/facade/DeliveryFacadeTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -40,7 +41,6 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.context.ApplicationEventPublisher;
 
 public class DeliveryFacadeTest extends MockTest {
 
@@ -52,9 +52,6 @@ public class DeliveryFacadeTest extends MockTest {
 
     @Mock
     IdempotencyKeyService idempotencyKeyService;
-
-    @Mock
-    ApplicationEventPublisher eventPublisher;
 
     @Mock
     DriverService driverService;
@@ -205,6 +202,8 @@ public class DeliveryFacadeTest extends MockTest {
             .registerIdempotencyKey(any(IdempotencyCommand.class));
         when(companyService.findCompany(DEFAULT_CUSTOMER_ID.toString()))
             .thenThrow(new BusinessException(DeliveryErrorCode.EXTERNAL_API_ERROR));
+        doNothing().when(idempotencyKeyService)
+            .deleteIdempotencyKey(anyString());
 
         // when & then: 예외 발생 검증
         assertThatThrownBy(() -> deliveryFacade.createDelivery(request.toOrderToDeliveryCommand(),
@@ -213,7 +212,7 @@ public class DeliveryFacadeTest extends MockTest {
             .satisfies(exception -> {
                 BusinessException businessException = (BusinessException) exception;
                 assertThat(businessException.getErrorCode()).isEqualTo(
-                    DeliveryErrorCode.EXTERNAL_API_ERROR);
+                    DeliveryErrorCode.DELIVERY_CREATION_FAILED);
             });
 
         // then: 멱등키 등록 및 업체 조회는 호출되지만, 담당자 조회 및 배송 생성은 호출되지 않음
@@ -224,6 +223,8 @@ public class DeliveryFacadeTest extends MockTest {
         verify(deliveryService, never()).registerDelivery(any(DeliveryCommand.class), anyList());
         verify(idempotencyKeyService, never()).updateIdempotencyStatus(
             any(IdempotencyCommand.class));
+        // 보상 트랜잭션: 멱등키 삭제 호출 검증
+        verify(idempotencyKeyService, times(1)).deleteIdempotencyKey(anyString());
     }
 
     @Test
@@ -238,6 +239,9 @@ public class DeliveryFacadeTest extends MockTest {
             createCompany());
         when(driverService.findArrivalHubDrivers(any(UUID.class))).thenThrow(
             new BusinessException(DeliveryErrorCode.EXTERNAL_API_ERROR));
+        doNothing().when(idempotencyKeyService)
+            .deleteIdempotencyKey(anyString());
+
         assertThatThrownBy(() ->
             deliveryFacade.createDelivery(request.toOrderToDeliveryCommand(),
                 request.toIdempotencyCommand())
@@ -246,7 +250,7 @@ public class DeliveryFacadeTest extends MockTest {
             .satisfies(exception -> {
                 BusinessException businessException = (BusinessException) exception;
                 assertThat(businessException.getErrorCode()).isEqualTo(
-                    DeliveryErrorCode.EXTERNAL_API_ERROR);
+                    DeliveryErrorCode.DELIVERY_CREATION_FAILED);
             });
 
         // then: 멱등키 등록, 업체 조회, 담당자 조회는 호출되지만, 배송 생성은 호출되지 않음
@@ -257,6 +261,8 @@ public class DeliveryFacadeTest extends MockTest {
         verify(deliveryService, never()).registerDelivery(any(DeliveryCommand.class), anyList());
         verify(idempotencyKeyService, never()).updateIdempotencyStatus(
             any(IdempotencyCommand.class));
+        // 보상 트랜잭션: 멱등키 삭제 호출 검증
+        verify(idempotencyKeyService, times(1)).deleteIdempotencyKey(anyString());
     }
 
     @Test
@@ -271,6 +277,8 @@ public class DeliveryFacadeTest extends MockTest {
         when(driverService.findArrivalHubDrivers(any(UUID.class))).thenReturn(createDrivers());
         when(deliveryService.registerDelivery(any(DeliveryCommand.class), anyList()))
             .thenThrow(new BusinessException(DeliveryErrorCode.EXTERNAL_API_ERROR));
+        doNothing().when(idempotencyKeyService)
+            .deleteIdempotencyKey(anyString());
 
         // when & then: 예외 발생 검증
         assertThatThrownBy(() -> deliveryFacade.createDelivery(request.toOrderToDeliveryCommand(),
@@ -279,7 +287,7 @@ public class DeliveryFacadeTest extends MockTest {
             .satisfies(exception -> {
                 BusinessException businessException = (BusinessException) exception;
                 assertThat(businessException.getErrorCode()).isEqualTo(
-                    DeliveryErrorCode.EXTERNAL_API_ERROR);
+                    DeliveryErrorCode.DELIVERY_CREATION_FAILED);
             });
 
         // then: 멱등키 등록, 업체/담당자 조회, 배송 생성은 호출되지만, 멱등키 업데이트는 호출되지 않음
@@ -290,7 +298,40 @@ public class DeliveryFacadeTest extends MockTest {
         verify(deliveryService, times(1)).registerDelivery(any(DeliveryCommand.class), anyList());
         verify(idempotencyKeyService, never()).updateIdempotencyStatus(
             any(IdempotencyCommand.class));
+        // 보상 트랜잭션: 멱등키 삭제 호출 검증
+        verify(idempotencyKeyService, times(1)).deleteIdempotencyKey(anyString());
     }
+
+    @Test
+    void 배송생성_실패_보상트랜잭션_멱등키삭제_성공() {
+        // given: 배송 생성 요청 데이터 준비
+        DeliveryCreateRequest request = createDeliveryRequest(createOrderItemListWithDeliveryId());
+        String idempotencyKey = request.toIdempotencyCommand().idempotencyKey();
+
+        doNothing().when(idempotencyKeyService)
+            .registerIdempotencyKey(any(IdempotencyCommand.class));
+        when(companyService.findCompany(DEFAULT_CUSTOMER_ID.toString()))
+            .thenThrow(new BusinessException(DeliveryErrorCode.EXTERNAL_API_ERROR));
+        doNothing().when(idempotencyKeyService)
+            .deleteIdempotencyKey(idempotencyKey);
+
+        // when & then: 예외 발생 검증
+        assertThatThrownBy(() -> deliveryFacade.createDelivery(request.toOrderToDeliveryCommand(),
+            request.toIdempotencyCommand()))
+            .isInstanceOf(BusinessException.class)
+            .satisfies(exception -> {
+                BusinessException businessException = (BusinessException) exception;
+                assertThat(businessException.getErrorCode()).isEqualTo(
+                    DeliveryErrorCode.DELIVERY_CREATION_FAILED);
+            });
+
+        // then: 보상 트랜잭션 - 멱등키 삭제가 성공적으로 호출됨
+        verify(idempotencyKeyService, times(1)).registerIdempotencyKey(
+            any(IdempotencyCommand.class));
+        verify(idempotencyKeyService, times(1)).deleteIdempotencyKey(idempotencyKey);
+        verify(deliveryService, never()).registerDelivery(any(DeliveryCommand.class), anyList());
+    }
+
 
 
 }


### PR DESCRIPTION
- 멱등키는 REQUIRES_NEW로 먼저 저장되기 때문에 배송 생성 실패 시 롤백되지 않음
- 잘못 커밋된 멱등키를 정리하기 위해 실패 시 별도 REQUIRES_NEW 트랜잭션으로 삭제 처리
- 멱등키 정합성 유지를 위한 보상 처리 로직 추가