### PR TITLE
feat: 유저 등급 기능 구현 및 유저 서비스 리팩토링 진행

### DIFF
--- a/promotion/src/main/java/com/klp/promotion/grade/application/GradeService.java
+++ b/promotion/src/main/java/com/klp/promotion/grade/application/GradeService.java
@@ -4,8 +4,10 @@ import com.klp.common.exception.BusinessException;
 import com.klp.promotion.grade.application.dto.CreateGradeCommand;
 import com.klp.promotion.grade.application.dto.UpdateGradeCommand;
 import com.klp.promotion.grade.domain.entity.Grade;
+import com.klp.promotion.grade.domain.enums.GradeType;
 import com.klp.promotion.grade.domain.repository.GradeRepository;
 import com.klp.promotion.grade.exception.GradeErrorCode;
+import com.klp.promotion.grade.presentation.dto.response.DefaultGradeResponse;
 import com.klp.promotion.grade.presentation.dto.response.GradeResponse;
 import java.util.List;
 import java.util.UUID;
@@ -96,5 +98,10 @@ public class GradeService {
         if (minAmount != null && maxAmount != null && minAmount >= maxAmount) {
             throw new BusinessException(GradeErrorCode.INVALID_AMOUNT_RANGE);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public DefaultGradeResponse getDefaultGradeName() {
+        return DefaultGradeResponse.of(GradeType.NONE.getDisplayName());
     }
 }

--- a/promotion/src/main/java/com/klp/promotion/grade/presentation/controller/GradeInternalController.java
+++ b/promotion/src/main/java/com/klp/promotion/grade/presentation/controller/GradeInternalController.java
@@ -1,0 +1,26 @@
+package com.klp.promotion.grade.presentation.controller;
+
+import com.klp.promotion.grade.application.GradeService;
+import com.klp.promotion.grade.presentation.dto.response.DefaultGradeResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/internal/promotions/grades")
+@RequiredArgsConstructor
+public class GradeInternalController {
+
+    private final GradeService gradeService;
+
+    /**
+     * 기본 등급명을 조회합니다.
+     */
+    @GetMapping("/default")
+    public ResponseEntity<DefaultGradeResponse> getDefaultGrade() {
+        DefaultGradeResponse response = gradeService.getDefaultGradeName();
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/promotion/src/main/java/com/klp/promotion/grade/presentation/dto/response/DefaultGradeResponse.java
+++ b/promotion/src/main/java/com/klp/promotion/grade/presentation/dto/response/DefaultGradeResponse.java
@@ -1,0 +1,9 @@
+package com.klp.promotion.grade.presentation.dto.response;
+
+public record DefaultGradeResponse(
+    String gradeName
+) {
+    public static DefaultGradeResponse of(String gradeName) {
+        return new DefaultGradeResponse(gradeName);
+    }
+}

--- a/promotion/src/test/java/com/klp/promotion/grade/presentation/controller/GradeInternalControllerTest.java
+++ b/promotion/src/test/java/com/klp/promotion/grade/presentation/controller/GradeInternalControllerTest.java
@@ -1,0 +1,69 @@
+package com.klp.promotion.grade.presentation.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.klp.promotion.global.exception.GlobalExceptionHandler;
+import com.klp.promotion.global.security.config.SecurityConfig;
+import com.klp.promotion.global.security.filter.AuthorizationFilter;
+import com.klp.promotion.grade.application.GradeService;
+import com.klp.promotion.grade.presentation.dto.response.DefaultGradeResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(GradeInternalController.class)
+@Import({SecurityConfig.class, AuthorizationFilter.class, GlobalExceptionHandler.class})
+@DisplayName("GradeInternalController 테스트")
+class GradeInternalControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private GradeService gradeService;
+
+    @Nested
+    @DisplayName("기본 등급명 조회 API 테스트")
+    class GetDefaultGradeApiTest {
+
+        @Test
+        @DisplayName("기본 등급명을 정상적으로 조회한다")
+        void getDefaultGrade_Success() throws Exception {
+            // given
+            String defaultGradeName = "NONE";
+            DefaultGradeResponse response = DefaultGradeResponse.of(defaultGradeName);
+
+            when(gradeService.getDefaultGradeName()).thenReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/v1/internal/promotions/grades/default"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.gradeName").value(defaultGradeName));
+        }
+
+        @Test
+        @DisplayName("기본 등급명이 'NONE'임을 확인한다")
+        void getDefaultGrade_ReturnsNoneGrade() throws Exception {
+            // given
+            DefaultGradeResponse response = DefaultGradeResponse.of("NONE");
+
+            when(gradeService.getDefaultGradeName()).thenReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/v1/internal/promotions/grades/default"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.gradeName").value("NONE"));
+        }
+    }
+}

--- a/user/build.gradle
+++ b/user/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.cloud:spring-cloud-starter-bus-kafka'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'

--- a/user/src/main/java/com/klp/UserApplication.java
+++ b/user/src/main/java/com/klp/UserApplication.java
@@ -3,9 +3,11 @@ package com.klp;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
 @EnableDiscoveryClient
+@EnableFeignClients
 public class UserApplication {
 
     public static void main(String[] args) {

--- a/user/src/main/java/com/klp/global/exception/CompanyFeignErrorDecoder.java
+++ b/user/src/main/java/com/klp/global/exception/CompanyFeignErrorDecoder.java
@@ -1,0 +1,58 @@
+package com.klp.global.exception;
+
+import com.klp.user.domain.exception.ExternalApiErrorCode;
+import com.klp.user.domain.exception.ExternalApiException;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class CompanyFeignErrorDecoder implements ErrorDecoder {
+
+    private final ErrorDecoder errorDecoder = new Default();
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        int status = response.status();
+
+        return switch (status) {
+
+            // 5xx - 외부 서비스 장애
+            case 500, 502, 503, 504 -> {
+                log.error("[CompanyFeignErrorDecoder] 업체 서비스 장애 발생. method={}, status={}",
+                    methodKey, status);
+                yield new ExternalApiException(ExternalApiErrorCode.COMPANY_SERVICE_UNAVAILABLE);
+            }
+
+            // 4xx - 클라이언트 오류
+            case 400 -> {
+                log.warn("[CompanyFeignErrorDecoder] 잘못된 요청. method={}, status=400", methodKey);
+                yield new ExternalApiException(ExternalApiErrorCode.COMPANY_SERVICE_BAD_REQUEST);
+            }
+            case 401 -> {
+                log.warn("[CompanyFeignErrorDecoder] 인증 실패. method={}, status=401", methodKey);
+                yield new ExternalApiException(ExternalApiErrorCode.COMPANY_SERVICE_UNAUTHORIZED);
+            }
+            case 403 -> {
+                log.warn("[CompanyFeignErrorDecoder] 인가 거부. method={}, status=403", methodKey);
+                yield new ExternalApiException(ExternalApiErrorCode.COMPANY_SERVICE_FORBIDDEN);
+            }
+            case 404 -> {
+                log.warn("[CompanyFeignErrorDecoder] 업체 정보 없음. method={}, status=404", methodKey);
+                yield new ExternalApiException(ExternalApiErrorCode.COMPANY_NOT_FOUND);
+            }
+
+            // 기타 오류
+            default -> {
+                if (status >= 400 && status < 500) {
+                    log.warn("[CompanyFeignErrorDecoder] 기타 4xx 오류. method={}, status={}",
+                        methodKey, status);
+                    yield new ExternalApiException(ExternalApiErrorCode.COMPANY_SERVICE_BAD_REQUEST);
+                }
+                log.error("[CompanyFeignErrorDecoder] 예상치 못한 오류. method={}, status={}",
+                    methodKey, status);
+                yield errorDecoder.decode(methodKey, response);
+            }
+        };
+    }
+}

--- a/user/src/main/java/com/klp/global/exception/GlobalExceptionHandler.java
+++ b/user/src/main/java/com/klp/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.klp.global.exception;
 
 import com.klp.common.exception.BusinessException;
 import com.klp.common.exception.ErrorResponse;
+import com.klp.user.domain.exception.ExternalApiException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpStatus;
@@ -27,6 +28,16 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BusinessException.class)
     protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
         log.warn("handleBusinessException : {}", e.getMessage());
+
+        ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode().name(), e.getMessage());
+
+        return ResponseEntity.status(e.getErrorCode().getStatus())
+            .body(errorResponse);
+    }
+
+    @ExceptionHandler(ExternalApiException.class)
+    protected ResponseEntity<ErrorResponse> handleExternalApiException(ExternalApiException e) {
+        log.error("handleExternalApiException : {}", e.getMessage());
 
         ErrorResponse errorResponse = ErrorResponse.of(e.getErrorCode().name(), e.getMessage());
 

--- a/user/src/main/java/com/klp/global/exception/PromotionFeignErrorDecoder.java
+++ b/user/src/main/java/com/klp/global/exception/PromotionFeignErrorDecoder.java
@@ -1,0 +1,58 @@
+package com.klp.global.exception;
+
+import com.klp.user.domain.exception.ExternalApiErrorCode;
+import com.klp.user.domain.exception.ExternalApiException;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class PromotionFeignErrorDecoder implements ErrorDecoder {
+
+    private final ErrorDecoder errorDecoder = new Default();
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        int status = response.status();
+
+        return switch (status) {
+
+            // 5xx - 외부 서비스 장애
+            case 500, 502, 503, 504 -> {
+                log.error("[PromotionFeignErrorDecoder] 프로모션 서비스 장애 발생. method={}, status={}",
+                    methodKey, status);
+                yield new ExternalApiException(ExternalApiErrorCode.PROMOTION_SERVICE_UNAVAILABLE);
+            }
+
+            // 4xx - 클라이언트 오류
+            case 400 -> {
+                log.warn("[PromotionFeignErrorDecoder] 잘못된 요청. method={}, status=400", methodKey);
+                yield new ExternalApiException(ExternalApiErrorCode.PROMOTION_SERVICE_BAD_REQUEST);
+            }
+            case 401 -> {
+                log.warn("[PromotionFeignErrorDecoder] 인증 실패. method={}, status=401", methodKey);
+                yield new ExternalApiException(ExternalApiErrorCode.PROMOTION_SERVICE_UNAUTHORIZED);
+            }
+            case 403 -> {
+                log.warn("[PromotionFeignErrorDecoder] 인가 거부. method={}, status=403", methodKey);
+                yield new ExternalApiException(ExternalApiErrorCode.PROMOTION_SERVICE_FORBIDDEN);
+            }
+            case 404 -> {
+                log.warn("[PromotionFeignErrorDecoder] 회원 등급 정보 없음. method={}, status=404", methodKey);
+                yield new ExternalApiException(ExternalApiErrorCode.USER_GRADE_NOT_FOUND);
+            }
+
+            // 기타 오류
+            default -> {
+                if (status >= 400 && status < 500) {
+                    log.warn("[PromotionFeignErrorDecoder] 기타 4xx 오류. method={}, status={}",
+                        methodKey, status);
+                    yield new ExternalApiException(ExternalApiErrorCode.PROMOTION_SERVICE_BAD_REQUEST);
+                }
+                log.error("[PromotionFeignErrorDecoder] 예상치 못한 오류. method={}, status={}",
+                    methodKey, status);
+                yield errorDecoder.decode(methodKey, response);
+            }
+        };
+    }
+}

--- a/user/src/main/java/com/klp/user/application/UserFacade.java
+++ b/user/src/main/java/com/klp/user/application/UserFacade.java
@@ -1,0 +1,260 @@
+package com.klp.user.application;
+
+import com.klp.common.exception.BusinessException;
+import com.klp.common.model.PageResponse;
+import com.klp.user.domain.entity.User;
+import com.klp.user.domain.entity.UserGrade;
+import com.klp.user.domain.enums.AffiliationType;
+import com.klp.user.domain.enums.UserRole;
+import com.klp.user.domain.exception.ExternalApiException;
+import com.klp.user.domain.exception.UserErrorCode;
+import com.klp.user.infrastructure.client.CompanyClient;
+import com.klp.user.infrastructure.client.PromotionClient;
+import com.klp.user.infrastructure.client.dto.response.CompanyListResponse;
+import com.klp.user.infrastructure.client.dto.response.CompanyResponse;
+import com.klp.user.infrastructure.client.dto.response.DefaultGradeResponse;
+import com.klp.user.presentation.dto.request.UserCreateRequest;
+import com.klp.user.presentation.dto.request.UserUpdateRequest;
+import com.klp.user.presentation.dto.response.DriverDetailResponse;
+import com.klp.user.presentation.dto.response.DriverInfo;
+import com.klp.user.presentation.dto.response.HubDriverListResponse;
+import com.klp.user.presentation.dto.response.LogisticsDriverListResponse;
+import com.klp.user.presentation.dto.response.UserDetailResponse;
+import com.klp.user.presentation.dto.response.UserGradeResponse;
+import com.klp.user.presentation.dto.response.UserInfoResponse;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserFacade {
+
+    private final UserService userService;
+    private final UserGradeService userGradeService;
+    private final CompanyClient companyClient;
+    private final PromotionClient promotionClient;
+
+    /**
+     * 회원가입 플로우 - PENDING 상태로 생성
+     */
+    @Transactional
+    public Long createPendingUser(UserCreateRequest request) {
+        UUID affiliationId = getAffiliationId(request.affiliationName(), request.affiliationType());
+        User user = userService.createPendingUser(request, affiliationId);
+
+        log.info("회원가입 대기 상태 생성 완료 - userId: {}, role: {}", user.getUserId(), user.getRole());
+
+        return user.getUserId();
+    }
+
+    /**
+     * 회원 승인 플로우 - CUSTOMER인 경우 기본 등급 생성
+     */
+    @Transactional
+    public void approvePendingUser(Long userId) {
+        User user = userService.findNotDeletedUser(userId);
+        userService.approvePendingUser(user);
+
+        if (user.getRole() == UserRole.CUSTOMER) {
+            String gradeName = getDefaultGradeName();
+            userGradeService.createUserGrade(user, gradeName);
+            log.info("고객 승인 완료 - userId: {}, 등급: {}", userId, gradeName);
+        } else {
+            log.info("사용자 가입 승인 완료 - userId: {}, role: {}", userId, user.getRole());
+        }
+    }
+
+    /**
+     * 회원 거부 플로우
+     */
+    @Transactional
+    public void rejectPendingUser(Long userId) {
+        User user = userService.findNotDeletedUser(userId);
+        userService.rejectPendingUser(user);
+        log.info("사용자 가입 거부 완료 - userId: {}", userId);
+    }
+
+    /**
+     * 회원 상세 조회 - Company 호출 + 등급 조회
+     */
+    @Transactional(readOnly = true)
+    public UserDetailResponse getUserDetails(Long userId) {
+        User user = userService.findNotDeletedUser(userId);
+        String affiliationName = getAffiliationName(user);
+
+        String gradeName = null;
+        if (user.getRole() == UserRole.CUSTOMER) {
+            gradeName = userGradeService.getCurrentGradeName(userId);
+        }
+
+        return UserDetailResponse.of(user, affiliationName, gradeName);
+    }
+
+    /**
+     * 회원 목록 조회 - Company 호출 + 등급 조회
+     */
+    @Transactional(readOnly = true)
+    public PageResponse<UserInfoResponse> getUserList(String keyword, Pageable pageable) {
+        Page<User> userPage = userService.getUserList(keyword, pageable);
+
+        return PageResponse.of(userPage, user -> {
+            String affiliationName = getAffiliationName(user);
+            String gradeName = null;
+
+            if (user.getRole() == UserRole.CUSTOMER) {
+                gradeName = userGradeService.getCurrentGradeName(user.getUserId());
+            }
+
+            return UserInfoResponse.of(user, affiliationName, gradeName);
+        });
+    }
+
+    /**
+     * 회원 정보 수정
+     */
+    @Transactional
+    public void updateUserInfo(Long userId, UserUpdateRequest request) {
+        User user = userService.findNotDeletedUser(userId);
+        userService.updateUserInfo(user, request);
+        log.info("회원 정보 수정 완료 - userId: {}", userId);
+    }
+
+    /**
+     * 드라이버 조회 - 허브별
+     */
+    @Transactional(readOnly = true)
+    public HubDriverListResponse getDriversByHubId(UUID hubId) {
+        List<User> drivers = userService.findDriversByHubId(hubId);
+
+        List<DriverInfo> driverInfoList = drivers.stream()
+            .map(DriverInfo::from)
+            .toList();
+
+        return HubDriverListResponse.of(hubId, driverInfoList);
+    }
+
+    /**
+     * 드라이버 조회 - 물류 회사
+     */
+    @Transactional(readOnly = true)
+    public LogisticsDriverListResponse getDriversByLogistics() {
+        List<User> drivers = userService.findDriversByLogistics();
+
+        List<DriverInfo> driverInfoList = drivers.stream()
+            .map(DriverInfo::from)
+            .toList();
+
+        return LogisticsDriverListResponse.of(driverInfoList);
+    }
+
+    /**
+     * 드라이버 상세 조회
+     */
+    @Transactional(readOnly = true)
+    public DriverDetailResponse getDriverById(Long driverId) {
+        User driver = userService.findDriverById(driverId);
+        return DriverDetailResponse.from(driver);
+    }
+
+    /**
+     * 회원 등급 조회
+     */
+    @Transactional(readOnly = true)
+    public UserGradeResponse getCurrentUserGrade(Long userId) {
+        userService.findNotDeletedUser(userId);
+        UserGrade userGrade = userGradeService.getCurrentUserGrade(userId);
+        return UserGradeResponse.from(userGrade);
+    }
+
+    /**
+     * 회원 등급 변경
+     */
+    @Transactional
+    public UserGradeResponse updateUserGrade(Long userId, String gradeName) {
+        userService.findNotDeletedUser(userId);
+        UserGrade newGrade = userGradeService.updateUserGrade(userId, gradeName);
+        log.info("회원 등급 변경 완료 - userId: {}, gradeName: {}", userId, gradeName);
+        return UserGradeResponse.from(newGrade);
+    }
+
+    /**
+     * 기본 등급명 조회 (Promotion 서비스)
+     */
+    private String getDefaultGradeName() {
+        try {
+            DefaultGradeResponse response = promotionClient.getDefaultGrade();
+            return response.gradeName();
+        } catch (ExternalApiException e) {
+            log.error("기본 등급 조회 실패", e);
+            return "등급 없음";
+        }
+    }
+
+    /**
+     * 소속명 조회 (Company 서비스)
+     */
+    private String getAffiliationName(User user) {
+        if (user.getAffiliationType() == AffiliationType.CUSTOMER) {
+            return "고객";
+        }
+
+        if (user.getAffiliationId() == null) {
+            log.warn("affiliationId가 null입니다 - userId: {}", user.getUserId());
+            throw new BusinessException(UserErrorCode.INVALID_AFFILIATION);
+        }
+
+        try {
+            CompanyResponse companyResponse = companyClient.getCompanyById(user.getAffiliationId());
+            return companyResponse.name();
+        } catch (ExternalApiException e) {
+            log.error("업체 정보 조회 실패 - affiliationId: {}, errorCode: {}",
+                user.getAffiliationId(), e.getErrorCode().name());
+            throw e;
+        } catch (Exception e) {
+            log.error("예상치 못한 예외 발생 - affiliationId: {}", user.getAffiliationId(), e);
+            throw new BusinessException(UserErrorCode.INTERNAL_SERVER_ERROR,
+                "업체 정보 조회 중 예상치 못한 오류가 발생했습니다.");
+        }
+    }
+
+    /**
+     * 소속 ID 조회 (Company 서비스)
+     */
+    private UUID getAffiliationId(String affiliationName, AffiliationType affiliationType) {
+        if (affiliationType == AffiliationType.CUSTOMER) {
+            return null;
+        }
+
+        try {
+            CompanyListResponse response = companyClient.getCompaniesByName(affiliationName);
+
+            if (response.companies().isEmpty()) {
+                log.warn("업체 정보를 찾을 수 없음 - affiliationName: {}", affiliationName);
+                throw new BusinessException(UserErrorCode.BAD_REQUEST,
+                    "해당 이름의 업체를 찾을 수 없습니다: " + affiliationName);
+            }
+
+            UUID companyId = response.companies().get(0).companyId();
+            log.debug("업체 ID 조회 성공 - affiliationName: {}, companyId: {}", affiliationName, companyId);
+            return companyId;
+
+        } catch (BusinessException e) {
+            throw e;
+        } catch (ExternalApiException e) {
+            log.error("업체 정보 조회 실패 - affiliationName: {}, errorCode: {}",
+                affiliationName, e.getErrorCode().name());
+            throw e;
+        } catch (Exception e) {
+            log.error("예상치 못한 예외 발생 - affiliationName: {}", affiliationName, e);
+            throw new BusinessException(UserErrorCode.INTERNAL_SERVER_ERROR,
+                "업체 정보 조회 중 예상치 못한 오류가 발생했습니다.");
+        }
+    }
+}

--- a/user/src/main/java/com/klp/user/application/UserGradeService.java
+++ b/user/src/main/java/com/klp/user/application/UserGradeService.java
@@ -23,7 +23,7 @@ public class UserGradeService {
      */
     @Transactional(readOnly = true)
     public String getCurrentGradeName(Long userId) {
-        return userGradeRepository.findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId)
+        return userGradeRepository.findFirstByUser(userId)
             .map(UserGrade::getGradeName)
             .orElse(null);
     }
@@ -33,7 +33,7 @@ public class UserGradeService {
      */
     @Transactional(readOnly = true)
     public UserGrade getCurrentUserGrade(Long userId) {
-        return userGradeRepository.findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId)
+        return userGradeRepository.findFirstByUser(userId)
             .orElseThrow(() -> new BusinessException(UserErrorCode.USER_GRADE_NOT_FOUND));
     }
 

--- a/user/src/main/java/com/klp/user/application/UserGradeService.java
+++ b/user/src/main/java/com/klp/user/application/UserGradeService.java
@@ -1,0 +1,67 @@
+package com.klp.user.application;
+
+import com.klp.common.exception.BusinessException;
+import com.klp.user.domain.entity.User;
+import com.klp.user.domain.entity.UserGrade;
+import com.klp.user.domain.exception.UserErrorCode;
+import com.klp.user.domain.repository.UserGradeRepository;
+import com.klp.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserGradeService {
+
+    private final UserGradeRepository userGradeRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 현재 등급명을 조회
+     */
+    @Transactional(readOnly = true)
+    public String getCurrentGradeName(Long userId) {
+        return userGradeRepository.findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId)
+            .map(UserGrade::getGradeName)
+            .orElse(null);
+    }
+
+    /**
+     * 현재 등급 엔티티를 조회
+     */
+    @Transactional(readOnly = true)
+    public UserGrade getCurrentUserGrade(Long userId) {
+        return userGradeRepository.findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId)
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_GRADE_NOT_FOUND));
+    }
+
+    /**
+     * 등급 생성
+     */
+    public UserGrade createUserGrade(User user, String gradeName) {
+        UserGrade userGrade = UserGrade.create(user, gradeName);
+        return userGradeRepository.save(userGrade);
+    }
+
+    /**
+     * 등급 변경 (새로운 이력 생성)
+     */
+    public UserGrade updateUserGrade(Long userId, String gradeName) {
+        User user = findNotDeletedUser(userId);
+        UserGrade newGrade = UserGrade.create(user, gradeName);
+        return userGradeRepository.save(newGrade);
+    }
+
+    private User findNotDeletedUser(Long userId) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        if (user.isDeleted()) {
+            throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
+        }
+
+        return user;
+    }
+}

--- a/user/src/main/java/com/klp/user/application/UserService.java
+++ b/user/src/main/java/com/klp/user/application/UserService.java
@@ -4,8 +4,16 @@ import com.klp.common.exception.BusinessException;
 import com.klp.common.model.PageResponse;
 import com.klp.user.application.command.ValidateUserCommand;
 import com.klp.user.domain.entity.User;
+import com.klp.user.domain.enums.AffiliationType;
+import com.klp.user.domain.enums.UserRole;
+import com.klp.user.domain.exception.ExternalApiException;
 import com.klp.user.domain.exception.UserErrorCode;
 import com.klp.user.domain.repository.UserRepository;
+import com.klp.user.infrastructure.client.CompanyClient;
+import com.klp.user.infrastructure.client.PromotionClient;
+import com.klp.user.infrastructure.client.dto.request.CreateUserGradeRequest;
+import com.klp.user.infrastructure.client.dto.response.CompanyListResponse;
+import com.klp.user.infrastructure.client.dto.response.CompanyResponse;
 import com.klp.user.presentation.dto.request.UserCreateRequest;
 import com.klp.user.presentation.dto.request.UserUpdateRequest;
 import com.klp.user.presentation.dto.response.DriverDetailResponse;
@@ -21,7 +29,6 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -34,6 +41,8 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final CompanyClient companyClient;
+    private final PromotionClient promotionClient;
 
     @Transactional(readOnly = true)
     public UsernameCheckResponse checkUserNameAvailable(String username) {
@@ -42,22 +51,9 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public UserDetailResponse getMyDetails(Long userId) {
-        // TODO 업체Id를 통해 업체 이름을 받아오는 요청 필요
-        String affiliationName = "tempAffiliation";
-
-        User user = findNotDeletedUser(userId);
-
-        return UserDetailResponse.of(affiliationName, user);
-    }
-
-
-    @Transactional(readOnly = true)
     public UserDetailResponse getUserDetails(Long userId) {
-        // TODO 업체Id를 통해 업체 이름을 받아오는 요청 필요
-        String affiliationName = "tempAffiliation";
-
         User user = findNotDeletedUser(userId);
+        String affiliationName = getAffiliationName(user);
 
         return UserDetailResponse.of(affiliationName, user);
     }
@@ -72,9 +68,8 @@ public class UserService {
             userPage = userRepository.searchByKeyword(keyword, pageable);
         }
 
-        // TODO 업체Id를 통해 업체 이름을 받아오는 요청 필요
         return PageResponse.of(userPage, user ->
-            UserInfoResponse.of(user, "tempAffiliation")
+            UserInfoResponse.of(user, getAffiliationName(user))
         );
     }
 
@@ -83,13 +78,13 @@ public class UserService {
         User user = findNotDeletedUser(userId);
         String encodedPassword = passwordEncoder.encode(request.password());
 
-        user.update(request.username(), encodedPassword, request.slackId(), request.phone(), request.email(), request.role());
+        user.update(request.username(), encodedPassword, request.slackId(), request.phone(), request.email(),
+            request.role());
     }
 
     @Transactional
     public Long createPendingUser(UserCreateRequest request) {
-        // TODO 업체 이름을 통해 업체 ID를 받아오는 요청 필요
-        UUID affiliationId = UUID.randomUUID();
+        UUID affiliationId = getAffiliationId(request.affiliationName(), request.affiliationType());
 
         String encodedPassword = passwordEncoder.encode(request.password());
         User user = User.create(
@@ -124,6 +119,22 @@ public class UserService {
         User user = findNotDeletedUser(userId);
 
         user.approve();
+
+        if (user.getRole() == UserRole.CUSTOMER) {
+            try {
+                promotionClient.createUserGrade(new CreateUserGradeRequest(userId));
+                log.info("고객 승인 완료(등급 NONE 설정) - userId: {}", userId);
+            } catch (ExternalApiException e) {
+                log.error("회원 등급 생성 실패 - userId: {}, errorCode: {}", userId, e.getErrorCode().name());
+                throw e;
+            } catch (Exception e) {
+                log.error("회원 등급 생성 중 예상치 못한 오류 발생 - userId: {}", userId, e);
+                throw new BusinessException(UserErrorCode.INTERNAL_SERVER_ERROR,
+                    "회원 등급 생성 중 예상치 못한 오류가 발생했습니다.");
+            }
+        } else {
+            log.info("사용자 가입 승인 완료 - userId: {}", userId);
+        }
     }
 
     @Transactional
@@ -161,6 +172,68 @@ public class UserService {
             .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
         return DriverDetailResponse.from(driver);
+    }
+
+    /**
+     * 사용자의 소속 이름을 조회합니다. CUSTOMER인 경우 "고객"을 반환하고, 그 외에는 CompanyClient를 통해 업체 이름을 조회합니다.
+     */
+    private String getAffiliationName(User user) {
+        if (user.getAffiliationType() == AffiliationType.CUSTOMER) {
+            return "고객";
+        }
+
+        if (user.getAffiliationId() == null) {
+            log.warn("affiliationId가 null입니다 - userId: {}", user.getUserId());
+            throw new BusinessException(UserErrorCode.INVALID_AFFILIATION);
+        }
+
+        try {
+            CompanyResponse companyResponse = companyClient.getCompanyById(user.getAffiliationId());
+            return companyResponse.name();
+        } catch (ExternalApiException e) {
+            log.error("업체 정보 조회 실패 - affiliationId: {}, errorCode: {}",
+                user.getAffiliationId(), e.getErrorCode().name());
+            throw e;
+        } catch (Exception e) {
+            log.error("예상치 못한 예외 발생 - affiliationId: {}", user.getAffiliationId(), e);
+            throw new BusinessException(UserErrorCode.INTERNAL_SERVER_ERROR,
+                "업체 정보 조회 중 예상치 못한 오류가 발생했습니다.");
+        }
+    }
+
+    /**
+     * 업체 이름으로 업체 ID를 조회합니다. CUSTOMER인 경우 null을 반환하고, 그 외에는 CompanyClient를 통해 업체 ID를 조회합니다.
+     */
+    private UUID getAffiliationId(String affiliationName, AffiliationType affiliationType) {
+        if (affiliationType == AffiliationType.CUSTOMER) {
+            return null;
+        }
+
+        try {
+            CompanyListResponse response = companyClient.getCompaniesByName(affiliationName);
+
+            if (response.companies().isEmpty()) {
+                log.warn("업체 정보를 찾을 수 없음 - affiliationName: {}", affiliationName);
+                throw new BusinessException(UserErrorCode.BAD_REQUEST,
+                    "해당 이름의 업체를 찾을 수 없습니다: " + affiliationName);
+            }
+
+            // 첫 번째 결과를 사용 (동일한 이름의 업체가 여러 개일 경우 첫 번째 선택) -> 원래라면 사용자가 업체를 선택하는 부분이 존재해야 함
+            UUID companyId = response.companies().get(0).companyId();
+            log.debug("업체 ID 조회 성공 - affiliationName: {}, companyId: {}", affiliationName, companyId);
+            return companyId;
+
+        } catch (BusinessException e) {
+            throw e;
+        } catch (ExternalApiException e) {
+            log.error("업체 정보 조회 실패 - affiliationName: {}, errorCode: {}",
+                affiliationName, e.getErrorCode().name());
+            throw e;
+        } catch (Exception e) {
+            log.error("예상치 못한 예외 발생 - affiliationName: {}", affiliationName, e);
+            throw new BusinessException(UserErrorCode.INTERNAL_SERVER_ERROR,
+                "업체 정보 조회 중 예상치 못한 오류가 발생했습니다.");
+        }
     }
 
     private boolean validatePassword(String rawPassword, String encodedPassword) {

--- a/user/src/main/java/com/klp/user/application/UserService.java
+++ b/user/src/main/java/com/klp/user/application/UserService.java
@@ -1,28 +1,13 @@
 package com.klp.user.application;
 
 import com.klp.common.exception.BusinessException;
-import com.klp.common.model.PageResponse;
 import com.klp.user.application.command.ValidateUserCommand;
 import com.klp.user.domain.entity.User;
-import com.klp.user.domain.enums.AffiliationType;
-import com.klp.user.domain.enums.UserRole;
-import com.klp.user.domain.exception.ExternalApiException;
 import com.klp.user.domain.exception.UserErrorCode;
 import com.klp.user.domain.repository.UserRepository;
-import com.klp.user.infrastructure.client.CompanyClient;
-import com.klp.user.infrastructure.client.PromotionClient;
-import com.klp.user.infrastructure.client.dto.request.CreateUserGradeRequest;
-import com.klp.user.infrastructure.client.dto.response.CompanyListResponse;
-import com.klp.user.infrastructure.client.dto.response.CompanyResponse;
 import com.klp.user.presentation.dto.request.UserCreateRequest;
 import com.klp.user.presentation.dto.request.UserUpdateRequest;
-import com.klp.user.presentation.dto.response.DriverDetailResponse;
-import com.klp.user.presentation.dto.response.DriverInfo;
-import com.klp.user.presentation.dto.response.HubDriverListResponse;
-import com.klp.user.presentation.dto.response.LogisticsDriverListResponse;
 import com.klp.user.presentation.dto.response.UserDataResponse;
-import com.klp.user.presentation.dto.response.UserDetailResponse;
-import com.klp.user.presentation.dto.response.UserInfoResponse;
 import com.klp.user.presentation.dto.response.UsernameCheckResponse;
 import java.util.List;
 import java.util.UUID;
@@ -41,8 +26,6 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
-    private final CompanyClient companyClient;
-    private final PromotionClient promotionClient;
 
     @Transactional(readOnly = true)
     public UsernameCheckResponse checkUserNameAvailable(String username) {
@@ -51,41 +34,23 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public UserDetailResponse getUserDetails(Long userId) {
-        User user = findNotDeletedUser(userId);
-        String affiliationName = getAffiliationName(user);
-
-        return UserDetailResponse.of(affiliationName, user);
-    }
-
-    @Transactional(readOnly = true)
-    public PageResponse<UserInfoResponse> getUserList(String keyword, Pageable pageable) {
-        Page<User> userPage;
-
+    public Page<User> getUserList(String keyword, Pageable pageable) {
         if (keyword == null || keyword.trim().isEmpty()) {
-            userPage = userRepository.findAll(pageable);
+            return userRepository.findAll(pageable);
         } else {
-            userPage = userRepository.searchByKeyword(keyword, pageable);
+            return userRepository.searchByKeyword(keyword, pageable);
         }
-
-        return PageResponse.of(userPage, user ->
-            UserInfoResponse.of(user, getAffiliationName(user))
-        );
     }
 
     @Transactional
-    public void updateUserInfo(Long userId, UserUpdateRequest request) {
-        User user = findNotDeletedUser(userId);
+    public void updateUserInfo(User user, UserUpdateRequest request) {
         String encodedPassword = passwordEncoder.encode(request.password());
-
         user.update(request.username(), encodedPassword, request.slackId(), request.phone(), request.email(),
             request.role());
     }
 
     @Transactional
-    public Long createPendingUser(UserCreateRequest request) {
-        UUID affiliationId = getAffiliationId(request.affiliationName(), request.affiliationType());
-
+    public User createPendingUser(UserCreateRequest request, UUID affiliationId) {
         String encodedPassword = passwordEncoder.encode(request.password());
         User user = User.create(
             affiliationId,
@@ -98,8 +63,7 @@ public class UserService {
             request.role()
         );
 
-        User saved = userRepository.save(user);
-        return saved.getUserId();
+        return userRepository.save(user);
     }
 
     @Transactional(readOnly = true)
@@ -115,132 +79,36 @@ public class UserService {
     }
 
     @Transactional
-    public void approvePendingUser(Long userId) {
-        User user = findNotDeletedUser(userId);
-
+    public void approvePendingUser(User user) {
         user.approve();
-
-        if (user.getRole() == UserRole.CUSTOMER) {
-            try {
-                promotionClient.createUserGrade(new CreateUserGradeRequest(userId));
-                log.info("고객 승인 완료(등급 NONE 설정) - userId: {}", userId);
-            } catch (ExternalApiException e) {
-                log.error("회원 등급 생성 실패 - userId: {}, errorCode: {}", userId, e.getErrorCode().name());
-                throw e;
-            } catch (Exception e) {
-                log.error("회원 등급 생성 중 예상치 못한 오류 발생 - userId: {}", userId, e);
-                throw new BusinessException(UserErrorCode.INTERNAL_SERVER_ERROR,
-                    "회원 등급 생성 중 예상치 못한 오류가 발생했습니다.");
-            }
-        } else {
-            log.info("사용자 가입 승인 완료 - userId: {}", userId);
-        }
     }
 
     @Transactional
-    public void rejectPendingUser(Long userId) {
-        User user = findNotDeletedUser(userId);
-
+    public void rejectPendingUser(User user) {
         user.reject();
     }
 
     @Transactional(readOnly = true)
-    public HubDriverListResponse getDriversByHubId(UUID hubId) {
-        List<User> drivers = userRepository.findDriversByHubId(hubId);
-
-        List<DriverInfo> driverInfoList = drivers.stream()
-            .map(DriverInfo::from)
-            .toList();
-
-        return HubDriverListResponse.of(hubId, driverInfoList);
+    public List<User> findDriversByHubId(UUID hubId) {
+        return userRepository.findDriversByHubId(hubId);
     }
 
     @Transactional(readOnly = true)
-    public LogisticsDriverListResponse getDriversByLogistics() {
-        List<User> drivers = userRepository.findDriversByLogistics();
-
-        List<DriverInfo> driverInfoList = drivers.stream()
-            .map(DriverInfo::from)
-            .toList();
-
-        return LogisticsDriverListResponse.of(driverInfoList);
+    public List<User> findDriversByLogistics() {
+        return userRepository.findDriversByLogistics();
     }
 
     @Transactional(readOnly = true)
-    public DriverDetailResponse getDriverById(Long driverId) {
-        User driver = userRepository.findDriverById(driverId)
+    public User findDriverById(Long driverId) {
+        return userRepository.findDriverById(driverId)
             .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
-
-        return DriverDetailResponse.from(driver);
-    }
-
-    /**
-     * 사용자의 소속 이름을 조회합니다. CUSTOMER인 경우 "고객"을 반환하고, 그 외에는 CompanyClient를 통해 업체 이름을 조회합니다.
-     */
-    private String getAffiliationName(User user) {
-        if (user.getAffiliationType() == AffiliationType.CUSTOMER) {
-            return "고객";
-        }
-
-        if (user.getAffiliationId() == null) {
-            log.warn("affiliationId가 null입니다 - userId: {}", user.getUserId());
-            throw new BusinessException(UserErrorCode.INVALID_AFFILIATION);
-        }
-
-        try {
-            CompanyResponse companyResponse = companyClient.getCompanyById(user.getAffiliationId());
-            return companyResponse.name();
-        } catch (ExternalApiException e) {
-            log.error("업체 정보 조회 실패 - affiliationId: {}, errorCode: {}",
-                user.getAffiliationId(), e.getErrorCode().name());
-            throw e;
-        } catch (Exception e) {
-            log.error("예상치 못한 예외 발생 - affiliationId: {}", user.getAffiliationId(), e);
-            throw new BusinessException(UserErrorCode.INTERNAL_SERVER_ERROR,
-                "업체 정보 조회 중 예상치 못한 오류가 발생했습니다.");
-        }
-    }
-
-    /**
-     * 업체 이름으로 업체 ID를 조회합니다. CUSTOMER인 경우 null을 반환하고, 그 외에는 CompanyClient를 통해 업체 ID를 조회합니다.
-     */
-    private UUID getAffiliationId(String affiliationName, AffiliationType affiliationType) {
-        if (affiliationType == AffiliationType.CUSTOMER) {
-            return null;
-        }
-
-        try {
-            CompanyListResponse response = companyClient.getCompaniesByName(affiliationName);
-
-            if (response.companies().isEmpty()) {
-                log.warn("업체 정보를 찾을 수 없음 - affiliationName: {}", affiliationName);
-                throw new BusinessException(UserErrorCode.BAD_REQUEST,
-                    "해당 이름의 업체를 찾을 수 없습니다: " + affiliationName);
-            }
-
-            // 첫 번째 결과를 사용 (동일한 이름의 업체가 여러 개일 경우 첫 번째 선택) -> 원래라면 사용자가 업체를 선택하는 부분이 존재해야 함
-            UUID companyId = response.companies().get(0).companyId();
-            log.debug("업체 ID 조회 성공 - affiliationName: {}, companyId: {}", affiliationName, companyId);
-            return companyId;
-
-        } catch (BusinessException e) {
-            throw e;
-        } catch (ExternalApiException e) {
-            log.error("업체 정보 조회 실패 - affiliationName: {}, errorCode: {}",
-                affiliationName, e.getErrorCode().name());
-            throw e;
-        } catch (Exception e) {
-            log.error("예상치 못한 예외 발생 - affiliationName: {}", affiliationName, e);
-            throw new BusinessException(UserErrorCode.INTERNAL_SERVER_ERROR,
-                "업체 정보 조회 중 예상치 못한 오류가 발생했습니다.");
-        }
     }
 
     private boolean validatePassword(String rawPassword, String encodedPassword) {
         return passwordEncoder.matches(rawPassword, encodedPassword);
     }
 
-    private User findNotDeletedUser(Long userId) {
+    public User findNotDeletedUser(Long userId) {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 

--- a/user/src/main/java/com/klp/user/application/command/UpdateUserGradeCommand.java
+++ b/user/src/main/java/com/klp/user/application/command/UpdateUserGradeCommand.java
@@ -1,0 +1,8 @@
+package com.klp.user.application.command;
+
+public record UpdateUserGradeCommand(
+    Long userId,
+    String gradeName
+) {
+
+}

--- a/user/src/main/java/com/klp/user/domain/entity/User.java
+++ b/user/src/main/java/com/klp/user/domain/entity/User.java
@@ -29,7 +29,7 @@ public class User extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userId;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private UUID affiliationId;
 
     @Column(nullable = false)
@@ -146,6 +146,13 @@ public class User extends BaseEntity {
                 if (affiliationType != AffiliationType.LOGISTICS && affiliationType != AffiliationType.HUB) {
                     throw new BusinessException(
                         UserErrorCode.BAD_REQUEST, "배송 담당자는 LOGISTICS 또는 HUB 소속이어야 합니다."
+                    );
+                }
+                break;
+            case CUSTOMER:
+                if (affiliationType != AffiliationType.CUSTOMER) {
+                    throw new BusinessException(
+                        UserErrorCode.BAD_REQUEST, "고객은 CUSTOMER 소속이어야 합니다."
                     );
                 }
                 break;

--- a/user/src/main/java/com/klp/user/domain/entity/User.java
+++ b/user/src/main/java/com/klp/user/domain/entity/User.java
@@ -29,7 +29,7 @@ public class User extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userId;
 
-    @Column(nullable = true)
+    @Column
     private UUID affiliationId;
 
     @Column(nullable = false)

--- a/user/src/main/java/com/klp/user/domain/entity/UserGrade.java
+++ b/user/src/main/java/com/klp/user/domain/entity/UserGrade.java
@@ -7,6 +7,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -19,7 +20,16 @@ import org.hibernate.annotations.Comment;
 
 @Entity
 @Getter
-@Table(name = "p_user_grades", schema = "user_schema")
+@Table(
+    name = "p_user_grades",
+    schema = "user_schema",
+    indexes = {
+        @Index(
+            name = "idx_user_grade_user_evaluated",
+            columnList = "user_id, evaluated_at DESC"
+        )
+    }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserGrade extends BaseEntity {
 

--- a/user/src/main/java/com/klp/user/domain/entity/UserGrade.java
+++ b/user/src/main/java/com/klp/user/domain/entity/UserGrade.java
@@ -1,0 +1,54 @@
+package com.klp.user.domain.entity;
+
+import com.klp.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Getter
+@Table(name = "p_user_grades", schema = "user_schema")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserGrade extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "user_grade_id")
+    @Comment("회원등급 ID")
+    private UUID userGradeId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    @Comment("유저ID")
+    private User user;
+
+    @Column(name = "grade_name", nullable = false)
+    @Comment("등급명")
+    private String gradeName;
+
+    @Column(name = "evaluated_at")
+    @Comment("등급 변경 시간")
+    private LocalDateTime evaluatedAt;
+
+    private UserGrade(User user, String gradeName) {
+        this.user = user;
+        this.gradeName = gradeName;
+        this.evaluatedAt = LocalDateTime.now();
+    }
+
+    public static UserGrade create(User user, String gradeName) {
+        return new UserGrade(user, gradeName);
+    }
+}

--- a/user/src/main/java/com/klp/user/domain/enums/AffiliationType.java
+++ b/user/src/main/java/com/klp/user/domain/enums/AffiliationType.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum AffiliationType {
     LOGISTICS("물류 회사"),
     COMPANY("업체"),
-    HUB("허브");
+    HUB("허브"),
+    CUSTOMER("고객");
 
     private final String description;
 }

--- a/user/src/main/java/com/klp/user/domain/enums/UserRole.java
+++ b/user/src/main/java/com/klp/user/domain/enums/UserRole.java
@@ -9,7 +9,8 @@ public enum UserRole {
     MASTER("마스터"),
     HUB("허브 관리자"),
     COMPANY("업체 담당자"),
-    DRIVER("배송 담당자");
+    DRIVER("배송 담당자"),
+    CUSTOMER("고객");
 
     private final String description;
 }

--- a/user/src/main/java/com/klp/user/domain/exception/ExternalApiErrorCode.java
+++ b/user/src/main/java/com/klp/user/domain/exception/ExternalApiErrorCode.java
@@ -1,0 +1,30 @@
+package com.klp.user.domain.exception;
+
+import com.klp.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExternalApiErrorCode implements ErrorCode {
+
+    COMPANY_SERVICE_UNAVAILABLE(HttpStatus.BAD_GATEWAY, "업체 서비스 호출 중 오류가 발생했습니다."),
+    COMPANY_SERVICE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "업체 서비스 호출 시 잘못된 요청입니다."),
+    COMPANY_SERVICE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "업체 서비스 인증에 실패했습니다."),
+    COMPANY_SERVICE_FORBIDDEN(HttpStatus.FORBIDDEN, "업체 서비스 접근 권한이 없습니다."),
+    COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "업체 정보를 찾을 수 없습니다."),
+
+    PROMOTION_SERVICE_UNAVAILABLE(HttpStatus.BAD_GATEWAY, "프로모션 서비스 호출 중 오류가 발생했습니다."),
+    PROMOTION_SERVICE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "프로모션 서비스 호출 시 잘못된 요청입니다."),
+    PROMOTION_SERVICE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "프로모션 서비스 인증에 실패했습니다."),
+    PROMOTION_SERVICE_FORBIDDEN(HttpStatus.FORBIDDEN, "프로모션 서비스 접근 권한이 없습니다."),
+    USER_GRADE_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 등급 정보를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    public String getErrorCode() {
+        return this.name();
+    }
+}

--- a/user/src/main/java/com/klp/user/domain/exception/ExternalApiException.java
+++ b/user/src/main/java/com/klp/user/domain/exception/ExternalApiException.java
@@ -1,0 +1,20 @@
+package com.klp.user.domain.exception;
+
+import com.klp.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class ExternalApiException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public ExternalApiException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ExternalApiException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/user/src/main/java/com/klp/user/domain/exception/UserErrorCode.java
+++ b/user/src/main/java/com/klp/user/domain/exception/UserErrorCode.java
@@ -20,7 +20,11 @@ public enum UserErrorCode implements ErrorCode {
     ALREADY_APPROVED(HttpStatus.CONFLICT, "이미 승인된 상태입니다"),
     ALREADY_REJECTED(HttpStatus.CONFLICT, "이미 승인 거절된 상태입니다"),
 
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 유저가 존재하지 않습니다");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 유저가 존재하지 않습니다"),
+
+    INVALID_AFFILIATION(HttpStatus.BAD_REQUEST, "소속 정보가 없습니다."),
+
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/user/src/main/java/com/klp/user/domain/exception/UserErrorCode.java
+++ b/user/src/main/java/com/klp/user/domain/exception/UserErrorCode.java
@@ -22,9 +22,11 @@ public enum UserErrorCode implements ErrorCode {
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 유저가 존재하지 않습니다"),
 
-    INVALID_AFFILIATION(HttpStatus.BAD_REQUEST, "소속 정보가 없습니다."),
+        INVALID_AFFILIATION(HttpStatus.BAD_REQUEST, "소속 정보가 없습니다."),
 
-    ;
+        USER_GRADE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원의 등급 정보를 찾을 수 없습니다"),
+
+        ;
 
     private final HttpStatus status;
     private final String message;

--- a/user/src/main/java/com/klp/user/domain/repository/UserGradeRepository.java
+++ b/user/src/main/java/com/klp/user/domain/repository/UserGradeRepository.java
@@ -1,16 +1,11 @@
 package com.klp.user.domain.repository;
 
 import com.klp.user.domain.entity.UserGrade;
-import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
-public interface UserGradeRepository extends JpaRepository<UserGrade, UUID> {
+public interface UserGradeRepository {
 
-    Optional<UserGrade> findFirstByUser_UserIdOrderByEvaluatedAtDesc(Long userId);
+    Optional<UserGrade> findFirstByUser(Long userId);
 
-    List<UserGrade> findAllByUser_UserId(Long userId);
+    UserGrade save(UserGrade userGrade);
 }

--- a/user/src/main/java/com/klp/user/domain/repository/UserGradeRepository.java
+++ b/user/src/main/java/com/klp/user/domain/repository/UserGradeRepository.java
@@ -1,0 +1,16 @@
+package com.klp.user.domain.repository;
+
+import com.klp.user.domain.entity.UserGrade;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserGradeRepository extends JpaRepository<UserGrade, UUID> {
+
+    Optional<UserGrade> findFirstByUser_UserIdOrderByEvaluatedAtDesc(Long userId);
+
+    List<UserGrade> findAllByUser_UserId(Long userId);
+}

--- a/user/src/main/java/com/klp/user/global/config/CompanyFeignClientConfig.java
+++ b/user/src/main/java/com/klp/user/global/config/CompanyFeignClientConfig.java
@@ -1,0 +1,15 @@
+package com.klp.user.global.config;
+
+import com.klp.global.exception.CompanyFeignErrorDecoder;
+import feign.codec.ErrorDecoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CompanyFeignClientConfig {
+
+    @Bean
+    public ErrorDecoder companyFeignErrorDecoder() {
+        return new CompanyFeignErrorDecoder();
+    }
+}

--- a/user/src/main/java/com/klp/user/global/config/PromotionFeignClientConfig.java
+++ b/user/src/main/java/com/klp/user/global/config/PromotionFeignClientConfig.java
@@ -1,0 +1,15 @@
+package com.klp.user.global.config;
+
+import com.klp.global.exception.PromotionFeignErrorDecoder;
+import feign.codec.ErrorDecoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PromotionFeignClientConfig {
+
+    @Bean
+    public ErrorDecoder promotionFeignErrorDecoder() {
+        return new PromotionFeignErrorDecoder();
+    }
+}

--- a/user/src/main/java/com/klp/user/infrastructure/client/CompanyClient.java
+++ b/user/src/main/java/com/klp/user/infrastructure/client/CompanyClient.java
@@ -1,0 +1,26 @@
+package com.klp.user.infrastructure.client;
+
+import com.klp.user.global.config.CompanyFeignClientConfig;
+import com.klp.user.infrastructure.client.dto.response.CompanyListResponse;
+import com.klp.user.infrastructure.client.dto.response.CompanyResponse;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "hub-service", configuration = CompanyFeignClientConfig.class)
+public interface CompanyClient {
+
+    /**
+     * 업체 ID로 업체 정보를 조회합니다.
+     */
+    @GetMapping("/v1/companies/{companyId}")
+    CompanyResponse getCompanyById(@PathVariable("companyId") UUID companyId);
+
+    /**
+     * 업체 이름으로 업체 목록을 조회합니다.
+     */
+    @GetMapping("/v1/companies")
+    CompanyListResponse getCompaniesByName(@RequestParam("name") String name);
+}

--- a/user/src/main/java/com/klp/user/infrastructure/client/PromotionClient.java
+++ b/user/src/main/java/com/klp/user/infrastructure/client/PromotionClient.java
@@ -1,0 +1,18 @@
+package com.klp.user.infrastructure.client;
+
+import com.klp.user.global.config.PromotionFeignClientConfig;
+import com.klp.user.infrastructure.client.dto.request.CreateUserGradeRequest;
+import com.klp.user.infrastructure.client.dto.response.UserGradeResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "promotion-service", configuration = PromotionFeignClientConfig.class)
+public interface PromotionClient {
+
+    /**
+     * 회원 등급을 생성합니다.
+     */
+    @PostMapping("/v1/internal/promotions/user-grades")
+    UserGradeResponse createUserGrade(@RequestBody CreateUserGradeRequest request);
+}

--- a/user/src/main/java/com/klp/user/infrastructure/client/PromotionClient.java
+++ b/user/src/main/java/com/klp/user/infrastructure/client/PromotionClient.java
@@ -2,13 +2,21 @@ package com.klp.user.infrastructure.client;
 
 import com.klp.user.global.config.PromotionFeignClientConfig;
 import com.klp.user.infrastructure.client.dto.request.CreateUserGradeRequest;
+import com.klp.user.infrastructure.client.dto.response.DefaultGradeResponse;
 import com.klp.user.infrastructure.client.dto.response.UserGradeResponse;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(name = "promotion-service", configuration = PromotionFeignClientConfig.class)
 public interface PromotionClient {
+
+    /**
+     * 기본 등급명을 조회합니다. (NONE 등급 - "등급 없음")
+     */
+    @GetMapping("/v1/internal/promotions/grades/default")
+    DefaultGradeResponse getDefaultGrade();
 
     /**
      * 회원 등급을 생성합니다.

--- a/user/src/main/java/com/klp/user/infrastructure/client/dto/request/CreateUserGradeRequest.java
+++ b/user/src/main/java/com/klp/user/infrastructure/client/dto/request/CreateUserGradeRequest.java
@@ -1,0 +1,7 @@
+package com.klp.user.infrastructure.client.dto.request;
+
+public record CreateUserGradeRequest(
+    Long userId
+) {
+
+}

--- a/user/src/main/java/com/klp/user/infrastructure/client/dto/response/CompanyListResponse.java
+++ b/user/src/main/java/com/klp/user/infrastructure/client/dto/response/CompanyListResponse.java
@@ -1,0 +1,16 @@
+package com.klp.user.infrastructure.client.dto.response;
+
+import java.util.List;
+import java.util.UUID;
+
+public record CompanyListResponse(
+    List<CompanySummaryResponse> companies
+) {
+
+    public record CompanySummaryResponse(
+        UUID companyId,
+        String companyName
+    ) {
+
+    }
+}

--- a/user/src/main/java/com/klp/user/infrastructure/client/dto/response/CompanyResponse.java
+++ b/user/src/main/java/com/klp/user/infrastructure/client/dto/response/CompanyResponse.java
@@ -1,0 +1,13 @@
+package com.klp.user.infrastructure.client.dto.response;
+
+import java.util.UUID;
+
+public record CompanyResponse(
+    UUID companyId,
+    UUID hubId,
+    String type,
+    String name,
+    String address
+) {
+
+}

--- a/user/src/main/java/com/klp/user/infrastructure/client/dto/response/DefaultGradeResponse.java
+++ b/user/src/main/java/com/klp/user/infrastructure/client/dto/response/DefaultGradeResponse.java
@@ -1,0 +1,6 @@
+package com.klp.user.infrastructure.client.dto.response;
+
+public record DefaultGradeResponse(
+    String gradeName
+) {
+}

--- a/user/src/main/java/com/klp/user/infrastructure/client/dto/response/UserGradeResponse.java
+++ b/user/src/main/java/com/klp/user/infrastructure/client/dto/response/UserGradeResponse.java
@@ -1,0 +1,15 @@
+package com.klp.user.infrastructure.client.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record UserGradeResponse(
+    UUID userGradeId,
+    Long userId,
+    String gradeType,
+    String gradeDisplayName,
+    Integer discountRate,
+    LocalDateTime evaluatedAt
+) {
+
+}

--- a/user/src/main/java/com/klp/user/infrastructure/repository/UserGradeJpaRepository.java
+++ b/user/src/main/java/com/klp/user/infrastructure/repository/UserGradeJpaRepository.java
@@ -1,0 +1,11 @@
+package com.klp.user.infrastructure.repository;
+
+import com.klp.user.domain.entity.UserGrade;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserGradeJpaRepository extends JpaRepository<UserGrade, UUID> {
+
+    Optional<UserGrade> findFirstByUser_UserIdOrderByEvaluatedAtDesc(Long userId);
+}

--- a/user/src/main/java/com/klp/user/infrastructure/repository/UserGradeRepositoryImpl.java
+++ b/user/src/main/java/com/klp/user/infrastructure/repository/UserGradeRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.klp.user.infrastructure.repository;
+
+import com.klp.user.domain.entity.UserGrade;
+import com.klp.user.domain.repository.UserGradeRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserGradeRepositoryImpl implements UserGradeRepository {
+
+    private final UserGradeJpaRepository userGradeJpaRepository;
+
+    @Override
+    public Optional<UserGrade> findFirstByUser(Long userId) {
+        return userGradeJpaRepository.findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId);
+    }
+
+    @Override
+    public UserGrade save(UserGrade userGrade) {
+        return userGradeJpaRepository.save(userGrade);
+    }
+}

--- a/user/src/main/java/com/klp/user/presentation/UserController.java
+++ b/user/src/main/java/com/klp/user/presentation/UserController.java
@@ -2,6 +2,7 @@ package com.klp.user.presentation;
 
 import com.klp.common.model.PageResponse;
 import com.klp.global.security.model.UserDetailsImpl;
+import com.klp.user.application.UserFacade;
 import com.klp.user.application.UserService;
 import com.klp.user.presentation.dto.request.UserCreateRequest;
 import com.klp.user.presentation.dto.request.UserUpdateRequest;
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserService userService;
+    private final UserFacade userFacade;
 
     @GetMapping("/check")
     public ResponseEntity<UsernameCheckResponse> checkUsername(@RequestParam String username) {
@@ -41,7 +43,7 @@ public class UserController {
 
     @PostMapping("/pending")
     public ResponseEntity<Void> createPendingUser(@RequestBody UserCreateRequest request) {
-        Long userId = userService.createPendingUser(request);
+        Long userId = userFacade.createPendingUser(request);
 
         URI location = URI.create("/v1/users/" + userId);
 
@@ -56,7 +58,7 @@ public class UserController {
     @GetMapping("/me")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<UserDetailResponse> getMyDetails(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-        UserDetailResponse response = userService.getUserDetails(userDetails.getUserId());
+        UserDetailResponse response = userFacade.getUserDetails(userDetails.getUserId());
         return ResponseEntity.ok().body(response);
     }
 
@@ -66,7 +68,7 @@ public class UserController {
         @RequestParam(required = false) String keyword,
         Pageable pageable
     ) {
-        PageResponse<UserInfoResponse> response = userService.getUserList(keyword, pageable);
+        PageResponse<UserInfoResponse> response = userFacade.getUserList(keyword, pageable);
 
         return ResponseEntity.ok().body(response);
     }
@@ -76,7 +78,7 @@ public class UserController {
     public ResponseEntity<UserDetailResponse> getUserDetails(
         @PathVariable Long userId
     ) {
-        UserDetailResponse response = userService.getUserDetails(userId);
+        UserDetailResponse response = userFacade.getUserDetails(userId);
         return ResponseEntity.ok().body(response);
     }
 
@@ -86,7 +88,7 @@ public class UserController {
         @PathVariable Long userId,
         @Valid @RequestBody UserUpdateRequest request
     ) {
-        userService.updateUserInfo(userId, request);
+        userFacade.updateUserInfo(userId, request);
 
         return ResponseEntity.ok().build();
     }
@@ -96,7 +98,7 @@ public class UserController {
     public ResponseEntity<Void> approvePendingUser(
         @PathVariable Long userId
     ) {
-        userService.approvePendingUser(userId);
+        userFacade.approvePendingUser(userId);
 
         return ResponseEntity.ok().build();
     }
@@ -106,7 +108,7 @@ public class UserController {
     public ResponseEntity<Void> rejectPendingUser(
         @PathVariable Long userId
     ) {
-        userService.rejectPendingUser(userId);
+        userFacade.rejectPendingUser(userId);
 
         return ResponseEntity.ok().build();
     }

--- a/user/src/main/java/com/klp/user/presentation/UserController.java
+++ b/user/src/main/java/com/klp/user/presentation/UserController.java
@@ -56,7 +56,7 @@ public class UserController {
     @GetMapping("/me")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<UserDetailResponse> getMyDetails(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-        UserDetailResponse response = userService.getMyDetails(userDetails.getUserId());
+        UserDetailResponse response = userService.getUserDetails(userDetails.getUserId());
         return ResponseEntity.ok().body(response);
     }
 

--- a/user/src/main/java/com/klp/user/presentation/UserGradeController.java
+++ b/user/src/main/java/com/klp/user/presentation/UserGradeController.java
@@ -1,0 +1,42 @@
+package com.klp.user.presentation;
+
+import com.klp.user.application.UserFacade;
+import com.klp.user.presentation.dto.request.UserGradeUpdateRequest;
+import com.klp.user.presentation.dto.response.UserGradeResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/users/grades")
+@RequiredArgsConstructor
+public class UserGradeController {
+
+    private final UserFacade userFacade;
+
+    @GetMapping("/{userId}")
+    @PreAuthorize("hasRole('MASTER') or (hasRole('CUSTOMER') and #userId == authentication.principal.userId)")
+    public ResponseEntity<UserGradeResponse> getUserGrade(
+        @PathVariable Long userId
+    ) {
+        UserGradeResponse response = userFacade.getCurrentUserGrade(userId);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @PatchMapping("/{userId}")
+    @PreAuthorize("hasRole('MASTER')")
+    public ResponseEntity<UserGradeResponse> updateUserGrade(
+        @PathVariable Long userId,
+        @Valid @RequestBody UserGradeUpdateRequest request
+    ) {
+        UserGradeResponse response = userFacade.updateUserGrade(userId, request.gradeName());
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/user/src/main/java/com/klp/user/presentation/UserInternalController.java
+++ b/user/src/main/java/com/klp/user/presentation/UserInternalController.java
@@ -1,6 +1,6 @@
 package com.klp.user.presentation;
 
-import com.klp.user.application.UserService;
+import com.klp.user.application.UserFacade;
 import com.klp.user.presentation.dto.response.DriverDetailResponse;
 import com.klp.user.presentation.dto.response.HubDriverListResponse;
 import com.klp.user.presentation.dto.response.LogisticsDriverListResponse;
@@ -19,32 +19,32 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class UserInternalController {
 
-    private final UserService userService;
+    private final UserFacade userFacade;
 
     @GetMapping("/{userId}")
     public ResponseEntity<UserDetailResponse> getUserDetails(
         @PathVariable Long userId
     ) {
-        UserDetailResponse response = userService.getUserDetails(userId);
+        UserDetailResponse response = userFacade.getUserDetails(userId);
         return ResponseEntity.ok().body(response);
     }
 
 
     @GetMapping("/driver/logistics")
     public ResponseEntity<LogisticsDriverListResponse> getDriversByLogistics() {
-        LogisticsDriverListResponse response = userService.getDriversByLogistics();
+        LogisticsDriverListResponse response = userFacade.getDriversByLogistics();
         return ResponseEntity.ok().body(response);
     }
 
     @GetMapping("/driver/{hubId}")
     public ResponseEntity<HubDriverListResponse> getDriversByHubId(@PathVariable UUID hubId) {
-        HubDriverListResponse response = userService.getDriversByHubId(hubId);
+        HubDriverListResponse response = userFacade.getDriversByHubId(hubId);
         return ResponseEntity.ok().body(response);
     }
 
     @GetMapping("/driver")
     public ResponseEntity<DriverDetailResponse> getDriverById(@RequestParam("id") Long driverId) {
-        DriverDetailResponse response = userService.getDriverById(driverId);
+        DriverDetailResponse response = userFacade.getDriverById(driverId);
         return ResponseEntity.ok().body(response);
     }
 }

--- a/user/src/main/java/com/klp/user/presentation/dto/request/UserGradeUpdateRequest.java
+++ b/user/src/main/java/com/klp/user/presentation/dto/request/UserGradeUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.klp.user.presentation.dto.request;
+
+import com.klp.user.application.command.UpdateUserGradeCommand;
+import jakarta.validation.constraints.NotBlank;
+
+public record UserGradeUpdateRequest(
+    @NotBlank(message = "등급 이름은 필수입니다.")
+    String gradeName
+) {
+
+    public UpdateUserGradeCommand toCommand(Long userId) {
+        return new UpdateUserGradeCommand(userId, gradeName);
+    }
+}

--- a/user/src/main/java/com/klp/user/presentation/dto/response/UserDetailResponse.java
+++ b/user/src/main/java/com/klp/user/presentation/dto/response/UserDetailResponse.java
@@ -11,10 +11,11 @@ public record UserDetailResponse(
     String phone,
     String email,
     String role,
+    String gradeName,
     boolean activate
 ) {
 
-    public static UserDetailResponse of(String affiliationName, User user) {
+    public static UserDetailResponse of(User user, String affiliationName, String gradeName) {
         return new UserDetailResponse(
             user.getUserId(),
             affiliationName,
@@ -23,6 +24,7 @@ public record UserDetailResponse(
             user.getPhone(),
             user.getEmail(),
             user.getRole().name(),
+            gradeName,
             user.getStatus() == UserStatus.APPROVED
         );
     }

--- a/user/src/main/java/com/klp/user/presentation/dto/response/UserGradeResponse.java
+++ b/user/src/main/java/com/klp/user/presentation/dto/response/UserGradeResponse.java
@@ -1,0 +1,19 @@
+package com.klp.user.presentation.dto.response;
+
+import com.klp.user.domain.entity.UserGrade;
+import java.time.LocalDateTime;
+
+public record UserGradeResponse(
+    Long userId,
+    String gradeName,
+    LocalDateTime evaluatedAt
+) {
+
+    public static UserGradeResponse from(UserGrade userGrade) {
+        return new UserGradeResponse(
+            userGrade.getUser().getUserId(),
+            userGrade.getGradeName(),
+            userGrade.getEvaluatedAt()
+        );
+    }
+}

--- a/user/src/main/java/com/klp/user/presentation/dto/response/UserInfoResponse.java
+++ b/user/src/main/java/com/klp/user/presentation/dto/response/UserInfoResponse.java
@@ -10,10 +10,11 @@ public record UserInfoResponse(
     String phone,
     String email,
     String role,
-    String status
+    String status,
+    String gradeName
 ) {
 
-    public static UserInfoResponse of(User user, String affiliationName) {
+    public static UserInfoResponse of(User user, String affiliationName, String gradeName) {
         return new UserInfoResponse(
             user.getUserId(),
             affiliationName,
@@ -22,7 +23,8 @@ public record UserInfoResponse(
             user.getPhone(),
             user.getEmail(),
             user.getRole().name(),
-            user.getStatus().name()
+            user.getStatus().name(),
+            gradeName
         );
     }
 }

--- a/user/src/test/java/com/klp/user/application/UserFacadeTest.java
+++ b/user/src/test/java/com/klp/user/application/UserFacadeTest.java
@@ -1,0 +1,394 @@
+package com.klp.user.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import com.klp.common.model.PageResponse;
+import com.klp.user.domain.entity.User;
+import com.klp.user.domain.entity.UserGrade;
+import com.klp.user.domain.enums.AffiliationType;
+import com.klp.user.domain.enums.UserRole;
+import com.klp.user.infrastructure.client.CompanyClient;
+import com.klp.user.infrastructure.client.PromotionClient;
+import com.klp.user.infrastructure.client.dto.response.CompanyListResponse;
+import com.klp.user.infrastructure.client.dto.response.CompanyResponse;
+import com.klp.user.infrastructure.client.dto.response.DefaultGradeResponse;
+import com.klp.user.presentation.dto.request.UserCreateRequest;
+import com.klp.user.presentation.dto.request.UserUpdateRequest;
+import com.klp.user.presentation.dto.response.UserDetailResponse;
+import com.klp.user.presentation.dto.response.UserGradeResponse;
+import com.klp.user.presentation.dto.response.UserInfoResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserFacade 단위 테스트")
+class UserFacadeTest {
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private UserGradeService userGradeService;
+
+    @Mock
+    private CompanyClient companyClient;
+
+    @Mock
+    private PromotionClient promotionClient;
+
+    @InjectMocks
+    private UserFacade userFacade;
+
+    private User testUser;
+    private User customerUser;
+    private final Long userId = 1L;
+    private final Long customerId = 2L;
+    private final UUID affiliationId = UUID.randomUUID();
+    private final String username = "testuser";
+    private final String customerName = "customer";
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.create(
+            affiliationId,
+            AffiliationType.HUB,
+            username,
+            "Password1!",
+            "U12345678",
+            "010-1234-5678",
+            "test@example.com",
+            UserRole.HUB
+        );
+        ReflectionTestUtils.setField(testUser, "userId", userId);
+
+        customerUser = User.create(
+            UUID.randomUUID(),
+            AffiliationType.CUSTOMER,
+            customerName,
+            "Password1!",
+            "U87654321",
+            "010-8765-4321",
+            "customer@example.com",
+            UserRole.CUSTOMER
+        );
+        ReflectionTestUtils.setField(customerUser, "userId", customerId);
+    }
+
+    @Nested
+    @DisplayName("createPendingUser 테스트")
+    class CreatePendingUserTest {
+
+        @Test
+        @DisplayName("HUB 권한 회원가입 - Company 서비스 호출하여 소속 ID 조회")
+        void createPendingUser_WithHubRole_CallsCompanyClient() {
+            // given
+            String companyName = "회사명";
+            UserCreateRequest request = new UserCreateRequest(
+                username,
+                "Password1!",
+                "U12345678",
+                "010-1234-5678",
+                "test@example.com",
+                UserRole.HUB,
+                companyName,
+                AffiliationType.HUB
+            );
+
+            CompanyListResponse.CompanySummaryResponse companySummaryResponse =
+                new CompanyListResponse.CompanySummaryResponse(affiliationId, companyName);
+            CompanyListResponse companyListResponse = new CompanyListResponse(List.of(companySummaryResponse));
+
+            given(companyClient.getCompaniesByName(companyName)).willReturn(companyListResponse);
+            given(userService.createPendingUser(eq(request), eq(affiliationId))).willReturn(testUser);
+
+            // when
+            Long result = userFacade.createPendingUser(request);
+
+            // then
+            assertThat(result).isEqualTo(userId);
+            then(companyClient).should(times(1)).getCompaniesByName(companyName);
+            then(userService).should(times(1)).createPendingUser(eq(request), eq(affiliationId));
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 권한 회원가입 - Company 서비스 호출하지 않음")
+        void createPendingUser_WithCustomerRole_DoesNotCallCompanyClient() {
+            // given
+            UserCreateRequest request = new UserCreateRequest(
+                customerName,
+                "Password1!",
+                "U87654321",
+                "010-8765-4321",
+                "customer@example.com",
+                UserRole.CUSTOMER,
+                "고객",
+                AffiliationType.CUSTOMER
+            );
+
+            given(userService.createPendingUser(eq(request), eq(null))).willReturn(customerUser);
+
+            // when
+            Long result = userFacade.createPendingUser(request);
+
+            // then
+            assertThat(result).isEqualTo(customerId);
+            then(companyClient).should(never()).getCompaniesByName(anyString());
+            then(userService).should(times(1)).createPendingUser(eq(request), eq(null));
+        }
+    }
+
+    @Nested
+    @DisplayName("approvePendingUser 테스트")
+    class ApprovePendingUserTest {
+
+        @Test
+        @DisplayName("CUSTOMER 권한 승인 - Promotion 서비스에서 기본 등급 조회 후 UserGrade 생성")
+        void approvePendingUser_WithCustomerRole_CreatesUserGrade() {
+            // given
+            String defaultGradeName = "등급 없음";
+            DefaultGradeResponse defaultGradeResponse = new DefaultGradeResponse(defaultGradeName);
+
+            UserGrade createdGrade = UserGrade.create(customerUser, defaultGradeName);
+            ReflectionTestUtils.setField(createdGrade, "userGradeId", UUID.randomUUID());
+            ReflectionTestUtils.setField(createdGrade, "evaluatedAt", LocalDateTime.now());
+
+            given(userService.findNotDeletedUser(customerId)).willReturn(customerUser);
+            given(promotionClient.getDefaultGrade()).willReturn(defaultGradeResponse);
+            given(userGradeService.createUserGrade(customerUser, defaultGradeName)).willReturn(createdGrade);
+
+            // when
+            userFacade.approvePendingUser(customerId);
+
+            // then
+            then(userService).should(times(1)).findNotDeletedUser(customerId);
+            then(userService).should(times(1)).approvePendingUser(customerUser);
+            then(promotionClient).should(times(1)).getDefaultGrade();
+            then(userGradeService).should(times(1)).createUserGrade(customerUser, defaultGradeName);
+        }
+
+        @Test
+        @DisplayName("HUB 권한 승인 - UserGrade 생성하지 않음")
+        void approvePendingUser_WithHubRole_DoesNotCreateUserGrade() {
+            // given
+            given(userService.findNotDeletedUser(userId)).willReturn(testUser);
+
+            // when
+            userFacade.approvePendingUser(userId);
+
+            // then
+            then(userService).should(times(1)).findNotDeletedUser(userId);
+            then(userService).should(times(1)).approvePendingUser(testUser);
+            then(promotionClient).should(never()).getDefaultGrade();
+            then(userGradeService).should(never()).createUserGrade(any(), anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("rejectPendingUser 테스트")
+    class RejectPendingUserTest {
+
+        @Test
+        @DisplayName("회원 거부 처리")
+        void rejectPendingUser_RejectsUser() {
+            // given
+            given(userService.findNotDeletedUser(userId)).willReturn(testUser);
+
+            // when
+            userFacade.rejectPendingUser(userId);
+
+            // then
+            then(userService).should(times(1)).findNotDeletedUser(userId);
+            then(userService).should(times(1)).rejectPendingUser(testUser);
+        }
+    }
+
+    @Nested
+    @DisplayName("getUserDetails 테스트")
+    class GetUserDetailsTest {
+
+        @Test
+        @DisplayName("CUSTOMER 유저 상세 조회 - 등급 정보 포함")
+        void getUserDetails_WithCustomerRole_IncludesGrade() {
+            // given
+            String gradeName = "브론즈";
+
+            given(userService.findNotDeletedUser(customerId)).willReturn(customerUser);
+            given(userGradeService.getCurrentGradeName(customerId)).willReturn(gradeName);
+
+            // when
+            UserDetailResponse response = userFacade.getUserDetails(customerId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.userId()).isEqualTo(customerId);
+            assertThat(response.username()).isEqualTo(customerName);
+            assertThat(response.gradeName()).isEqualTo(gradeName);
+            assertThat(response.affiliationName()).isEqualTo("고객");
+            then(userGradeService).should(times(1)).getCurrentGradeName(customerId);
+        }
+
+        @Test
+        @DisplayName("HUB 유저 상세 조회 - Company 서비스 호출하여 소속명 조회")
+        void getUserDetails_WithHubRole_CallsCompanyClient() {
+            // given
+            String companyName = "회사명";
+            CompanyResponse companyResponse = new CompanyResponse(
+                affiliationId, UUID.randomUUID(), "type", companyName, "주소"
+            );
+
+            given(userService.findNotDeletedUser(userId)).willReturn(testUser);
+            given(companyClient.getCompanyById(affiliationId)).willReturn(companyResponse);
+
+            // when
+            UserDetailResponse response = userFacade.getUserDetails(userId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.userId()).isEqualTo(userId);
+            assertThat(response.affiliationName()).isEqualTo(companyName);
+            assertThat(response.gradeName()).isNull();
+            then(companyClient).should(times(1)).getCompanyById(affiliationId);
+            then(userGradeService).should(never()).getCurrentGradeName(anyLong());
+        }
+    }
+
+    @Nested
+    @DisplayName("getUserList 테스트")
+    class GetUserListTest {
+
+        @Test
+        @DisplayName("유저 목록 조회 - Company 및 등급 정보 포함")
+        void getUserList_IncludesCompanyAndGradeInfo() {
+            // given
+            Pageable pageable = PageRequest.of(0, 10);
+            List<User> userList = List.of(testUser, customerUser);
+            Page<User> userPage = new PageImpl<>(userList, pageable, 2);
+
+            String companyName = "회사명";
+            String gradeName = "브론즈";
+            CompanyResponse companyResponse = new CompanyResponse(
+                affiliationId, UUID.randomUUID(), "type", companyName, "주소"
+            );
+
+            given(userService.getUserList(null, pageable)).willReturn(userPage);
+            given(companyClient.getCompanyById(affiliationId)).willReturn(companyResponse);
+            given(userGradeService.getCurrentGradeName(customerId)).willReturn(gradeName);
+
+            // when
+            PageResponse<UserInfoResponse> response = userFacade.getUserList(null, pageable);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getData()).hasSize(2);
+            assertThat(response.getData().get(0).affiliationName()).isEqualTo(companyName);
+            assertThat(response.getData().get(1).gradeName()).isEqualTo(gradeName);
+            then(companyClient).should(times(1)).getCompanyById(affiliationId);
+            then(userGradeService).should(times(1)).getCurrentGradeName(customerId);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateUserInfo 테스트")
+    class UpdateUserInfoTest {
+
+        @Test
+        @DisplayName("유저 정보 수정")
+        void updateUserInfo_UpdatesSuccessfully() {
+            // given
+            UserUpdateRequest request = new UserUpdateRequest(
+                "newname",
+                "newPassword1!",
+                "newSlackId",
+                "010-1111-1111",
+                "new@example.com",
+                UserRole.DRIVER
+            );
+
+            given(userService.findNotDeletedUser(userId)).willReturn(testUser);
+
+            // when
+            userFacade.updateUserInfo(userId, request);
+
+            // then
+            then(userService).should(times(1)).findNotDeletedUser(userId);
+            then(userService).should(times(1)).updateUserInfo(testUser, request);
+        }
+    }
+
+    @Nested
+    @DisplayName("getCurrentUserGrade 테스트")
+    class GetCurrentUserGradeTest {
+
+        @Test
+        @DisplayName("현재 유저 등급 조회")
+        void getCurrentUserGrade_ReturnsUserGrade() {
+            // given
+            String gradeName = "브론즈";
+            UserGrade userGrade = UserGrade.create(customerUser, gradeName);
+            ReflectionTestUtils.setField(userGrade, "userGradeId", UUID.randomUUID());
+            ReflectionTestUtils.setField(userGrade, "evaluatedAt", LocalDateTime.now());
+
+            given(userService.findNotDeletedUser(customerId)).willReturn(customerUser);
+            given(userGradeService.getCurrentUserGrade(customerId)).willReturn(userGrade);
+
+            // when
+            UserGradeResponse response = userFacade.getCurrentUserGrade(customerId);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.userId()).isEqualTo(customerId);
+            assertThat(response.gradeName()).isEqualTo(gradeName);
+            then(userService).should(times(1)).findNotDeletedUser(customerId);
+            then(userGradeService).should(times(1)).getCurrentUserGrade(customerId);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateUserGrade 테스트")
+    class UpdateUserGradeTest {
+
+        @Test
+        @DisplayName("유저 등급 변경")
+        void updateUserGrade_UpdatesSuccessfully() {
+            // given
+            String newGradeName = "골드";
+            UserGrade newGrade = UserGrade.create(customerUser, newGradeName);
+            ReflectionTestUtils.setField(newGrade, "userGradeId", UUID.randomUUID());
+            ReflectionTestUtils.setField(newGrade, "evaluatedAt", LocalDateTime.now());
+
+            given(userService.findNotDeletedUser(customerId)).willReturn(customerUser);
+            given(userGradeService.updateUserGrade(customerId, newGradeName)).willReturn(newGrade);
+
+            // when
+            UserGradeResponse response = userFacade.updateUserGrade(customerId, newGradeName);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.gradeName()).isEqualTo(newGradeName);
+            then(userService).should(times(1)).findNotDeletedUser(customerId);
+            then(userGradeService).should(times(1)).updateUserGrade(customerId, newGradeName);
+        }
+    }
+}

--- a/user/src/test/java/com/klp/user/application/UserGradeServiceTest.java
+++ b/user/src/test/java/com/klp/user/application/UserGradeServiceTest.java
@@ -1,0 +1,318 @@
+package com.klp.user.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.klp.common.exception.BusinessException;
+import com.klp.user.domain.entity.User;
+import com.klp.user.domain.entity.UserGrade;
+import com.klp.user.domain.enums.AffiliationType;
+import com.klp.user.domain.enums.UserRole;
+import com.klp.user.domain.exception.UserErrorCode;
+import com.klp.user.domain.repository.UserGradeRepository;
+import com.klp.user.domain.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserGradeService 단위 테스트")
+class UserGradeServiceTest {
+
+    @Mock
+    private UserGradeRepository userGradeRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserGradeService userGradeService;
+
+    private User testUser;
+    private final Long userId = 1L;
+    private final String gradeName = "BRONZE";
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.create(
+            UUID.randomUUID(),
+            AffiliationType.CUSTOMER,
+            "testuser",
+            "Password1!",
+            "U12345678",
+            "010-1234-5678",
+            "test@example.com",
+            UserRole.CUSTOMER
+        );
+        ReflectionTestUtils.setField(testUser, "userId", userId);
+    }
+
+    @Nested
+    @DisplayName("getCurrentGradeName 테스트")
+    class GetCurrentGradeNameTest {
+
+        @Test
+        @DisplayName("등급이 존재하는 경우 등급명 반환")
+        void getCurrentGradeName_WhenGradeExists_ReturnsGradeName() {
+            // given
+            UserGrade userGrade = UserGrade.create(testUser, gradeName);
+            given(userGradeRepository.findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId))
+                .willReturn(Optional.of(userGrade));
+
+            // when
+            String result = userGradeService.getCurrentGradeName(userId);
+
+            // then
+            assertThat(result).isEqualTo(gradeName);
+            then(userGradeRepository).should(times(1))
+                .findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId);
+        }
+
+        @Test
+        @DisplayName("등급이 존재하지 않는 경우 null 반환")
+        void getCurrentGradeName_WhenGradeNotExists_ReturnsNull() {
+            // given
+            given(userGradeRepository.findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId))
+                .willReturn(Optional.empty());
+
+            // when
+            String result = userGradeService.getCurrentGradeName(userId);
+
+            // then
+            assertThat(result).isNull();
+            then(userGradeRepository).should(times(1))
+                .findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId);
+        }
+
+        @Test
+        @DisplayName("여러 등급이 존재하는 경우 가장 최근 등급명 반환")
+        void getCurrentGradeName_WhenMultipleGradesExist_ReturnsLatestGradeName() {
+            // given
+            String latestGradeName = "GOLD";
+            UserGrade latestGrade = UserGrade.create(testUser, latestGradeName);
+            ReflectionTestUtils.setField(latestGrade, "evaluatedAt", LocalDateTime.now());
+
+            given(userGradeRepository.findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId))
+                .willReturn(Optional.of(latestGrade));
+
+            // when
+            String result = userGradeService.getCurrentGradeName(userId);
+
+            // then
+            assertThat(result).isEqualTo(latestGradeName);
+            then(userGradeRepository).should(times(1))
+                .findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId);
+        }
+    }
+
+    @Nested
+    @DisplayName("getCurrentUserGrade 테스트")
+    class GetCurrentUserGradeTest {
+
+        @Test
+        @DisplayName("등급이 존재하는 경우 등급 엔티티 반환")
+        void getCurrentUserGrade_WhenGradeExists_ReturnsUserGrade() {
+            // given
+            UserGrade userGrade = UserGrade.create(testUser, gradeName);
+            UUID gradeId = UUID.randomUUID();
+            ReflectionTestUtils.setField(userGrade, "userGradeId", gradeId);
+
+            given(userGradeRepository.findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId))
+                .willReturn(Optional.of(userGrade));
+
+            // when
+            UserGrade result = userGradeService.getCurrentUserGrade(userId);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getUserGradeId()).isEqualTo(gradeId);
+            assertThat(result.getGradeName()).isEqualTo(gradeName);
+            then(userGradeRepository).should(times(1))
+                .findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId);
+        }
+
+        @Test
+        @DisplayName("등급이 존재하지 않는 경우 예외 발생")
+        void getCurrentUserGrade_WhenGradeNotExists_ThrowsException() {
+            // given
+            given(userGradeRepository.findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId))
+                .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> userGradeService.getCurrentUserGrade(userId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_GRADE_NOT_FOUND);
+
+            then(userGradeRepository).should(times(1))
+                .findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId);
+        }
+
+        @Test
+        @DisplayName("여러 등급이 존재하는 경우 가장 최근 등급 반환")
+        void getCurrentUserGrade_WhenMultipleGradesExist_ReturnsLatestGrade() {
+            // given
+            String latestGradeName = "GOLD";
+            UserGrade latestGrade = UserGrade.create(testUser, latestGradeName);
+            UUID latestGradeId = UUID.randomUUID();
+            ReflectionTestUtils.setField(latestGrade, "userGradeId", latestGradeId);
+            ReflectionTestUtils.setField(latestGrade, "evaluatedAt", LocalDateTime.now());
+
+            given(userGradeRepository.findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId))
+                .willReturn(Optional.of(latestGrade));
+
+            // when
+            UserGrade result = userGradeService.getCurrentUserGrade(userId);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getUserGradeId()).isEqualTo(latestGradeId);
+            assertThat(result.getGradeName()).isEqualTo(latestGradeName);
+            then(userGradeRepository).should(times(1))
+                .findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId);
+        }
+    }
+
+    @Nested
+    @DisplayName("createUserGrade 테스트")
+    class CreateUserGradeTest {
+
+        @Test
+        @DisplayName("유저 등급을 성공적으로 생성")
+        void createUserGrade_CreatesSuccessfully() {
+            // given
+            UserGrade userGrade = UserGrade.create(testUser, gradeName);
+            UUID gradeId = UUID.randomUUID();
+            ReflectionTestUtils.setField(userGrade, "userGradeId", gradeId);
+            ReflectionTestUtils.setField(userGrade, "evaluatedAt", LocalDateTime.now());
+
+            given(userGradeRepository.save(any(UserGrade.class))).willReturn(userGrade);
+
+            // when
+            UserGrade result = userGradeService.createUserGrade(testUser, gradeName);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getUserGradeId()).isEqualTo(gradeId);
+            assertThat(result.getGradeName()).isEqualTo(gradeName);
+            then(userGradeRepository).should(times(1)).save(any(UserGrade.class));
+        }
+
+        @Test
+        @DisplayName("기본 등급으로 유저 등급 생성")
+        void createUserGrade_WithDefaultGrade_CreatesSuccessfully() {
+            // given
+            String defaultGradeName = "NONE";
+            UserGrade userGrade = UserGrade.create(testUser, defaultGradeName);
+            UUID gradeId = UUID.randomUUID();
+            ReflectionTestUtils.setField(userGrade, "userGradeId", gradeId);
+
+            given(userGradeRepository.save(any(UserGrade.class))).willReturn(userGrade);
+
+            // when
+            UserGrade result = userGradeService.createUserGrade(testUser, defaultGradeName);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getGradeName()).isEqualTo(defaultGradeName);
+            then(userGradeRepository).should(times(1)).save(any(UserGrade.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("updateUserGrade 테스트")
+    class UpdateUserGradeTest {
+
+        @Test
+        @DisplayName("유저 등급 변경 - 새로운 이력 생성")
+        void updateUserGrade_CreatesNewGradeHistory() {
+            // given
+            String newGradeName = "GOLD";
+            UserGrade newGrade = UserGrade.create(testUser, newGradeName);
+            UUID newGradeId = UUID.randomUUID();
+            ReflectionTestUtils.setField(newGrade, "userGradeId", newGradeId);
+            ReflectionTestUtils.setField(newGrade, "evaluatedAt", LocalDateTime.now());
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+            given(userGradeRepository.save(any(UserGrade.class))).willReturn(newGrade);
+
+            // when
+            UserGrade result = userGradeService.updateUserGrade(userId, newGradeName);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getUserGradeId()).isEqualTo(newGradeId);
+            assertThat(result.getGradeName()).isEqualTo(newGradeName);
+            then(userRepository).should(times(1)).findById(userId);
+            then(userGradeRepository).should(times(1)).save(any(UserGrade.class));
+        }
+
+        @Test
+        @DisplayName("유저가 존재하지 않는 경우 예외 발생")
+        void updateUserGrade_WhenUserNotFound_ThrowsException() {
+            // given
+            String newGradeName = "GOLD";
+            given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> userGradeService.updateUserGrade(userId, newGradeName))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_NOT_FOUND);
+
+            then(userRepository).should(times(1)).findById(userId);
+            then(userGradeRepository).should(times(0)).save(any(UserGrade.class));
+        }
+
+        @Test
+        @DisplayName("삭제된 유저인 경우 예외 발생")
+        void updateUserGrade_WhenUserDeleted_ThrowsException() {
+            // given
+            String newGradeName = "GOLD";
+            testUser.delete(1L);
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+            // when & then
+            assertThatThrownBy(() -> userGradeService.updateUserGrade(userId, newGradeName))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_NOT_FOUND);
+
+            then(userRepository).should(times(1)).findById(userId);
+            then(userGradeRepository).should(times(0)).save(any(UserGrade.class));
+        }
+
+        @Test
+        @DisplayName("등급을 하향 변경하는 경우 새로운 이력 생성")
+        void updateUserGrade_WhenDowngrade_CreatesNewHistory() {
+            // given
+            String downgradeName = "SILVER";
+            UserGrade downgradeGrade = UserGrade.create(testUser, downgradeName);
+            UUID downgradeGradeId = UUID.randomUUID();
+            ReflectionTestUtils.setField(downgradeGrade, "userGradeId", downgradeGradeId);
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+            given(userGradeRepository.save(any(UserGrade.class))).willReturn(downgradeGrade);
+
+            // when
+            UserGrade result = userGradeService.updateUserGrade(userId, downgradeName);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getGradeName()).isEqualTo(downgradeName);
+            then(userRepository).should(times(1)).findById(userId);
+            then(userGradeRepository).should(times(1)).save(any(UserGrade.class));
+        }
+    }
+}

--- a/user/src/test/java/com/klp/user/application/UserGradeServiceTest.java
+++ b/user/src/test/java/com/klp/user/application/UserGradeServiceTest.java
@@ -69,7 +69,7 @@ class UserGradeServiceTest {
         void getCurrentGradeName_WhenGradeExists_ReturnsGradeName() {
             // given
             UserGrade userGrade = UserGrade.create(testUser, gradeName);
-            given(userGradeRepository.findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId))
+            given(userGradeRepository.findFirstByUser(userId))
                 .willReturn(Optional.of(userGrade));
 
             // when
@@ -78,14 +78,14 @@ class UserGradeServiceTest {
             // then
             assertThat(result).isEqualTo(gradeName);
             then(userGradeRepository).should(times(1))
-                .findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId);
+                .findFirstByUser(userId);
         }
 
         @Test
         @DisplayName("등급이 존재하지 않는 경우 null 반환")
         void getCurrentGradeName_WhenGradeNotExists_ReturnsNull() {
             // given
-            given(userGradeRepository.findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId))
+            given(userGradeRepository.findFirstByUser(userId))
                 .willReturn(Optional.empty());
 
             // when
@@ -94,7 +94,7 @@ class UserGradeServiceTest {
             // then
             assertThat(result).isNull();
             then(userGradeRepository).should(times(1))
-                .findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId);
+                .findFirstByUser(userId);
         }
 
         @Test
@@ -105,7 +105,7 @@ class UserGradeServiceTest {
             UserGrade latestGrade = UserGrade.create(testUser, latestGradeName);
             ReflectionTestUtils.setField(latestGrade, "evaluatedAt", LocalDateTime.now());
 
-            given(userGradeRepository.findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId))
+            given(userGradeRepository.findFirstByUser(userId))
                 .willReturn(Optional.of(latestGrade));
 
             // when
@@ -114,7 +114,7 @@ class UserGradeServiceTest {
             // then
             assertThat(result).isEqualTo(latestGradeName);
             then(userGradeRepository).should(times(1))
-                .findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId);
+                .findFirstByUser(userId);
         }
     }
 
@@ -130,7 +130,7 @@ class UserGradeServiceTest {
             UUID gradeId = UUID.randomUUID();
             ReflectionTestUtils.setField(userGrade, "userGradeId", gradeId);
 
-            given(userGradeRepository.findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId))
+            given(userGradeRepository.findFirstByUser(userId))
                 .willReturn(Optional.of(userGrade));
 
             // when
@@ -141,14 +141,14 @@ class UserGradeServiceTest {
             assertThat(result.getUserGradeId()).isEqualTo(gradeId);
             assertThat(result.getGradeName()).isEqualTo(gradeName);
             then(userGradeRepository).should(times(1))
-                .findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId);
+                .findFirstByUser(userId);
         }
 
         @Test
         @DisplayName("등급이 존재하지 않는 경우 예외 발생")
         void getCurrentUserGrade_WhenGradeNotExists_ThrowsException() {
             // given
-            given(userGradeRepository.findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId))
+            given(userGradeRepository.findFirstByUser(userId))
                 .willReturn(Optional.empty());
 
             // when & then
@@ -157,7 +157,7 @@ class UserGradeServiceTest {
                 .hasFieldOrPropertyWithValue("errorCode", UserErrorCode.USER_GRADE_NOT_FOUND);
 
             then(userGradeRepository).should(times(1))
-                .findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId);
+                .findFirstByUser(userId);
         }
 
         @Test
@@ -170,7 +170,7 @@ class UserGradeServiceTest {
             ReflectionTestUtils.setField(latestGrade, "userGradeId", latestGradeId);
             ReflectionTestUtils.setField(latestGrade, "evaluatedAt", LocalDateTime.now());
 
-            given(userGradeRepository.findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId))
+            given(userGradeRepository.findFirstByUser(userId))
                 .willReturn(Optional.of(latestGrade));
 
             // when
@@ -181,7 +181,7 @@ class UserGradeServiceTest {
             assertThat(result.getUserGradeId()).isEqualTo(latestGradeId);
             assertThat(result.getGradeName()).isEqualTo(latestGradeName);
             then(userGradeRepository).should(times(1))
-                .findFirstByUser_UserIdOrderByEvaluatedAtDesc(userId);
+                .findFirstByUser(userId);
         }
     }
 

--- a/user/src/test/java/com/klp/user/application/UserServiceTest.java
+++ b/user/src/test/java/com/klp/user/application/UserServiceTest.java
@@ -13,6 +13,9 @@ import com.klp.user.domain.entity.User;
 import com.klp.user.domain.enums.AffiliationType;
 import com.klp.user.domain.enums.UserRole;
 import com.klp.user.domain.repository.UserRepository;
+import com.klp.user.infrastructure.client.CompanyClient;
+import com.klp.user.infrastructure.client.PromotionClient;
+import com.klp.user.infrastructure.client.dto.response.CompanyResponse;
 import com.klp.user.presentation.dto.request.UserUpdateRequest;
 import com.klp.user.presentation.dto.response.UserDetailResponse;
 import com.klp.user.presentation.dto.response.UserInfoResponse;
@@ -44,6 +47,12 @@ class UserServiceTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private CompanyClient companyClient;
+
+    @Mock
+    private PromotionClient promotionClient;
 
     @InjectMocks
     private UserService userService;
@@ -114,9 +123,11 @@ class UserServiceTest {
         void getMyDetails_WhenUserExists_ReturnsUserDetails() {
             // given
             given(userRepository.findById(userId)).willReturn(Optional.ofNullable(testUser));
+            given(companyClient.getCompanyById(any(UUID.class)))
+                .willReturn(new CompanyResponse(affiliationId, UUID.randomUUID(), "type", "회사명", "주소"));
 
             // when
-            UserDetailResponse response = userService.getMyDetails(userId);
+            UserDetailResponse response = userService.getUserDetails(userId);
 
             // then
             assertThat(response).isNotNull();
@@ -137,6 +148,8 @@ class UserServiceTest {
         void getUserDetails_WhenUserExists_ReturnsUserDetails() {
             // given
             given(userRepository.findById(userId)).willReturn(Optional.ofNullable(testUser));
+            given(companyClient.getCompanyById(any(UUID.class)))
+                .willReturn(new CompanyResponse(affiliationId, UUID.randomUUID(), "type", "회사명", "주소"));
 
             // when
             UserDetailResponse response = userService.getUserDetails(userId);
@@ -196,6 +209,8 @@ class UserServiceTest {
             // given
             Page<User> userPage = new PageImpl<>(userList, pageable, userList.size());
             given(userRepository.findAll(pageable)).willReturn(userPage);
+            given(companyClient.getCompanyById(any(UUID.class)))
+                .willReturn(new CompanyResponse(affiliationId, UUID.randomUUID(), "type", "회사명", "주소"));
 
             // when
             PageResponse<UserInfoResponse> response = userService.getUserList(null, pageable);
@@ -214,6 +229,8 @@ class UserServiceTest {
             // given
             Page<User> userPage = new PageImpl<>(userList, pageable, userList.size());
             given(userRepository.findAll(pageable)).willReturn(userPage);
+            given(companyClient.getCompanyById(any(UUID.class)))
+                .willReturn(new CompanyResponse(affiliationId, UUID.randomUUID(), "type", "회사명", "주소"));
 
             // when
             PageResponse<UserInfoResponse> response = userService.getUserList("", pageable);
@@ -232,6 +249,8 @@ class UserServiceTest {
             String keyword = "user1";
             Page<User> userPage = new PageImpl<>(List.of(userList.get(0)), pageable, 1);
             given(userRepository.searchByKeyword(keyword, pageable)).willReturn(userPage);
+            given(companyClient.getCompanyById(any(UUID.class)))
+                .willReturn(new CompanyResponse(affiliationId, UUID.randomUUID(), "type", "회사명", "주소"));
 
             // when
             PageResponse<UserInfoResponse> response = userService.getUserList(keyword, pageable);
@@ -310,12 +329,14 @@ class UserServiceTest {
             // given
             UUID hubId = UUID.randomUUID();
             User driver1 = User.create(
-                hubId, AffiliationType.HUB, "driver1", "password", "slack1", "010-1111-1111", "driver1@example.com", UserRole.DRIVER
+                hubId, AffiliationType.HUB, "driver1", "password", "slack1", "010-1111-1111", "driver1@example.com",
+                UserRole.DRIVER
             );
             ReflectionTestUtils.setField(driver1, "userId", 1L);
 
             User driver2 = User.create(
-                hubId, AffiliationType.HUB, "driver2", "password", "slack2", "010-2222-2222", "driver2@example.com", UserRole.DRIVER
+                hubId, AffiliationType.HUB, "driver2", "password", "slack2", "010-2222-2222", "driver2@example.com",
+                UserRole.DRIVER
             );
             ReflectionTestUtils.setField(driver2, "userId", 2L);
 
@@ -345,12 +366,14 @@ class UserServiceTest {
             // given
             UUID logisticsId = UUID.randomUUID();
             User driver1 = User.create(
-                logisticsId, AffiliationType.LOGISTICS, "driver1", "password", "slack1", "010-1111-1111", "driver1@example.com", UserRole.DRIVER
+                logisticsId, AffiliationType.LOGISTICS, "driver1", "password", "slack1", "010-1111-1111",
+                "driver1@example.com", UserRole.DRIVER
             );
             ReflectionTestUtils.setField(driver1, "userId", 1L);
 
             User driver2 = User.create(
-                logisticsId, AffiliationType.LOGISTICS, "driver2", "password", "slack2", "010-2222-2222", "driver2@example.com", UserRole.DRIVER
+                logisticsId, AffiliationType.LOGISTICS, "driver2", "password", "slack2", "010-2222-2222",
+                "driver2@example.com", UserRole.DRIVER
             );
             ReflectionTestUtils.setField(driver2, "userId", 2L);
 
@@ -380,7 +403,8 @@ class UserServiceTest {
             Long driverId = 1L;
             UUID hubId = UUID.randomUUID();
             User driver = User.create(
-                hubId, AffiliationType.HUB, "driver1", "password", "slack1", "010-1111-1111", "driver1@example.com", UserRole.DRIVER
+                hubId, AffiliationType.HUB, "driver1", "password", "slack1", "010-1111-1111", "driver1@example.com",
+                UserRole.DRIVER
             );
             ReflectionTestUtils.setField(driver, "userId", driverId);
 

--- a/user/src/test/java/com/klp/user/application/UserServiceTest.java
+++ b/user/src/test/java/com/klp/user/application/UserServiceTest.java
@@ -8,17 +8,11 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
-import com.klp.common.model.PageResponse;
 import com.klp.user.domain.entity.User;
 import com.klp.user.domain.enums.AffiliationType;
 import com.klp.user.domain.enums.UserRole;
 import com.klp.user.domain.repository.UserRepository;
-import com.klp.user.infrastructure.client.CompanyClient;
-import com.klp.user.infrastructure.client.PromotionClient;
-import com.klp.user.infrastructure.client.dto.response.CompanyResponse;
 import com.klp.user.presentation.dto.request.UserUpdateRequest;
-import com.klp.user.presentation.dto.response.UserDetailResponse;
-import com.klp.user.presentation.dto.response.UserInfoResponse;
 import com.klp.user.presentation.dto.response.UsernameCheckResponse;
 import java.util.List;
 import java.util.Optional;
@@ -47,12 +41,6 @@ class UserServiceTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
-
-    @Mock
-    private CompanyClient companyClient;
-
-    @Mock
-    private PromotionClient promotionClient;
 
     @InjectMocks
     private UserService userService;
@@ -115,52 +103,22 @@ class UserServiceTest {
     }
 
     @Nested
-    @DisplayName("getMyDetails 테스트")
-    class GetMyDetailsTest {
+    @DisplayName("findNotDeletedUser 테스트")
+    class FindNotDeletedUserTest {
 
         @Test
-        @DisplayName("본인의 상세 정보를 성공적으로 조회")
-        void getMyDetails_WhenUserExists_ReturnsUserDetails() {
+        @DisplayName("삭제되지 않은 유저를 성공적으로 조회")
+        void findNotDeletedUser_WhenUserExists_ReturnsUser() {
             // given
             given(userRepository.findById(userId)).willReturn(Optional.ofNullable(testUser));
-            given(companyClient.getCompanyById(any(UUID.class)))
-                .willReturn(new CompanyResponse(affiliationId, UUID.randomUUID(), "type", "회사명", "주소"));
 
             // when
-            UserDetailResponse response = userService.getUserDetails(userId);
+            User result = userService.findNotDeletedUser(userId);
 
             // then
-            assertThat(response).isNotNull();
-            assertThat(response.userId()).isEqualTo(userId);
-            assertThat(response.username()).isEqualTo(username);
-            assertThat(response.slackId()).isEqualTo(slackId);
-            assertThat(response.phone()).isEqualTo(phone);
-            then(userRepository).should(times(1)).findById(userId);
-        }
-    }
-
-    @Nested
-    @DisplayName("getUserDetails 테스트")
-    class GetUserDetailsTest {
-
-        @Test
-        @DisplayName("특정 유저의 상세 정보를 성공적으로 조회")
-        void getUserDetails_WhenUserExists_ReturnsUserDetails() {
-            // given
-            given(userRepository.findById(userId)).willReturn(Optional.ofNullable(testUser));
-            given(companyClient.getCompanyById(any(UUID.class)))
-                .willReturn(new CompanyResponse(affiliationId, UUID.randomUUID(), "type", "회사명", "주소"));
-
-            // when
-            UserDetailResponse response = userService.getUserDetails(userId);
-
-            // then
-            assertThat(response).isNotNull();
-            assertThat(response.userId()).isEqualTo(userId);
-            assertThat(response.username()).isEqualTo(username);
-            assertThat(response.slackId()).isEqualTo(slackId);
-            assertThat(response.phone()).isEqualTo(phone);
-            assertThat(response.role()).isEqualTo(testUser.getRole().name());
+            assertThat(result).isNotNull();
+            assertThat(result.getUserId()).isEqualTo(userId);
+            assertThat(result.getName()).isEqualTo(username);
             then(userRepository).should(times(1)).findById(userId);
         }
     }
@@ -209,16 +167,14 @@ class UserServiceTest {
             // given
             Page<User> userPage = new PageImpl<>(userList, pageable, userList.size());
             given(userRepository.findAll(pageable)).willReturn(userPage);
-            given(companyClient.getCompanyById(any(UUID.class)))
-                .willReturn(new CompanyResponse(affiliationId, UUID.randomUUID(), "type", "회사명", "주소"));
 
             // when
-            PageResponse<UserInfoResponse> response = userService.getUserList(null, pageable);
+            Page<User> result = userService.getUserList(null, pageable);
 
             // then
-            assertThat(response).isNotNull();
-            assertThat(response.getData()).hasSize(2);
-            assertThat(response.getTotalItems()).isEqualTo(2);
+            assertThat(result).isNotNull();
+            assertThat(result.getContent()).hasSize(2);
+            assertThat(result.getTotalElements()).isEqualTo(2);
             then(userRepository).should(times(1)).findAll(pageable);
             then(userRepository).should(never()).searchByKeyword(anyString(), any(Pageable.class));
         }
@@ -229,15 +185,13 @@ class UserServiceTest {
             // given
             Page<User> userPage = new PageImpl<>(userList, pageable, userList.size());
             given(userRepository.findAll(pageable)).willReturn(userPage);
-            given(companyClient.getCompanyById(any(UUID.class)))
-                .willReturn(new CompanyResponse(affiliationId, UUID.randomUUID(), "type", "회사명", "주소"));
 
             // when
-            PageResponse<UserInfoResponse> response = userService.getUserList("", pageable);
+            Page<User> result = userService.getUserList("", pageable);
 
             // then
-            assertThat(response).isNotNull();
-            assertThat(response.getData()).hasSize(2);
+            assertThat(result).isNotNull();
+            assertThat(result.getContent()).hasSize(2);
             then(userRepository).should(times(1)).findAll(pageable);
             then(userRepository).should(never()).searchByKeyword(anyString(), any(Pageable.class));
         }
@@ -249,16 +203,14 @@ class UserServiceTest {
             String keyword = "user1";
             Page<User> userPage = new PageImpl<>(List.of(userList.get(0)), pageable, 1);
             given(userRepository.searchByKeyword(keyword, pageable)).willReturn(userPage);
-            given(companyClient.getCompanyById(any(UUID.class)))
-                .willReturn(new CompanyResponse(affiliationId, UUID.randomUUID(), "type", "회사명", "주소"));
 
             // when
-            PageResponse<UserInfoResponse> response = userService.getUserList(keyword, pageable);
+            Page<User> result = userService.getUserList(keyword, pageable);
 
             // then
-            assertThat(response).isNotNull();
-            assertThat(response.getData()).hasSize(1);
-            assertThat(response.getTotalItems()).isEqualTo(1);
+            assertThat(result).isNotNull();
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getTotalElements()).isEqualTo(1);
             then(userRepository).should(times(1)).searchByKeyword(keyword, pageable);
             then(userRepository).should(never()).findAll(any(Pageable.class));
         }
@@ -272,12 +224,12 @@ class UserServiceTest {
             given(userRepository.searchByKeyword(keyword, pageable)).willReturn(emptyPage);
 
             // when
-            PageResponse<UserInfoResponse> response = userService.getUserList(keyword, pageable);
+            Page<User> result = userService.getUserList(keyword, pageable);
 
             // then
-            assertThat(response).isNotNull();
-            assertThat(response.getData()).isEmpty();
-            assertThat(response.getTotalItems()).isZero();
+            assertThat(result).isNotNull();
+            assertThat(result.getContent()).isEmpty();
+            assertThat(result.getTotalElements()).isZero();
             then(userRepository).should(times(1)).searchByKeyword(keyword, pageable);
         }
     }
@@ -307,25 +259,25 @@ class UserServiceTest {
                 newRole
             );
 
-            given(userRepository.findById(userId)).willReturn(Optional.ofNullable(testUser));
             given(passwordEncoder.encode(newPassword)).willReturn(encodedPassword);
 
             // when
-            userService.updateUserInfo(userId, request);
+            userService.updateUserInfo(testUser, request);
 
             // then
-            then(userRepository).should(times(1)).findById(userId);
             then(passwordEncoder).should(times(1)).encode(newPassword);
+            assertThat(testUser.getName()).isEqualTo(newUsername);
+            assertThat(testUser.getSlackId()).isEqualTo(newSlackId);
         }
     }
 
     @Nested
-    @DisplayName("getDriversByHubId 테스트")
-    class GetDriversByHubIdTest {
+    @DisplayName("findDriversByHubId 테스트")
+    class FindDriversByHubIdTest {
 
         @Test
         @DisplayName("허브 ID로 배송 담당자 조회 성공")
-        void getDriversByHubId_ReturnsDriverList() {
+        void findDriversByHubId_ReturnsDriverList() {
             // given
             UUID hubId = UUID.randomUUID();
             User driver1 = User.create(
@@ -345,24 +297,23 @@ class UserServiceTest {
             given(userRepository.findDriversByHubId(hubId)).willReturn(drivers);
 
             // when
-            var response = userService.getDriversByHubId(hubId);
+            List<User> result = userService.findDriversByHubId(hubId);
 
             // then
-            assertThat(response.hubId()).isEqualTo(hubId);
-            assertThat(response.drivers()).hasSize(2);
-            assertThat(response.drivers().get(0).userId()).isEqualTo(1L);
-            assertThat(response.drivers().get(0).username()).isEqualTo("driver1");
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).getUserId()).isEqualTo(1L);
+            assertThat(result.get(0).getName()).isEqualTo("driver1");
             then(userRepository).should(times(1)).findDriversByHubId(hubId);
         }
     }
 
     @Nested
-    @DisplayName("getDriversByLogistics 테스트")
-    class GetDriversByLogisticsTest {
+    @DisplayName("findDriversByLogistics 테스트")
+    class FindDriversByLogisticsTest {
 
         @Test
         @DisplayName("물류회사 소속 배송 담당자 조회 성공")
-        void getDriversByLogistics_ReturnsDriverList() {
+        void findDriversByLogistics_ReturnsDriverList() {
             // given
             UUID logisticsId = UUID.randomUUID();
             User driver1 = User.create(
@@ -382,23 +333,23 @@ class UserServiceTest {
             given(userRepository.findDriversByLogistics()).willReturn(drivers);
 
             // when
-            var response = userService.getDriversByLogistics();
+            List<User> result = userService.findDriversByLogistics();
 
             // then
-            assertThat(response.drivers()).hasSize(2);
-            assertThat(response.drivers().get(0).userId()).isEqualTo(1L);
-            assertThat(response.drivers().get(0).username()).isEqualTo("driver1");
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).getUserId()).isEqualTo(1L);
+            assertThat(result.get(0).getName()).isEqualTo("driver1");
             then(userRepository).should(times(1)).findDriversByLogistics();
         }
     }
 
     @Nested
-    @DisplayName("getDriverById 테스트")
-    class GetDriverByIdTest {
+    @DisplayName("findDriverById 테스트")
+    class FindDriverByIdTest {
 
         @Test
         @DisplayName("배송 담당자 ID로 상세 정보 조회 성공")
-        void getDriverById_ReturnsDriverDetail() {
+        void findDriverById_ReturnsDriver() {
             // given
             Long driverId = 1L;
             UUID hubId = UUID.randomUUID();
@@ -411,15 +362,91 @@ class UserServiceTest {
             given(userRepository.findDriverById(driverId)).willReturn(Optional.of(driver));
 
             // when
-            var response = userService.getDriverById(driverId);
+            User result = userService.findDriverById(driverId);
 
             // then
-            assertThat(response.userId()).isEqualTo(driverId);
-            assertThat(response.hubId()).isEqualTo(hubId);
-            assertThat(response.username()).isEqualTo("driver1");
-            assertThat(response.slackId()).isEqualTo("slack1");
-            assertThat(response.phone()).isEqualTo("010-1111-1111");
+            assertThat(result.getUserId()).isEqualTo(driverId);
+            assertThat(result.getAffiliationId()).isEqualTo(hubId);
+            assertThat(result.getName()).isEqualTo("driver1");
+            assertThat(result.getSlackId()).isEqualTo("slack1");
+            assertThat(result.getPhone()).isEqualTo("010-1111-1111");
             then(userRepository).should(times(1)).findDriverById(driverId);
+        }
+    }
+
+    @Nested
+    @DisplayName("createPendingUser 테스트")
+    class CreatePendingUserTest {
+
+        @Test
+        @DisplayName("회원가입 시 PENDING 상태로 생성")
+        void createPendingUser_CreatesPendingUser() {
+            // given
+            UUID affiliationId = UUID.randomUUID();
+            String password = "Password1!";
+            String encodedPassword = "encodedPassword";
+
+            var request = new com.klp.user.presentation.dto.request.UserCreateRequest(
+                username,
+                password,
+                slackId,
+                phone,
+                "test@example.com",
+                UserRole.HUB,
+                "회사명",
+                AffiliationType.HUB
+            );
+
+            given(passwordEncoder.encode(password)).willReturn(encodedPassword);
+            given(userRepository.save(any(User.class))).willAnswer(invocation -> {
+                User user = invocation.getArgument(0);
+                ReflectionTestUtils.setField(user, "userId", userId);
+                return user;
+            });
+
+            // when
+            User result = userService.createPendingUser(request, affiliationId);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getUserId()).isEqualTo(userId);
+            assertThat(result.getName()).isEqualTo(username);
+            then(passwordEncoder).should(times(1)).encode(password);
+            then(userRepository).should(times(1)).save(any(User.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("approvePendingUser 테스트")
+    class ApprovePendingUserTest {
+
+        @Test
+        @DisplayName("유저 승인 처리")
+        void approvePendingUser_ApprovesUser() {
+            // given
+
+            // when
+            userService.approvePendingUser(testUser);
+
+            // then
+            assertThat(testUser.getStatus()).isEqualTo(com.klp.user.domain.enums.UserStatus.APPROVED);
+        }
+    }
+
+    @Nested
+    @DisplayName("rejectPendingUser 테스트")
+    class RejectPendingUserTest {
+
+        @Test
+        @DisplayName("유저 거부 처리")
+        void rejectPendingUser_RejectsUser() {
+            // given
+
+            // when
+            userService.rejectPendingUser(testUser);
+
+            // then
+            assertThat(testUser.getStatus()).isEqualTo(com.klp.user.domain.enums.UserStatus.REJECTED);
         }
     }
 }

--- a/user/src/test/java/com/klp/user/presentation/UserControllerTest.java
+++ b/user/src/test/java/com/klp/user/presentation/UserControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.klp.global.exception.GlobalExceptionHandler;
 import com.klp.global.security.config.SecurityConfig;
 import com.klp.global.security.filter.AuthorizationFilter;
+import com.klp.user.application.UserFacade;
 import com.klp.user.application.UserService;
 import com.klp.user.presentation.dto.response.UsernameCheckResponse;
 import org.junit.jupiter.api.DisplayName;
@@ -28,6 +29,9 @@ class UserControllerTest {
 
     @MockitoBean
     private UserService userService;
+
+    @MockitoBean
+    private UserFacade userFacade;
 
     @Nested
     @DisplayName("유저 이름 사용 가능 여부 확인 테스트")

--- a/user/src/test/java/com/klp/user/presentation/UserControllerTest.java
+++ b/user/src/test/java/com/klp/user/presentation/UserControllerTest.java
@@ -3,20 +3,13 @@ package com.klp.user.presentation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.klp.global.exception.GlobalExceptionHandler;
 import com.klp.global.security.config.SecurityConfig;
 import com.klp.global.security.filter.AuthorizationFilter;
 import com.klp.user.application.UserService;
-import com.klp.user.presentation.dto.response.DriverDetailResponse;
-import com.klp.user.presentation.dto.response.DriverInfo;
-import com.klp.user.presentation.dto.response.HubDriverListResponse;
-import com.klp.user.presentation.dto.response.LogisticsDriverListResponse;
 import com.klp.user.presentation.dto.response.UsernameCheckResponse;
-import java.util.List;
-import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -26,7 +19,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(UserController.class)
+@WebMvcTest({UserController.class, UserInternalController.class})
 @Import({SecurityConfig.class, AuthorizationFilter.class, GlobalExceptionHandler.class})
 class UserControllerTest {
 
@@ -75,84 +68,5 @@ class UserControllerTest {
     @DisplayName("유저 정보 변경 테스트")
     class updateUserInfo {
 
-    }
-
-    @Nested
-    @DisplayName("허브 소속 배송 담당자 조회 테스트")
-    class GetDriversByHubIdTest {
-
-        @Test
-        @DisplayName("성공 시 200 OK와 배송 담당자 목록을 반환한다")
-        void getDriversByHubId_success() throws Exception {
-            // given
-            UUID hubId = UUID.randomUUID();
-            DriverInfo driver1 = new DriverInfo(1L, "driver1", "slack1", "010-1111-1111", "driver1@example.com");
-            DriverInfo driver2 = new DriverInfo(2L, "driver2", "slack2", "010-2222-2222", "driver2@example.com");
-            HubDriverListResponse response = HubDriverListResponse.of(hubId, List.of(driver1, driver2));
-
-            // when
-            when(userService.getDriversByHubId(hubId)).thenReturn(response);
-
-            // then
-            mockMvc.perform(get("/v1/users/driver/" + hubId))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.hubId").value(hubId.toString()))
-                .andExpect(jsonPath("$.drivers.length()").value(2))
-                .andExpect(jsonPath("$.drivers[0].userId").value(1))
-                .andExpect(jsonPath("$.drivers[0].username").value("driver1"));
-        }
-    }
-
-    @Nested
-    @DisplayName("물류회사 소속 배송 담당자 조회 테스트")
-    class GetDriversByLogisticsTest {
-
-        @Test
-        @DisplayName("성공 시 200 OK와 배송 담당자 목록을 반환한다")
-        void getDriversByLogistics_success() throws Exception {
-            // given
-            DriverInfo driver1 = new DriverInfo(1L, "driver1", "slack1", "010-1111-1111", "driver1@example.com");
-            DriverInfo driver2 = new DriverInfo(2L, "driver2", "slack2", "010-2222-2222", "driver2@example.com");
-            LogisticsDriverListResponse response = LogisticsDriverListResponse.of(List.of(driver1, driver2));
-
-            // when
-            when(userService.getDriversByLogistics()).thenReturn(response);
-
-            // then
-            mockMvc.perform(get("/v1/users/driver/logistics"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.drivers.length()").value(2))
-                .andExpect(jsonPath("$.drivers[0].userId").value(1))
-                .andExpect(jsonPath("$.drivers[0].username").value("driver1"));
-        }
-    }
-
-    @Nested
-    @DisplayName("배송 담당자 상세 조회 테스트")
-    class GetDriverByIdTest {
-
-        @Test
-        @DisplayName("성공 시 200 OK와 배송 담당자 상세 정보를 반환한다")
-        void getDriverById_success() throws Exception {
-            // given
-            Long driverId = 1L;
-            UUID hubId = UUID.randomUUID();
-            DriverDetailResponse response = new DriverDetailResponse(
-                driverId, hubId, "driver1", "slack1", "010-1111-1111", "driver1@example.com"
-            );
-
-            // when
-            when(userService.getDriverById(driverId)).thenReturn(response);
-
-            // then
-            mockMvc.perform(get("/v1/users/driver")
-                    .param("id", driverId.toString()))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.userId").value(1))
-                .andExpect(jsonPath("$.hubId").value(hubId.toString()))
-                .andExpect(jsonPath("$.username").value("driver1"))
-                .andExpect(jsonPath("$.slackId").value("slack1"))
-                .andExpect(jsonPath("$.phone").value("010-1111-1111"));
-        }
     }
 }

--- a/user/src/test/java/com/klp/user/presentation/UserInternalControllerTest.java
+++ b/user/src/test/java/com/klp/user/presentation/UserInternalControllerTest.java
@@ -1,0 +1,115 @@
+package com.klp.user.presentation;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.klp.global.exception.GlobalExceptionHandler;
+import com.klp.global.security.config.SecurityConfig;
+import com.klp.global.security.filter.AuthorizationFilter;
+import com.klp.user.application.UserService;
+import com.klp.user.presentation.dto.response.DriverDetailResponse;
+import com.klp.user.presentation.dto.response.DriverInfo;
+import com.klp.user.presentation.dto.response.HubDriverListResponse;
+import com.klp.user.presentation.dto.response.LogisticsDriverListResponse;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(UserInternalController.class)
+@Import({SecurityConfig.class, AuthorizationFilter.class, GlobalExceptionHandler.class})
+class UserInternalControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserService userService;
+
+    @Nested
+    @DisplayName("허브 소속 배송 담당자 조회 테스트")
+    class GetDriversByHubIdTest {
+
+        @Test
+        @DisplayName("성공 시 200 OK와 배송 담당자 목록을 반환한다")
+        void getDriversByHubId_success() throws Exception {
+            // given
+            UUID hubId = UUID.randomUUID();
+            DriverInfo driver1 = new DriverInfo(1L, "driver1", "slack1", "010-1111-1111", "driver1@example.com");
+            DriverInfo driver2 = new DriverInfo(2L, "driver2", "slack2", "010-2222-2222", "driver2@example.com");
+            HubDriverListResponse response = HubDriverListResponse.of(hubId, List.of(driver1, driver2));
+
+            // when
+            when(userService.getDriversByHubId(hubId)).thenReturn(response);
+
+            // then
+            mockMvc.perform(get("/v1/internal/users/driver/" + hubId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.hubId").value(hubId.toString()))
+                .andExpect(jsonPath("$.drivers.length()").value(2))
+                .andExpect(jsonPath("$.drivers[0].userId").value(1))
+                .andExpect(jsonPath("$.drivers[0].username").value("driver1"));
+        }
+    }
+
+    @Nested
+    @DisplayName("물류회사 소속 배송 담당자 조회 테스트")
+    class GetDriversByLogisticsTest {
+
+        @Test
+        @DisplayName("성공 시 200 OK와 배송 담당자 목록을 반환한다")
+        void getDriversByLogistics_success() throws Exception {
+            // given
+            DriverInfo driver1 = new DriverInfo(1L, "driver1", "slack1", "010-1111-1111", "driver1@example.com");
+            DriverInfo driver2 = new DriverInfo(2L, "driver2", "slack2", "010-2222-2222", "driver2@example.com");
+            LogisticsDriverListResponse response = LogisticsDriverListResponse.of(List.of(driver1, driver2));
+
+            // when
+            when(userService.getDriversByLogistics()).thenReturn(response);
+
+            // then
+            mockMvc.perform(get("/v1/internal/users/driver/logistics"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.drivers.length()").value(2))
+                .andExpect(jsonPath("$.drivers[0].userId").value(1))
+                .andExpect(jsonPath("$.drivers[0].username").value("driver1"));
+        }
+    }
+
+    @Nested
+    @DisplayName("배송 담당자 상세 조회 테스트")
+    class GetDriverByIdTest {
+
+        @Test
+        @DisplayName("성공 시 200 OK와 배송 담당자 상세 정보를 반환한다")
+        void getDriverById_success() throws Exception {
+            // given
+            Long driverId = 1L;
+            UUID hubId = UUID.randomUUID();
+            DriverDetailResponse response = new DriverDetailResponse(
+                driverId, hubId, "driver1", "slack1", "010-1111-1111", "driver1@example.com"
+            );
+
+            // when
+            when(userService.getDriverById(driverId)).thenReturn(response);
+
+            // then
+            mockMvc.perform(get("/v1/internal/users/driver")
+                    .param("id", driverId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(1))
+                .andExpect(jsonPath("$.hubId").value(hubId.toString()))
+                .andExpect(jsonPath("$.username").value("driver1"))
+                .andExpect(jsonPath("$.slackId").value("slack1"))
+                .andExpect(jsonPath("$.phone").value("010-1111-1111"));
+        }
+    }
+}

--- a/user/src/test/java/com/klp/user/presentation/UserInternalControllerTest.java
+++ b/user/src/test/java/com/klp/user/presentation/UserInternalControllerTest.java
@@ -8,7 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.klp.global.exception.GlobalExceptionHandler;
 import com.klp.global.security.config.SecurityConfig;
 import com.klp.global.security.filter.AuthorizationFilter;
-import com.klp.user.application.UserService;
+import com.klp.user.application.UserFacade;
 import com.klp.user.presentation.dto.response.DriverDetailResponse;
 import com.klp.user.presentation.dto.response.DriverInfo;
 import com.klp.user.presentation.dto.response.HubDriverListResponse;
@@ -32,7 +32,7 @@ class UserInternalControllerTest {
     private MockMvc mockMvc;
 
     @MockitoBean
-    private UserService userService;
+    private UserFacade userFacade;
 
     @Nested
     @DisplayName("허브 소속 배송 담당자 조회 테스트")
@@ -48,7 +48,7 @@ class UserInternalControllerTest {
             HubDriverListResponse response = HubDriverListResponse.of(hubId, List.of(driver1, driver2));
 
             // when
-            when(userService.getDriversByHubId(hubId)).thenReturn(response);
+            when(userFacade.getDriversByHubId(hubId)).thenReturn(response);
 
             // then
             mockMvc.perform(get("/v1/internal/users/driver/" + hubId))
@@ -73,7 +73,7 @@ class UserInternalControllerTest {
             LogisticsDriverListResponse response = LogisticsDriverListResponse.of(List.of(driver1, driver2));
 
             // when
-            when(userService.getDriversByLogistics()).thenReturn(response);
+            when(userFacade.getDriversByLogistics()).thenReturn(response);
 
             // then
             mockMvc.perform(get("/v1/internal/users/driver/logistics"))
@@ -99,7 +99,7 @@ class UserInternalControllerTest {
             );
 
             // when
-            when(userService.getDriverById(driverId)).thenReturn(response);
+            when(userFacade.getDriverById(driverId)).thenReturn(response);
 
             // then
             mockMvc.perform(get("/v1/internal/users/driver")


### PR DESCRIPTION
## PR 내용
- [feat: 회원 서비스 고객 권한 추가](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/9f8d102a5930d740745ef1e2a4d1354c7f950beb)
  - 회원 서비스에 고객 권한을 추가했습니다.
  - 고객 권한의 경우 회원가입 시 `affiliationId = null, affiliationType = CUSTOMER, role = CUSTOMER`의 유효성을 체크합니다.

- [feat: UserGrade 추가 및 기능 작성](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/1fe7e2553f189147d4cbcffa0ab1fc57c3a9592b)
  - 회원 등급 기능을 추가했습니다.
  - 회원 등급의 경우 변경 시간을 기록하기 때문에, 변경 이력을 남기는 것이 필요하다고 판단하여 1:1관계가 아니라 1:N 관계로 설정했습니다
  - 회원 가입 승인 시, `CUSTOMER` 권한의 유저의 경우 Promotion 서비스에 가장 기본 등급의 이름을 요청하여 이 등급의 이름을 가지도록 설정했습니다.

- [feat: UserFacade 패턴 도입 및 리팩토링 진행](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/3aeb54f29b8626457c317efd7491914ddfe848c8)
  - UserService와 UserGradeService 간의 협업이 필요성이 생기게 되었으며, 각자 서비스에서 서로를 의존할 경우 순환참조 문제가 발생할 수 있어 Facade 패턴을 적용했습니다.