### PR TITLE
feat: 회원 주소 관련 기능 추가

### DIFF
--- a/user/src/main/java/com/klp/user/application/UserAddressService.java
+++ b/user/src/main/java/com/klp/user/application/UserAddressService.java
@@ -1,0 +1,73 @@
+package com.klp.user.application;
+
+import com.klp.common.exception.BusinessException;
+import com.klp.user.application.command.UserAddressCreateCommand;
+import com.klp.user.domain.entity.User;
+import com.klp.user.domain.entity.UserAddress;
+import com.klp.user.domain.exception.UserErrorCode;
+import com.klp.user.domain.repository.UserAddressRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserAddressService {
+
+    private final UserAddressRepository userAddressRepository;
+
+    @Transactional
+    public void createUserAddress(User user, UserAddressCreateCommand command) {
+        UserAddress userAddress = UserAddress.create(
+            user,
+            command.hubId(),
+            command.address(),
+            command.detail(),
+            command.isDefault(),
+            command.latitude(),
+            command.longitude()
+        );
+
+        userAddressRepository.save(userAddress);
+    }
+
+    @Transactional(readOnly = true)
+    public UserAddress getUserAddress(UUID userAddressId) {
+        return userAddressRepository.findById(userAddressId)
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_ADDRESS_NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserAddress> getUserAddressList(Long userId) {
+        return userAddressRepository.findByUserId(userId);
+    }
+
+    @Transactional
+    public void updateUserAddress(UUID userAddressId, UserAddressCreateCommand command) {
+        UserAddress userAddress = userAddressRepository.findById(userAddressId)
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_ADDRESS_NOT_FOUND));
+
+        userAddress.update(
+            command.hubId(),
+            command.address(),
+            command.detail(),
+            command.isDefault(),
+            command.latitude(),
+            command.longitude()
+        );
+
+        userAddressRepository.save(userAddress);
+    }
+
+    @Transactional
+    public void deleteUserAddress(UUID userAddressId, Long deletedBy) {
+        UserAddress userAddress = userAddressRepository.findById(userAddressId)
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_ADDRESS_NOT_FOUND));
+        userAddress.delete(deletedBy);
+        userAddressRepository.save(userAddress);
+    }
+}

--- a/user/src/main/java/com/klp/user/application/UserFacade.java
+++ b/user/src/main/java/com/klp/user/application/UserFacade.java
@@ -2,7 +2,9 @@ package com.klp.user.application;
 
 import com.klp.common.exception.BusinessException;
 import com.klp.common.model.PageResponse;
+import com.klp.user.application.command.UserAddressCreateCommand;
 import com.klp.user.domain.entity.User;
+import com.klp.user.domain.entity.UserAddress;
 import com.klp.user.domain.entity.UserGrade;
 import com.klp.user.domain.enums.AffiliationType;
 import com.klp.user.domain.enums.UserRole;
@@ -19,6 +21,8 @@ import com.klp.user.presentation.dto.response.DriverDetailResponse;
 import com.klp.user.presentation.dto.response.DriverInfo;
 import com.klp.user.presentation.dto.response.HubDriverListResponse;
 import com.klp.user.presentation.dto.response.LogisticsDriverListResponse;
+import com.klp.user.presentation.dto.response.UserAddressListResponse;
+import com.klp.user.presentation.dto.response.UserAddressResponse;
 import com.klp.user.presentation.dto.response.UserDetailResponse;
 import com.klp.user.presentation.dto.response.UserGradeResponse;
 import com.klp.user.presentation.dto.response.UserInfoResponse;
@@ -38,6 +42,7 @@ public class UserFacade {
 
     private final UserService userService;
     private final UserGradeService userGradeService;
+    private final UserAddressService userAddressService;
     private final CompanyClient companyClient;
     private final PromotionClient promotionClient;
 
@@ -256,5 +261,54 @@ public class UserFacade {
             throw new BusinessException(UserErrorCode.INTERNAL_SERVER_ERROR,
                 "업체 정보 조회 중 예상치 못한 오류가 발생했습니다.");
         }
+    }
+
+    /**
+     * 회원 주소 생성(요청으로 자신 주소 근처 hubId를 받음)
+     */
+    @Transactional
+    public void createUserAddress(UserAddressCreateCommand command) {
+        User user = userService.findNotDeletedUser(command.userId());
+        userAddressService.createUserAddress(user, command);
+        log.info("회원 주소 생성 완료 - userId: {}", command.userId());
+    }
+
+    /**
+     * 회원 주소 단건 조회
+     */
+    @Transactional(readOnly = true)
+    public UserAddressResponse getUserAddress(UUID userAddressId) {
+        UserAddress userAddress = userAddressService.getUserAddress(userAddressId);
+        return UserAddressResponse.from(userAddress);
+    }
+
+    /**
+     * 회원 주소 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public UserAddressListResponse getUserAddressList(Long userId) {
+        List<UserAddress> addresses = userAddressService.getUserAddressList(userId);
+        List<UserAddressResponse> addressResponses = addresses.stream()
+            .map(UserAddressResponse::from)
+            .toList();
+        return UserAddressListResponse.of(addressResponses);
+    }
+
+    /**
+     * 회원 주소 수정
+     */
+    @Transactional
+    public void updateUserAddress(UUID userAddressId, UserAddressCreateCommand command) {
+        userAddressService.updateUserAddress(userAddressId, command);
+        log.info("회원 주소 수정 완료 - addressId: {}", userAddressId);
+    }
+
+    /**
+     * 회원 주소 삭제
+     */
+    @Transactional
+    public void deleteUserAddress(UUID userAddressId, Long userId) {
+        userAddressService.deleteUserAddress(userAddressId, userId);
+        log.info("회원 주소 삭제 완료 - addressId: {}, deletedBy: {}", userAddressId, userId);
     }
 }

--- a/user/src/main/java/com/klp/user/application/command/UserAddressCreateCommand.java
+++ b/user/src/main/java/com/klp/user/application/command/UserAddressCreateCommand.java
@@ -1,0 +1,15 @@
+package com.klp.user.application.command;
+
+import java.util.UUID;
+
+public record UserAddressCreateCommand(
+    Long userId,
+    UUID hubId,
+    String address,
+    String detail,
+    boolean isDefault,
+    Double latitude,
+    Double longitude
+) {
+
+}

--- a/user/src/main/java/com/klp/user/domain/entity/UserAddress.java
+++ b/user/src/main/java/com/klp/user/domain/entity/UserAddress.java
@@ -1,0 +1,90 @@
+package com.klp.user.domain.entity;
+
+import com.klp.common.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Getter
+@Table(name = "p_user_address", schema = "user_schema")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserAddress extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "user_address_id")
+    @Comment("회원주소 ID")
+    private UUID userAddressId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    @Comment("유저ID")
+    private User user;
+
+    @Column(name = "hub_id", nullable = false)
+    private UUID hubId;
+
+    @Column(name = "address", nullable = false)
+    private String address;
+
+    @Column(name = "detail")
+    private String detail;
+
+    @Column(name = "is_default", nullable = false)
+    private boolean isDefault;
+
+    @Column(name = "latitude", nullable = false)
+    private Double latitude;
+
+    @Column(name = "longitude", nullable = false)
+    private Double longitude;
+
+    public static UserAddress create(
+        User user,
+        UUID hubId,
+        String address,
+        String detail,
+        boolean isDefault,
+        Double latitude,
+        Double longitude
+    ) {
+        UserAddress userAddress = new UserAddress();
+        userAddress.user = user;
+        userAddress.hubId = hubId;
+        userAddress.address = address;
+        userAddress.detail = detail;
+        userAddress.isDefault = isDefault;
+        userAddress.latitude = latitude;
+        userAddress.longitude = longitude;
+
+        return userAddress;
+    }
+
+    public void update(
+        UUID hubId,
+        String address,
+        String detail,
+        boolean isDefault,
+        Double latitude,
+        Double longitude
+    ) {
+        this.hubId = hubId;
+        this.address = address;
+        this.detail = detail;
+        this.isDefault = isDefault;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+}

--- a/user/src/main/java/com/klp/user/domain/exception/UserErrorCode.java
+++ b/user/src/main/java/com/klp/user/domain/exception/UserErrorCode.java
@@ -21,12 +21,8 @@ public enum UserErrorCode implements ErrorCode {
     ALREADY_REJECTED(HttpStatus.CONFLICT, "이미 승인 거절된 상태입니다"),
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 유저가 존재하지 않습니다"),
-
-        INVALID_AFFILIATION(HttpStatus.BAD_REQUEST, "소속 정보가 없습니다."),
-
-        USER_GRADE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원의 등급 정보를 찾을 수 없습니다"),
-
-        ;
+    INVALID_AFFILIATION(HttpStatus.BAD_REQUEST, "소속 정보가 없습니다."),
+    USER_GRADE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회원의 등급 정보를 찾을 수 없습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/user/src/main/java/com/klp/user/domain/repository/UserAddressRepository.java
+++ b/user/src/main/java/com/klp/user/domain/repository/UserAddressRepository.java
@@ -1,0 +1,15 @@
+package com.klp.user.domain.repository;
+
+import com.klp.user.domain.entity.UserAddress;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserAddressRepository {
+
+    UserAddress save(UserAddress userAddress);
+
+    Optional<UserAddress> findById(UUID userAddressId);
+
+    List<UserAddress> findByUserId(Long userId);
+}

--- a/user/src/main/java/com/klp/user/infrastructure/repository/UserAddressJpaRepository.java
+++ b/user/src/main/java/com/klp/user/infrastructure/repository/UserAddressJpaRepository.java
@@ -1,0 +1,11 @@
+package com.klp.user.infrastructure.repository;
+
+import com.klp.user.domain.entity.UserAddress;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserAddressJpaRepository extends JpaRepository<UserAddress, UUID> {
+
+    List<UserAddress> findByUser_UserId(Long userId);
+}

--- a/user/src/main/java/com/klp/user/infrastructure/repository/UserAddressRepositoryImpl.java
+++ b/user/src/main/java/com/klp/user/infrastructure/repository/UserAddressRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.klp.user.infrastructure.repository;
+
+import com.klp.user.domain.entity.UserAddress;
+import com.klp.user.domain.repository.UserAddressRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserAddressRepositoryImpl implements UserAddressRepository {
+
+    private final UserAddressJpaRepository userAddressJpaRepository;
+
+    @Override
+    public UserAddress save(UserAddress userAddress) {
+        return userAddressJpaRepository.save(userAddress);
+    }
+
+    @Override
+    public Optional<UserAddress> findById(UUID userAddressId) {
+        return userAddressJpaRepository.findById(userAddressId);
+    }
+
+    @Override
+    public List<UserAddress> findByUserId(Long userId) {
+        return userAddressJpaRepository.findByUser_UserId(userId);
+    }
+}

--- a/user/src/main/java/com/klp/user/presentation/UserAddressController.java
+++ b/user/src/main/java/com/klp/user/presentation/UserAddressController.java
@@ -1,0 +1,77 @@
+package com.klp.user.presentation;
+
+import com.klp.user.application.UserFacade;
+import com.klp.user.presentation.dto.request.UserAddressCreateRequest;
+import com.klp.user.presentation.dto.response.UserAddressListResponse;
+import com.klp.user.presentation.dto.response.UserAddressResponse;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/users/address")
+@RequiredArgsConstructor
+public class UserAddressController {
+
+    private final UserFacade userFacade;
+
+    @GetMapping("/{userId}/{addressId}")
+    @PreAuthorize("hasRole('MASTER') or (hasRole('CUSTOMER') and #userId == authentication.principal.userId)")
+    public ResponseEntity<UserAddressResponse> getUserAddress(
+        @PathVariable(name = "userId") Long userId,
+        @PathVariable(name = "addressId") UUID addressId
+    ) {
+        UserAddressResponse response = userFacade.getUserAddress(addressId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{userId}")
+    @PreAuthorize("hasRole('MASTER') or (hasRole('CUSTOMER') and #userId == authentication.principal.userId)")
+    public ResponseEntity<UserAddressListResponse> getUserAddressList(
+        @PathVariable(name = "userId") Long userId
+    ) {
+        UserAddressListResponse response = userFacade.getUserAddressList(userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{userId}")
+    @PreAuthorize("hasRole('MASTER') or (hasRole('CUSTOMER') and #userId == authentication.principal.userId)")
+    public ResponseEntity<Void> createUserAddress(
+        @PathVariable(name = "userId") Long userId,
+        @Valid @RequestBody UserAddressCreateRequest request
+    ) {
+        userFacade.createUserAddress(request.toCommand(userId));
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/{userId}/{addressId}")
+    @PreAuthorize("hasRole('MASTER') or (hasRole('CUSTOMER') and #userId == authentication.principal.userId)")
+    public ResponseEntity<Void> updateUserAddress(
+        @PathVariable(name = "userId") Long userId,
+        @PathVariable(name = "addressId") UUID addressId,
+        @Valid @RequestBody UserAddressCreateRequest request
+    ) {
+        userFacade.updateUserAddress(addressId, request.toCommand(userId));
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{userId}/{addressId}")
+    @PreAuthorize("hasRole('MASTER') or (hasRole('CUSTOMER') and #userId == authentication.principal.userId)")
+    public ResponseEntity<Void> deleteUserAddress(
+        @PathVariable(name = "userId") Long userId,
+        @PathVariable(name = "addressId") UUID addressId
+    ) {
+        userFacade.deleteUserAddress(addressId, userId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/user/src/main/java/com/klp/user/presentation/dto/request/UserAddressCreateRequest.java
+++ b/user/src/main/java/com/klp/user/presentation/dto/request/UserAddressCreateRequest.java
@@ -1,0 +1,26 @@
+package com.klp.user.presentation.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.klp.user.application.command.UserAddressCreateCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record UserAddressCreateRequest(
+    @NotNull(message = "허브 ID는 필수 입력값입니다")
+    UUID hubId,
+    @NotBlank(message = "주소는 필수 입력값입니다")
+    String address,
+    String detail,
+    @JsonProperty("is_default")
+    boolean isDefault,
+    @NotNull(message = "위도는 필수 입력값입니다")
+    Double latitude,
+    @NotNull(message = "경도는 필수 입력값입니다")
+    Double longitude
+) {
+
+    public UserAddressCreateCommand toCommand(Long userId) {
+        return new UserAddressCreateCommand(userId, hubId, address, detail, isDefault, latitude, longitude);
+    }
+}

--- a/user/src/main/java/com/klp/user/presentation/dto/response/UserAddressListResponse.java
+++ b/user/src/main/java/com/klp/user/presentation/dto/response/UserAddressListResponse.java
@@ -1,0 +1,12 @@
+package com.klp.user.presentation.dto.response;
+
+import java.util.List;
+
+public record UserAddressListResponse(
+    List<UserAddressResponse> addresses
+) {
+
+    public static UserAddressListResponse of(List<UserAddressResponse> addresses) {
+        return new UserAddressListResponse(addresses);
+    }
+}

--- a/user/src/main/java/com/klp/user/presentation/dto/response/UserAddressResponse.java
+++ b/user/src/main/java/com/klp/user/presentation/dto/response/UserAddressResponse.java
@@ -1,0 +1,27 @@
+package com.klp.user.presentation.dto.response;
+
+import com.klp.user.domain.entity.UserAddress;
+import java.util.UUID;
+
+public record UserAddressResponse(
+    UUID userAddressId,
+    UUID hubId,
+    String address,
+    String detail,
+    boolean isDefault,
+    Double latitude,
+    Double longitude
+) {
+
+    public static UserAddressResponse from(UserAddress userAddress) {
+        return new UserAddressResponse(
+            userAddress.getUserAddressId(),
+            userAddress.getHubId(),
+            userAddress.getAddress(),
+            userAddress.getDetail(),
+            userAddress.isDefault(),
+            userAddress.getLatitude(),
+            userAddress.getLongitude()
+        );
+    }
+}

--- a/user/src/test/java/com/klp/global/authorization/CustomWithMockUser.java
+++ b/user/src/test/java/com/klp/global/authorization/CustomWithMockUser.java
@@ -1,6 +1,5 @@
 package com.klp.global.authorization;
 
-import com.klp.user.domain.enums.UserRole;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import org.springframework.security.test.context.support.WithSecurityContext;
@@ -13,5 +12,5 @@ public @interface CustomWithMockUser {
 
     String username() default "testUser";
 
-    UserRole authority() default UserRole.MASTER;
+    String authority() default "MASTER";
 }

--- a/user/src/test/java/com/klp/global/authorization/CustomWithMockUser.java
+++ b/user/src/test/java/com/klp/global/authorization/CustomWithMockUser.java
@@ -1,0 +1,17 @@
+package com.klp.global.authorization;
+
+import com.klp.user.domain.enums.UserRole;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = CustomWithMockUserSecurityContextFactory.class)
+public @interface CustomWithMockUser {
+
+    long userId() default 1L;
+
+    String username() default "testUser";
+
+    UserRole authority() default UserRole.MASTER;
+}

--- a/user/src/test/java/com/klp/global/authorization/CustomWithMockUserSecurityContextFactory.java
+++ b/user/src/test/java/com/klp/global/authorization/CustomWithMockUserSecurityContextFactory.java
@@ -1,0 +1,27 @@
+package com.klp.global.authorization;
+
+import com.klp.global.security.model.UserDetailsImpl;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class CustomWithMockUserSecurityContextFactory implements WithSecurityContextFactory<CustomWithMockUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(CustomWithMockUser annotation) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        UserDetailsImpl principal = new UserDetailsImpl(
+            annotation.userId(),
+            annotation.username(),
+            annotation.authority().name()
+        );
+        UsernamePasswordAuthenticationToken authentication =
+            new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+
+        context.setAuthentication(authentication);
+        return context;
+    }
+
+}

--- a/user/src/test/java/com/klp/global/authorization/CustomWithMockUserSecurityContextFactory.java
+++ b/user/src/test/java/com/klp/global/authorization/CustomWithMockUserSecurityContextFactory.java
@@ -15,7 +15,7 @@ public class CustomWithMockUserSecurityContextFactory implements WithSecurityCon
         UserDetailsImpl principal = new UserDetailsImpl(
             annotation.userId(),
             annotation.username(),
-            annotation.authority().name()
+            annotation.authority()
         );
         UsernamePasswordAuthenticationToken authentication =
             new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());

--- a/user/src/test/java/com/klp/user/presentation/UserAddressControllerTest.java
+++ b/user/src/test/java/com/klp/user/presentation/UserAddressControllerTest.java
@@ -19,7 +19,6 @@ import com.klp.global.exception.GlobalExceptionHandler;
 import com.klp.global.security.config.SecurityConfig;
 import com.klp.global.security.filter.AuthorizationFilter;
 import com.klp.user.application.UserFacade;
-import com.klp.user.domain.enums.UserRole;
 import com.klp.user.presentation.dto.request.UserAddressCreateRequest;
 import com.klp.user.presentation.dto.response.UserAddressListResponse;
 import com.klp.user.presentation.dto.response.UserAddressResponse;
@@ -54,7 +53,7 @@ class UserAddressControllerTest {
 
         @Test
         @DisplayName("MASTER 권한으로 다른 사용자의 주소를 조회할 수 있다")
-        @CustomWithMockUser(userId = 1L, authority = UserRole.MASTER)
+        @CustomWithMockUser(userId = 1L, authority = "MASTER")
         void getUserAddress_asMaster_success() throws Exception {
             // given
             Long userId = 2L;
@@ -87,7 +86,7 @@ class UserAddressControllerTest {
 
         @Test
         @DisplayName("CUSTOMER 권한으로 본인의 주소를 조회할 수 있다")
-        @CustomWithMockUser(userId = 1L, authority = UserRole.CUSTOMER)
+        @CustomWithMockUser(userId = 1L, authority = "CUSTOMER")
         void getUserAddress_asCustomerOwn_success() throws Exception {
             // given
             Long userId = 1L;
@@ -115,7 +114,7 @@ class UserAddressControllerTest {
 
         @Test
         @DisplayName("CUSTOMER 권한으로 다른 사용자의 주소를 조회하면 403 에러가 발생한다")
-        @CustomWithMockUser(userId = 1L, authority = UserRole.CUSTOMER)
+        @CustomWithMockUser(userId = 1L, authority = "CUSTOMER")
         void getUserAddress_asCustomerOther_forbidden() throws Exception {
             // given
             Long userId = 2L;
@@ -135,7 +134,7 @@ class UserAddressControllerTest {
 
         @Test
         @DisplayName("MASTER 권한으로 다른 사용자의 주소 목록을 조회할 수 있다")
-        @CustomWithMockUser(userId = 1L, authority = UserRole.MASTER)
+        @CustomWithMockUser(userId = 1L, authority = "MASTER")
         void getUserAddressList_asMaster_success() throws Exception {
             // given
             Long userId = 2L;
@@ -169,7 +168,7 @@ class UserAddressControllerTest {
 
         @Test
         @DisplayName("CUSTOMER 권한으로 본인의 주소 목록을 조회할 수 있다")
-        @CustomWithMockUser(userId = 1L, authority = UserRole.CUSTOMER)
+        @CustomWithMockUser(userId = 1L, authority = "CUSTOMER")
         void getUserAddressList_asCustomerOwn_success() throws Exception {
             // given
             Long userId = 1L;
@@ -187,7 +186,7 @@ class UserAddressControllerTest {
 
         @Test
         @DisplayName("CUSTOMER 권한으로 다른 사용자의 주소 목록을 조회하면 403 에러가 발생한다")
-        @CustomWithMockUser(userId = 1L, authority = UserRole.CUSTOMER)
+        @CustomWithMockUser(userId = 1L, authority = "CUSTOMER")
         void getUserAddressList_asCustomerOther_forbidden() throws Exception {
             // given
             Long userId = 2L;
@@ -206,7 +205,7 @@ class UserAddressControllerTest {
 
         @Test
         @DisplayName("MASTER 권한으로 다른 사용자의 주소를 생성할 수 있다")
-        @CustomWithMockUser(userId = 1L, authority = UserRole.MASTER)
+        @CustomWithMockUser(userId = 1L, authority = "MASTER")
         void createUserAddress_asMaster_success() throws Exception {
             // given
             Long userId = 2L;
@@ -234,7 +233,7 @@ class UserAddressControllerTest {
 
         @Test
         @DisplayName("CUSTOMER 권한으로 본인의 주소를 생성할 수 있다")
-        @CustomWithMockUser(userId = 1L, authority = UserRole.CUSTOMER)
+        @CustomWithMockUser(userId = 1L, authority = "CUSTOMER")
         void createUserAddress_asCustomerOwn_success() throws Exception {
             // given
             Long userId = 1L;
@@ -262,7 +261,7 @@ class UserAddressControllerTest {
 
         @Test
         @DisplayName("CUSTOMER 권한으로 다른 사용자의 주소를 생성하면 403 에러가 발생한다")
-        @CustomWithMockUser(userId = 1L, authority = UserRole.CUSTOMER)
+        @CustomWithMockUser(userId = 1L, authority = "CUSTOMER")
         void createUserAddress_asCustomerOther_forbidden() throws Exception {
             // given
             Long userId = 2L;
@@ -288,7 +287,7 @@ class UserAddressControllerTest {
 
         @Test
         @DisplayName("필수 필드가 누락되면 400 에러가 발생한다")
-        @CustomWithMockUser(userId = 1L, authority = UserRole.CUSTOMER)
+        @CustomWithMockUser(userId = 1L, authority = "CUSTOMER")
         void createUserAddress_withInvalidRequest_badRequest() throws Exception {
             // given
             Long userId = 1L;
@@ -318,7 +317,7 @@ class UserAddressControllerTest {
 
         @Test
         @DisplayName("MASTER 권한으로 다른 사용자의 주소를 수정할 수 있다")
-        @CustomWithMockUser(userId = 1L, authority = UserRole.MASTER)
+        @CustomWithMockUser(userId = 1L, authority = "MASTER")
         void updateUserAddress_asMaster_success() throws Exception {
             // given
             Long userId = 2L;
@@ -347,7 +346,7 @@ class UserAddressControllerTest {
 
         @Test
         @DisplayName("CUSTOMER 권한으로 본인의 주소를 수정할 수 있다")
-        @CustomWithMockUser(userId = 1L, authority = UserRole.CUSTOMER)
+        @CustomWithMockUser(userId = 1L, authority = "CUSTOMER")
         void updateUserAddress_asCustomerOwn_success() throws Exception {
             // given
             Long userId = 1L;
@@ -376,7 +375,7 @@ class UserAddressControllerTest {
 
         @Test
         @DisplayName("CUSTOMER 권한으로 다른 사용자의 주소를 수정하면 403 에러가 발생한다")
-        @CustomWithMockUser(userId = 1L, authority = UserRole.CUSTOMER)
+        @CustomWithMockUser(userId = 1L, authority = "CUSTOMER")
         void updateUserAddress_asCustomerOther_forbidden() throws Exception {
             // given
             Long userId = 2L;
@@ -408,7 +407,7 @@ class UserAddressControllerTest {
 
         @Test
         @DisplayName("MASTER 권한으로 다른 사용자의 주소를 삭제할 수 있다")
-        @CustomWithMockUser(userId = 1L, authority = UserRole.MASTER)
+        @CustomWithMockUser(userId = 1L, authority = "MASTER")
         void deleteUserAddress_asMaster_success() throws Exception {
             // given
             Long userId = 2L;
@@ -425,7 +424,7 @@ class UserAddressControllerTest {
 
         @Test
         @DisplayName("CUSTOMER 권한으로 본인의 주소를 삭제할 수 있다")
-        @CustomWithMockUser(userId = 1L, authority = UserRole.CUSTOMER)
+        @CustomWithMockUser(userId = 1L, authority = "CUSTOMER")
         void deleteUserAddress_asCustomerOwn_success() throws Exception {
             // given
             Long userId = 1L;
@@ -442,7 +441,7 @@ class UserAddressControllerTest {
 
         @Test
         @DisplayName("CUSTOMER 권한으로 다른 사용자의 주소를 삭제하면 403 에러가 발생한다")
-        @CustomWithMockUser(userId = 1L, authority = UserRole.CUSTOMER)
+        @CustomWithMockUser(userId = 1L, authority = "CUSTOMER")
         void deleteUserAddress_asCustomerOther_forbidden() throws Exception {
             // given
             Long userId = 2L;

--- a/user/src/test/java/com/klp/user/presentation/UserAddressControllerTest.java
+++ b/user/src/test/java/com/klp/user/presentation/UserAddressControllerTest.java
@@ -1,0 +1,458 @@
+package com.klp.user.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.klp.global.authorization.CustomWithMockUser;
+import com.klp.global.exception.GlobalExceptionHandler;
+import com.klp.global.security.config.SecurityConfig;
+import com.klp.global.security.filter.AuthorizationFilter;
+import com.klp.user.application.UserFacade;
+import com.klp.user.domain.enums.UserRole;
+import com.klp.user.presentation.dto.request.UserAddressCreateRequest;
+import com.klp.user.presentation.dto.response.UserAddressListResponse;
+import com.klp.user.presentation.dto.response.UserAddressResponse;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(UserAddressController.class)
+@Import({SecurityConfig.class, AuthorizationFilter.class, GlobalExceptionHandler.class})
+class UserAddressControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private UserFacade userFacade;
+
+    @Nested
+    @DisplayName("주소 단건 조회 테스트")
+    class GetUserAddressTest {
+
+        @Test
+        @DisplayName("MASTER 권한으로 다른 사용자의 주소를 조회할 수 있다")
+        @CustomWithMockUser(userId = 1L, authority = UserRole.MASTER)
+        void getUserAddress_asMaster_success() throws Exception {
+            // given
+            Long userId = 2L;
+            UUID addressId = UUID.randomUUID();
+            UUID hubId = UUID.randomUUID();
+
+            UserAddressResponse response = new UserAddressResponse(
+                addressId,
+                hubId,
+                "테스트 주소",
+                "101동 101호",
+                true,
+                37.123456,
+                127.123456
+            );
+
+            when(userFacade.getUserAddress(addressId)).thenReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/v1/users/address/{userId}/{addressId}", userId, addressId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userAddressId").value(addressId.toString()))
+                .andExpect(jsonPath("$.hubId").value(hubId.toString()))
+                .andExpect(jsonPath("$.address").value("테스트 주소"))
+                .andExpect(jsonPath("$.detail").value("101동 101호"))
+                .andExpect(jsonPath("$.isDefault").value(true));
+
+            verify(userFacade, times(1)).getUserAddress(addressId);
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 권한으로 본인의 주소를 조회할 수 있다")
+        @CustomWithMockUser(userId = 1L, authority = UserRole.CUSTOMER)
+        void getUserAddress_asCustomerOwn_success() throws Exception {
+            // given
+            Long userId = 1L;
+            UUID addressId = UUID.randomUUID();
+            UUID hubId = UUID.randomUUID();
+
+            UserAddressResponse response = new UserAddressResponse(
+                addressId,
+                hubId,
+                "테스트 주소",
+                "101동 101호",
+                true,
+                37.123456,
+                127.123456
+            );
+
+            when(userFacade.getUserAddress(addressId)).thenReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/v1/users/address/{userId}/{addressId}", userId, addressId))
+                .andExpect(status().isOk());
+
+            verify(userFacade, times(1)).getUserAddress(addressId);
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 권한으로 다른 사용자의 주소를 조회하면 403 에러가 발생한다")
+        @CustomWithMockUser(userId = 1L, authority = UserRole.CUSTOMER)
+        void getUserAddress_asCustomerOther_forbidden() throws Exception {
+            // given
+            Long userId = 2L;
+            UUID addressId = UUID.randomUUID();
+
+            // when & then
+            mockMvc.perform(get("/v1/users/address/{userId}/{addressId}", userId, addressId))
+                .andExpect(status().isForbidden());
+
+            verify(userFacade, times(0)).getUserAddress(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("주소 목록 조회 테스트")
+    class GetUserAddressListTest {
+
+        @Test
+        @DisplayName("MASTER 권한으로 다른 사용자의 주소 목록을 조회할 수 있다")
+        @CustomWithMockUser(userId = 1L, authority = UserRole.MASTER)
+        void getUserAddressList_asMaster_success() throws Exception {
+            // given
+            Long userId = 2L;
+            UUID addressId = UUID.randomUUID();
+            UUID hubId = UUID.randomUUID();
+
+            UserAddressResponse addressResponse = new UserAddressResponse(
+                addressId,
+                hubId,
+                "테스트 주소",
+                "101동 101호",
+                true,
+                37.123456,
+                127.123456
+            );
+
+            UserAddressListResponse response = new UserAddressListResponse(
+                List.of(addressResponse)
+            );
+
+            when(userFacade.getUserAddressList(userId)).thenReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/v1/users/address/{userId}", userId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.addresses").isArray())
+                .andExpect(jsonPath("$.addresses[0].address").value("테스트 주소"));
+
+            verify(userFacade, times(1)).getUserAddressList(userId);
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 권한으로 본인의 주소 목록을 조회할 수 있다")
+        @CustomWithMockUser(userId = 1L, authority = UserRole.CUSTOMER)
+        void getUserAddressList_asCustomerOwn_success() throws Exception {
+            // given
+            Long userId = 1L;
+
+            UserAddressListResponse response = new UserAddressListResponse(List.of());
+
+            when(userFacade.getUserAddressList(userId)).thenReturn(response);
+
+            // when & then
+            mockMvc.perform(get("/v1/users/address/{userId}", userId))
+                .andExpect(status().isOk());
+
+            verify(userFacade, times(1)).getUserAddressList(userId);
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 권한으로 다른 사용자의 주소 목록을 조회하면 403 에러가 발생한다")
+        @CustomWithMockUser(userId = 1L, authority = UserRole.CUSTOMER)
+        void getUserAddressList_asCustomerOther_forbidden() throws Exception {
+            // given
+            Long userId = 2L;
+
+            // when & then
+            mockMvc.perform(get("/v1/users/address/{userId}", userId))
+                .andExpect(status().isForbidden());
+
+            verify(userFacade, times(0)).getUserAddressList(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("주소 생성 테스트")
+    class CreateUserAddressTest {
+
+        @Test
+        @DisplayName("MASTER 권한으로 다른 사용자의 주소를 생성할 수 있다")
+        @CustomWithMockUser(userId = 1L, authority = UserRole.MASTER)
+        void createUserAddress_asMaster_success() throws Exception {
+            // given
+            Long userId = 2L;
+            UUID hubId = UUID.randomUUID();
+
+            UserAddressCreateRequest request = new UserAddressCreateRequest(
+                hubId,
+                "테스트 주소",
+                "101동 101호",
+                true,
+                37.123456,
+                127.123456
+            );
+
+            doNothing().when(userFacade).createUserAddress(any());
+
+            // when & then
+            mockMvc.perform(post("/v1/users/address/{userId}", userId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+            verify(userFacade, times(1)).createUserAddress(any());
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 권한으로 본인의 주소를 생성할 수 있다")
+        @CustomWithMockUser(userId = 1L, authority = UserRole.CUSTOMER)
+        void createUserAddress_asCustomerOwn_success() throws Exception {
+            // given
+            Long userId = 1L;
+            UUID hubId = UUID.randomUUID();
+
+            UserAddressCreateRequest request = new UserAddressCreateRequest(
+                hubId,
+                "테스트 주소",
+                "101동 101호",
+                true,
+                37.123456,
+                127.123456
+            );
+
+            doNothing().when(userFacade).createUserAddress(any());
+
+            // when & then
+            mockMvc.perform(post("/v1/users/address/{userId}", userId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+            verify(userFacade, times(1)).createUserAddress(any());
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 권한으로 다른 사용자의 주소를 생성하면 403 에러가 발생한다")
+        @CustomWithMockUser(userId = 1L, authority = UserRole.CUSTOMER)
+        void createUserAddress_asCustomerOther_forbidden() throws Exception {
+            // given
+            Long userId = 2L;
+            UUID hubId = UUID.randomUUID();
+
+            UserAddressCreateRequest request = new UserAddressCreateRequest(
+                hubId,
+                "테스트 주소",
+                "101동 101호",
+                true,
+                37.123456,
+                127.123456
+            );
+
+            // when & then
+            mockMvc.perform(post("/v1/users/address/{userId}", userId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden());
+
+            verify(userFacade, times(0)).createUserAddress(any());
+        }
+
+        @Test
+        @DisplayName("필수 필드가 누락되면 400 에러가 발생한다")
+        @CustomWithMockUser(userId = 1L, authority = UserRole.CUSTOMER)
+        void createUserAddress_withInvalidRequest_badRequest() throws Exception {
+            // given
+            Long userId = 1L;
+
+            UserAddressCreateRequest request = new UserAddressCreateRequest(
+                null, // hubId 누락
+                "", // address 빈 문자열
+                "101동 101호",
+                true,
+                null, // latitude 누락
+                127.123456
+            );
+
+            // when & then
+            mockMvc.perform(post("/v1/users/address/{userId}", userId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+
+            verify(userFacade, times(0)).createUserAddress(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("주소 수정 테스트")
+    class UpdateUserAddressTest {
+
+        @Test
+        @DisplayName("MASTER 권한으로 다른 사용자의 주소를 수정할 수 있다")
+        @CustomWithMockUser(userId = 1L, authority = UserRole.MASTER)
+        void updateUserAddress_asMaster_success() throws Exception {
+            // given
+            Long userId = 2L;
+            UUID addressId = UUID.randomUUID();
+            UUID hubId = UUID.randomUUID();
+
+            UserAddressCreateRequest request = new UserAddressCreateRequest(
+                hubId,
+                "테스트 주소",
+                "102동 102호",
+                false,
+                37.654321,
+                127.654321
+            );
+
+            doNothing().when(userFacade).updateUserAddress(eq(addressId), any());
+
+            // when & then
+            mockMvc.perform(patch("/v1/users/address/{userId}/{addressId}", userId, addressId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+            verify(userFacade, times(1)).updateUserAddress(eq(addressId), any());
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 권한으로 본인의 주소를 수정할 수 있다")
+        @CustomWithMockUser(userId = 1L, authority = UserRole.CUSTOMER)
+        void updateUserAddress_asCustomerOwn_success() throws Exception {
+            // given
+            Long userId = 1L;
+            UUID addressId = UUID.randomUUID();
+            UUID hubId = UUID.randomUUID();
+
+            UserAddressCreateRequest request = new UserAddressCreateRequest(
+                hubId,
+                "테스트 주소",
+                "102동 102호",
+                false,
+                37.654321,
+                127.654321
+            );
+
+            doNothing().when(userFacade).updateUserAddress(eq(addressId), any());
+
+            // when & then
+            mockMvc.perform(patch("/v1/users/address/{userId}/{addressId}", userId, addressId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+            verify(userFacade, times(1)).updateUserAddress(eq(addressId), any());
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 권한으로 다른 사용자의 주소를 수정하면 403 에러가 발생한다")
+        @CustomWithMockUser(userId = 1L, authority = UserRole.CUSTOMER)
+        void updateUserAddress_asCustomerOther_forbidden() throws Exception {
+            // given
+            Long userId = 2L;
+            UUID addressId = UUID.randomUUID();
+            UUID hubId = UUID.randomUUID();
+
+            UserAddressCreateRequest request = new UserAddressCreateRequest(
+                hubId,
+                "테스트 주소",
+                "102동 102호",
+                false,
+                37.654321,
+                127.654321
+            );
+
+            // when & then
+            mockMvc.perform(patch("/v1/users/address/{userId}/{addressId}", userId, addressId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden());
+
+            verify(userFacade, times(0)).updateUserAddress(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("주소 삭제 테스트")
+    class DeleteUserAddressTest {
+
+        @Test
+        @DisplayName("MASTER 권한으로 다른 사용자의 주소를 삭제할 수 있다")
+        @CustomWithMockUser(userId = 1L, authority = UserRole.MASTER)
+        void deleteUserAddress_asMaster_success() throws Exception {
+            // given
+            Long userId = 2L;
+            UUID addressId = UUID.randomUUID();
+
+            doNothing().when(userFacade).deleteUserAddress(addressId, userId);
+
+            // when & then
+            mockMvc.perform(delete("/v1/users/address/{userId}/{addressId}", userId, addressId))
+                .andExpect(status().isOk());
+
+            verify(userFacade, times(1)).deleteUserAddress(addressId, userId);
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 권한으로 본인의 주소를 삭제할 수 있다")
+        @CustomWithMockUser(userId = 1L, authority = UserRole.CUSTOMER)
+        void deleteUserAddress_asCustomerOwn_success() throws Exception {
+            // given
+            Long userId = 1L;
+            UUID addressId = UUID.randomUUID();
+
+            doNothing().when(userFacade).deleteUserAddress(addressId, userId);
+
+            // when & then
+            mockMvc.perform(delete("/v1/users/address/{userId}/{addressId}", userId, addressId))
+                .andExpect(status().isOk());
+
+            verify(userFacade, times(1)).deleteUserAddress(addressId, userId);
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 권한으로 다른 사용자의 주소를 삭제하면 403 에러가 발생한다")
+        @CustomWithMockUser(userId = 1L, authority = UserRole.CUSTOMER)
+        void deleteUserAddress_asCustomerOther_forbidden() throws Exception {
+            // given
+            Long userId = 2L;
+            UUID addressId = UUID.randomUUID();
+
+            // when & then
+            mockMvc.perform(delete("/v1/users/address/{userId}/{addressId}", userId, addressId))
+                .andExpect(status().isForbidden());
+
+            verify(userFacade, times(0)).deleteUserAddress(any(), any());
+        }
+    }
+}

--- a/user/src/test/java/com/klp/user/presentation/UserControllerTest.java
+++ b/user/src/test/java/com/klp/user/presentation/UserControllerTest.java
@@ -52,25 +52,4 @@ class UserControllerTest {
                 .andExpect(status().isOk());
         }
     }
-
-    // ================== 아래 쪽 권한이 필요한 테스트의 경우 현재 커스텀 UserDetailsImpl을 사용하기 때문에 테스트 불가 ===================
-    // ==================@WitMockUser로는 커스텀 UserDetailsImpl을 가져올 수 없어 별도의 어노테이션을 구성해서 사용 예정 ================
-
-    @Nested
-    @DisplayName("본인 정보 상세 조회 테스트")
-    class getMyDetailsTest {
-
-    }
-
-    @Nested
-    @DisplayName("유저 목록 조회 테스트")
-    class getUserListTest {
-
-    }
-
-    @Nested
-    @DisplayName("유저 정보 변경 테스트")
-    class updateUserInfo {
-
-    }
 }


### PR DESCRIPTION
## PR 내용
- [feat: UserAddress 엔티티 작성](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/aecf77b5b7b0a8cb6a2a965d0bea4921143ae85b)
  - 회원 주소 관련 엔티티를 작성했습니다.
  - 상세 주소의 경우 초기에는 Null을 하용하지 않도록 작성했지만, 상세 주소가 없는 고소 존재할 수 있다고 생각해 Nullable하게 변경했습니다.

- [feat: 유저 주소 관련 기능 추가](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/6893f16f1451a77bc0204bfbf9cbbe99d1de91d3)
  - 컨트롤러에서 권한이 CUSTOMER일 경우, PathVariable의 userId와 SecurityContextHolder의 id값을 비교해 본인여부를 검증합니다.
  - 기본적인 CRUD 구성을 진행했습니다.

- [test: 인가 테스트를 위한 커스텀 어노테이션 및 ContextFactory 작성](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/85885344606e089e46305501cc4fd9ec9d47470d)
  - 커스텀한 UserDetails를 이용하고있기 때문에, 테스트 코드에서 기존의 `@WithMockUser`을 이용하여도 SecurityContextHolder에 인증 객체가 담기지 않는 문제를 해결했습니다.
  - `@CustomWithMockUser`: 현재 프로젝트 구성에 맞춰, userId, username, userRole 등을 직접 설정해 테스트를 진행할 수 있습니다.
  - `CustomWithMockUserSecurityContextFactory`: 커스텀한 UserDetails를 Test용 SecurityContext에 담아 테스트용 인증 객체를 사용할 수 있습니다.

## 리뷰 포인트
- 현재 주소 생성시에 근처 hubId도 함께 받아서 생성하도록 되어 있습니다. 주소를 기반으로 주소 근처의 hubId를 확인해서 서버에서 직접 넣는 방식으로의 변경이 좋을까요?