### PR TITLE
feat: 결제 승인, 취소, 실패 관련 이벤트 처리 및 아웃박스 패턴 구현

### DIFF
--- a/payment/build.gradle
+++ b/payment/build.gradle
@@ -46,6 +46,20 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    //trace
+    implementation 'io.micrometer:micrometer-tracing'
+    implementation("io.micrometer:micrometer-tracing-bridge-otel")
+    implementation("io.opentelemetry:opentelemetry-exporter-otlp")
+
+    //metric
+    implementation "org.springframework.boot:spring-boot-starter-actuator"
+    implementation "io.micrometer:micrometer-registry-prometheus"
+
+    //log
+    implementation "org.springframework.boot:spring-boot-starter-logging"
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-logback-mdc-1.0:2.7.0-alpha'
+    implementation 'io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0:2.10.0-alpha'
 }
 
 dependencyManagement {

--- a/payment/src/main/java/com/klp/payment/global/config/OpenTelemetryAppenderInitializer.java
+++ b/payment/src/main/java/com/klp/payment/global/config/OpenTelemetryAppenderInitializer.java
@@ -1,0 +1,21 @@
+package com.klp.payment.global.config;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OpenTelemetryAppenderInitializer implements InitializingBean {
+
+    private final OpenTelemetry openTelemetry;
+
+    public OpenTelemetryAppenderInitializer(OpenTelemetry openTelemetry) {
+        this.openTelemetry = openTelemetry;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        OpenTelemetryAppender.install(this.openTelemetry);
+    }
+}

--- a/payment/src/main/java/com/klp/payment/global/config/ScheduleConfig.java
+++ b/payment/src/main/java/com/klp/payment/global/config/ScheduleConfig.java
@@ -1,0 +1,10 @@
+package com.klp.payment.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class ScheduleConfig {
+
+}

--- a/payment/src/main/java/com/klp/payment/global/exception/PaymentErrorCode.java
+++ b/payment/src/main/java/com/klp/payment/global/exception/PaymentErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum PaymentErrorCode implements ErrorCode {
-    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 결제를 찾을 수 없습니다");
+    PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 결제를 찾을 수 없습니다"),
+    EVENT_SERIALIZATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이벤트 직렬화에 실패했습니다");
 
     private final HttpStatus status;
     private final String message;

--- a/payment/src/main/java/com/klp/payment/payment/application/PaymentOutboxService.java
+++ b/payment/src/main/java/com/klp/payment/payment/application/PaymentOutboxService.java
@@ -2,6 +2,8 @@ package com.klp.payment.payment.application;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.klp.payment.global.exception.BusinessException;
+import com.klp.payment.global.exception.PaymentErrorCode;
 import com.klp.payment.payment.domain.event.PaymentApprovedEvent;
 import com.klp.payment.payment.domain.event.PaymentCancelledEvent;
 import com.klp.payment.payment.domain.outbox.PaymentOutbox;
@@ -37,7 +39,7 @@ public class PaymentOutboxService {
 
         } catch (JsonProcessingException e) {
             log.error("이벤트 직렬화 실패: orderId={}", orderId, e);
-            throw new RuntimeException("이벤트 직렬화 실패", e);
+            throw new BusinessException(PaymentErrorCode.EVENT_SERIALIZATION_FAILED);
         }
     }
 

--- a/payment/src/main/java/com/klp/payment/payment/application/PaymentOutboxService.java
+++ b/payment/src/main/java/com/klp/payment/payment/application/PaymentOutboxService.java
@@ -6,6 +6,7 @@ import com.klp.payment.global.exception.BusinessException;
 import com.klp.payment.global.exception.PaymentErrorCode;
 import com.klp.payment.payment.domain.event.PaymentApprovedEvent;
 import com.klp.payment.payment.domain.event.PaymentCancelledEvent;
+import com.klp.payment.payment.domain.event.PaymentFailedEvent;
 import com.klp.payment.payment.domain.outbox.PaymentOutbox;
 import com.klp.payment.payment.domain.repository.PaymentOutboxRepository;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,10 @@ public class PaymentOutboxService {
 
     public void savePaymentCancelledEvent(PaymentCancelledEvent event) {
         saveOutbox(event.orderId(), "PaymentCancelledEvent", event);
+    }
+
+    public void savePaymentFailedEvent(PaymentFailedEvent event) {
+        saveOutbox(event.orderId(), "PaymentFailedEvent", event);
     }
 
     private void saveOutbox(java.util.UUID orderId, String eventType, Object event) {

--- a/payment/src/main/java/com/klp/payment/payment/application/PaymentOutboxService.java
+++ b/payment/src/main/java/com/klp/payment/payment/application/PaymentOutboxService.java
@@ -1,0 +1,44 @@
+package com.klp.payment.payment.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.klp.payment.payment.domain.event.PaymentApprovedEvent;
+import com.klp.payment.payment.domain.event.PaymentCancelledEvent;
+import com.klp.payment.payment.domain.outbox.PaymentOutbox;
+import com.klp.payment.payment.domain.repository.PaymentOutboxRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentOutboxService {
+
+    private final PaymentOutboxRepository paymentOutboxRepository;
+    private final ObjectMapper objectMapper;
+
+    public void savePaymentApprovedEvent(PaymentApprovedEvent event) {
+        saveOutbox(event.orderId(), "PaymentApprovedEvent", event);
+    }
+
+    public void savePaymentCancelledEvent(PaymentCancelledEvent event) {
+        saveOutbox(event.orderId(), "PaymentCancelledEvent", event);
+    }
+
+    private void saveOutbox(java.util.UUID orderId, String eventType, Object event) {
+        try {
+            String payload = objectMapper.writeValueAsString(event);
+
+            PaymentOutbox outbox = PaymentOutbox.create(orderId, eventType, payload);
+
+            paymentOutboxRepository.save(outbox);
+            log.info("Outbox 저장 완료: orderId={}, eventType={}", orderId, eventType);
+
+        } catch (JsonProcessingException e) {
+            log.error("이벤트 직렬화 실패: orderId={}", orderId, e);
+            throw new RuntimeException("이벤트 직렬화 실패", e);
+        }
+    }
+
+}

--- a/payment/src/main/java/com/klp/payment/payment/application/PaymentService.java
+++ b/payment/src/main/java/com/klp/payment/payment/application/PaymentService.java
@@ -167,4 +167,20 @@ public class PaymentService {
     public boolean existsByOrderId(UUID orderId) {
         return paymentRepository.existsByOrderId(orderId);
     }
+
+    /**
+     * 주문 취소로 인한 결제 취소 처리
+     */
+    @Transactional
+    public Payment cancelPaymentByOrderId(UUID orderId, String reason) {
+        Payment payment = paymentRepository.findFirstByOrderIdAndStatusApproved(orderId)
+            .orElse(null);
+
+        if (payment == null) {
+            return null;
+        }
+
+        payment.cancel(reason);
+        return payment;
+    }
 }

--- a/payment/src/main/java/com/klp/payment/payment/application/PaymentService.java
+++ b/payment/src/main/java/com/klp/payment/payment/application/PaymentService.java
@@ -9,6 +9,7 @@ import com.klp.payment.payment.application.command.CancelPaymentCommand;
 import com.klp.payment.payment.application.command.FailPaymentCommand;
 import com.klp.payment.payment.application.command.PreparePaymentCommand;
 import com.klp.payment.payment.domain.entity.Payment;
+import com.klp.payment.payment.domain.enums.CardType;
 import com.klp.payment.payment.domain.enums.PaymentMethodType;
 import com.klp.payment.payment.domain.repository.PaymentRepository;
 import com.klp.payment.payment.infrastructure.PaymentMockService;
@@ -30,6 +31,31 @@ public class PaymentService {
     private final PaymentRepository paymentRepository;
     private final PaymentMockService paymentMockService;
     private final UserClient userClient;
+
+    /**
+     * 자동 결제 흐름(결제 준비 + 결제 승인)
+     */
+    @Transactional
+    public Payment processPayment(UUID orderId, Long userId, UUID hubId, Long amount) {
+        Payment payment = Payment.create(orderId, userId, hubId, PaymentMethodType.CARD, amount);
+        paymentRepository.save(payment);
+
+        PaymentMockResult mockResult = paymentMockService.mockApprovePayment();
+
+        if (mockResult.success()) {
+            payment.approve(
+                mockResult.pgTransactionId(),
+                mockResult.billingKey(),
+                CardType.KAKAO,
+                0
+            );
+        } else {
+            payment.fail(mockResult.failReason());
+        }
+
+        return payment;
+    }
+
 
     /**
      * 결제 준비 메소드. 현재는 카드 결제만 지원
@@ -135,5 +161,10 @@ public class PaymentService {
         payment.fail(command.reason());
 
         return PaymentResponse.from(payment);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean existsByOrderId(UUID orderId) {
+        return paymentRepository.existsByOrderId(orderId);
     }
 }

--- a/payment/src/main/java/com/klp/payment/payment/application/listener/OrderEventListener.java
+++ b/payment/src/main/java/com/klp/payment/payment/application/listener/OrderEventListener.java
@@ -1,0 +1,71 @@
+package com.klp.payment.payment.application.listener;
+
+import com.klp.payment.payment.application.PaymentOutboxService;
+import com.klp.payment.payment.application.PaymentService;
+import com.klp.payment.payment.domain.entity.Payment;
+import com.klp.payment.payment.domain.event.OrderCreatedEvent;
+import com.klp.payment.payment.domain.event.PaymentApprovedEvent;
+import com.klp.payment.payment.infrastructure.kafka.config.KafkaTopicConfig;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaHandler;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@KafkaListener(
+    topics = KafkaTopicConfig.ORDER_TOPIC,
+    groupId = "payment-service-group",
+    containerFactory = "paymentKafkaListenerContainerFactory"
+)
+public class OrderEventListener {
+
+    private final PaymentService paymentService;
+    private final PaymentOutboxService outboxService;
+
+    @KafkaHandler
+    @Transactional
+    public void handleOrderCreated(OrderCreatedEvent event) {
+        log.info("주문 생성 이벤트 수신: orderId={}, amount={}", event.orderId(), event.finalOrderPrice());
+
+        if (paymentService.existsByOrderId(event.orderId())) {
+            log.info("이미 처리된 주문입니다: orderId={}", event.orderId());
+            return;
+        }
+
+        UUID hubId = event.products().isEmpty() ? null : event.products().get(0).hubId();
+        Payment payment = paymentService.processPayment(
+            event.orderId(),
+            event.userId(),
+            hubId,
+            (long) event.finalOrderPrice()
+        );
+
+        if (payment.isApproved()) {
+            String couponIdempotencyKey = UUID.randomUUID().toString();
+
+            PaymentApprovedEvent approvedEvent = PaymentApprovedEvent.from(
+                payment.getPaymentId(),
+                payment.getAmount().intValue(),
+                payment.getMethod().name(),
+                payment.getPaidAt(),
+                event,
+                couponIdempotencyKey
+            );
+
+            outboxService.savePaymentApprovedEvent(approvedEvent);
+            log.info("결제 승인 완료: paymentId={}", payment.getPaymentId());
+        } else {
+            log.warn("결제 실패: orderId={}", event.orderId());
+        }
+    }
+
+    @KafkaHandler(isDefault = true)
+    public void handleUnknown(Object event) {
+        log.warn("알 수 없는 이벤트 타입 수신: {}", event.getClass().getSimpleName());
+    }
+}

--- a/payment/src/main/java/com/klp/payment/payment/application/listener/OrderEventListener.java
+++ b/payment/src/main/java/com/klp/payment/payment/application/listener/OrderEventListener.java
@@ -5,6 +5,7 @@ import com.klp.payment.payment.application.PaymentService;
 import com.klp.payment.payment.domain.entity.Payment;
 import com.klp.payment.payment.domain.event.OrderCreatedEvent;
 import com.klp.payment.payment.domain.event.PaymentApprovedEvent;
+import com.klp.payment.payment.domain.event.PaymentFailedEvent;
 import com.klp.payment.payment.infrastructure.kafka.config.KafkaTopicConfig;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -60,7 +61,16 @@ public class OrderEventListener {
             outboxService.savePaymentApprovedEvent(approvedEvent);
             log.info("결제 승인 완료: paymentId={}", payment.getPaymentId());
         } else {
-            log.warn("결제 실패: orderId={}", event.orderId());
+            PaymentFailedEvent failedEvent = PaymentFailedEvent.from(
+                payment.getPaymentId(),
+                event.orderId(),
+                event.userId(),
+                payment.getReason(),
+                event
+            );
+
+            outboxService.savePaymentFailedEvent(failedEvent);
+            log.warn("결제 실패: orderId={}, reason={}", event.orderId(), payment.getReason());
         }
     }
 

--- a/payment/src/main/java/com/klp/payment/payment/application/listener/OrderEventListener.java
+++ b/payment/src/main/java/com/klp/payment/payment/application/listener/OrderEventListener.java
@@ -3,8 +3,10 @@ package com.klp.payment.payment.application.listener;
 import com.klp.payment.payment.application.PaymentOutboxService;
 import com.klp.payment.payment.application.PaymentService;
 import com.klp.payment.payment.domain.entity.Payment;
+import com.klp.payment.payment.domain.event.OrderCancelledEvent;
 import com.klp.payment.payment.domain.event.OrderCreatedEvent;
 import com.klp.payment.payment.domain.event.PaymentApprovedEvent;
+import com.klp.payment.payment.domain.event.PaymentCancelledEvent;
 import com.klp.payment.payment.domain.event.PaymentFailedEvent;
 import com.klp.payment.payment.infrastructure.kafka.config.KafkaTopicConfig;
 import java.util.UUID;
@@ -71,6 +73,35 @@ public class OrderEventListener {
 
             outboxService.savePaymentFailedEvent(failedEvent);
             log.warn("결제 실패: orderId={}, reason={}", event.orderId(), payment.getReason());
+        }
+    }
+
+    @KafkaHandler
+    @Transactional
+    public void handleOrderCancelled(OrderCancelledEvent event) {
+        log.info("주문 취소 이벤트 수신: orderId={}", event.orderId());
+
+        Payment payment = paymentService.cancelPaymentByOrderId(event.orderId(), "주문 취소");
+
+        if (payment != null) {
+            PaymentCancelledEvent cancelledEvent = PaymentCancelledEvent.from(
+                payment.getPaymentId(),
+                event.orderId(),
+                payment.getUserId(),
+                "주문 취소",
+                event.products().stream()
+                    .map(p -> new PaymentCancelledEvent.ProductInfo(
+                        p.productId(),
+                        p.hubId(),
+                        p.quantity()
+                    ))
+                    .toList()
+            );
+
+            outboxService.savePaymentCancelledEvent(cancelledEvent);
+            log.info("결제 취소 완료: paymentId={}", payment.getPaymentId());
+        } else {
+            log.info("취소할 결제가 없습니다: orderId={}", event.orderId());
         }
     }
 

--- a/payment/src/main/java/com/klp/payment/payment/domain/entity/Payment.java
+++ b/payment/src/main/java/com/klp/payment/payment/domain/entity/Payment.java
@@ -138,4 +138,8 @@ public class Payment extends BaseEntity {
             throw new IllegalStateException("승인된 결제만 취소 가능합니다.");
         }
     }
+
+    public boolean isApproved() {
+        return this.status == PaymentStatus.APPROVED;
+    }
 }

--- a/payment/src/main/java/com/klp/payment/payment/domain/event/OrderCancelledEvent.java
+++ b/payment/src/main/java/com/klp/payment/payment/domain/event/OrderCancelledEvent.java
@@ -1,6 +1,7 @@
 package com.klp.payment.payment.domain.event;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -8,8 +9,16 @@ import java.util.UUID;
  */
 public record OrderCancelledEvent(
     UUID orderId,
-    Long userId,
-    String reason,
+    String inventoryIdempotencyKey,
+    String deliveryIdempotencyKey,
+    List<ProductReplenishment> products,
     LocalDateTime occurredAt
 ) {
+
+    public record ProductReplenishment(
+        UUID productId,
+        UUID hubId,
+        Integer quantity
+    ) {
+    }
 }

--- a/payment/src/main/java/com/klp/payment/payment/domain/event/OrderCancelledEvent.java
+++ b/payment/src/main/java/com/klp/payment/payment/domain/event/OrderCancelledEvent.java
@@ -1,0 +1,15 @@
+package com.klp.payment.payment.domain.event;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Order 서비스에서 발행하는 주문 취소 이벤트 (구독용)
+ */
+public record OrderCancelledEvent(
+    UUID orderId,
+    Long userId,
+    String reason,
+    LocalDateTime occurredAt
+) {
+}

--- a/payment/src/main/java/com/klp/payment/payment/domain/event/OrderCreatedEvent.java
+++ b/payment/src/main/java/com/klp/payment/payment/domain/event/OrderCreatedEvent.java
@@ -1,0 +1,44 @@
+package com.klp.payment.payment.domain.event;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Order 서비스에서 발행하는 주문 생성 이벤트 (구독용)
+ */
+public record OrderCreatedEvent(
+    UUID orderId,
+    Long userId,
+    UUID supplierId,
+    UUID userCouponId,
+
+    int originalPrice,
+    int couponDiscountPrice,
+    int gradeDiscountPrice,
+    int finalOrderPrice,
+
+    String deliveryAddress,
+    BigDecimal deliveryLatitude,
+    BigDecimal deliveryLongitude,
+
+    List<ProductDeduction> products,
+
+    String inventoryIdempotencyKey,
+    String deliveryIdempotencyKey,
+
+    LocalDateTime occurredAt
+) {
+
+    public record ProductDeduction(
+        UUID orderItemId,
+        UUID productId,
+        String productName,
+        UUID hubId,
+        Integer quantity,
+        int unitPrice,
+        int totalPrice
+    ) {
+    }
+}

--- a/payment/src/main/java/com/klp/payment/payment/domain/event/PaymentApprovedEvent.java
+++ b/payment/src/main/java/com/klp/payment/payment/domain/event/PaymentApprovedEvent.java
@@ -1,0 +1,93 @@
+package com.klp.payment.payment.domain.event;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 결제 승인 이벤트 (발행용)
+ */
+public record PaymentApprovedEvent(
+    // Payment 고유 데이터
+    UUID paymentId,
+    int paidAmount,
+    String paymentMethod,
+    LocalDateTime paidAt,
+
+    // Order에서 받은 데이터
+    UUID orderId,
+    Long userId,
+    UUID supplierId,
+    UUID userCouponId,
+
+    int originalPrice,
+    int couponDiscountPrice,
+    int gradeDiscountPrice,
+
+    String deliveryAddress,
+    BigDecimal deliveryLatitude,
+    BigDecimal deliveryLongitude,
+
+    List<ProductInfo> products,
+
+    String deliveryIdempotencyKey,
+    String couponIdempotencyKey,
+
+    LocalDateTime occurredAt
+) {
+
+    public record ProductInfo(
+        UUID orderItemId,
+        UUID productId,
+        String productName,
+        UUID hubId,
+        Integer quantity,
+        int unitPrice,
+        int totalPrice
+    ) {
+
+    }
+
+    public static PaymentApprovedEvent from(
+        UUID paymentId,
+        int paidAmount,
+        String paymentMethod,
+        LocalDateTime paidAt,
+        OrderCreatedEvent orderEvent,
+        String couponIdempotencyKey
+    ) {
+        List<ProductInfo> products = orderEvent.products().stream()
+            .map(p -> new ProductInfo(
+                p.orderItemId(),
+                p.productId(),
+                p.productName(),
+                p.hubId(),
+                p.quantity(),
+                p.unitPrice(),
+                p.totalPrice()
+            ))
+            .toList();
+
+        return new PaymentApprovedEvent(
+            paymentId,
+            paidAmount,
+            paymentMethod,
+            paidAt,
+            orderEvent.orderId(),
+            orderEvent.userId(),
+            orderEvent.supplierId(),
+            orderEvent.userCouponId(),
+            orderEvent.originalPrice(),
+            orderEvent.couponDiscountPrice(),
+            orderEvent.gradeDiscountPrice(),
+            orderEvent.deliveryAddress(),
+            orderEvent.deliveryLatitude(),
+            orderEvent.deliveryLongitude(),
+            products,
+            orderEvent.deliveryIdempotencyKey(),
+            couponIdempotencyKey,
+            LocalDateTime.now()
+        );
+    }
+}

--- a/payment/src/main/java/com/klp/payment/payment/domain/event/PaymentCancelledEvent.java
+++ b/payment/src/main/java/com/klp/payment/payment/domain/event/PaymentCancelledEvent.java
@@ -1,0 +1,43 @@
+package com.klp.payment.payment.domain.event;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 결제 취소 이벤트 (Inventory 보상 트랜잭션용)
+ */
+public record PaymentCancelledEvent(
+    UUID paymentId,
+    UUID orderId,
+    Long userId,
+    String reason,
+    List<ProductInfo> products,
+    LocalDateTime occurredAt
+) {
+
+    public record ProductInfo(
+        UUID productId,
+        UUID hubId,
+        Integer quantity
+    ) {
+
+    }
+
+    public static PaymentCancelledEvent from(
+        UUID paymentId,
+        UUID orderId,
+        Long userId,
+        String reason,
+        List<ProductInfo> products
+    ) {
+        return new PaymentCancelledEvent(
+            paymentId,
+            orderId,
+            userId,
+            reason,
+            products,
+            LocalDateTime.now()
+        );
+    }
+}

--- a/payment/src/main/java/com/klp/payment/payment/domain/event/PaymentFailedEvent.java
+++ b/payment/src/main/java/com/klp/payment/payment/domain/event/PaymentFailedEvent.java
@@ -1,0 +1,51 @@
+package com.klp.payment.payment.domain.event;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 결제 실패 이벤트 (발행용 → Inventory 재고 복구)
+ */
+public record PaymentFailedEvent(
+    UUID paymentId,
+    UUID orderId,
+    Long userId,
+    String reason,
+    List<ProductInfo> products,
+    LocalDateTime occurredAt
+) {
+
+    public record ProductInfo(
+        UUID productId,
+        UUID hubId,
+        Integer quantity
+    ) {
+
+    }
+
+    public static PaymentFailedEvent from(
+        UUID paymentId,
+        UUID orderId,
+        Long userId,
+        String reason,
+        OrderCreatedEvent orderEvent
+    ) {
+        List<ProductInfo> products = orderEvent.products().stream()
+            .map(p -> new ProductInfo(
+                p.productId(),
+                p.hubId(),
+                p.quantity()
+            ))
+            .toList();
+
+        return new PaymentFailedEvent(
+            paymentId,
+            orderId,
+            userId,
+            reason,
+            products,
+            LocalDateTime.now()
+        );
+    }
+}

--- a/payment/src/main/java/com/klp/payment/payment/domain/outbox/OutboxStatus.java
+++ b/payment/src/main/java/com/klp/payment/payment/domain/outbox/OutboxStatus.java
@@ -1,0 +1,7 @@
+package com.klp.payment.payment.domain.outbox;
+
+public enum OutboxStatus {
+    PENDING,
+    PUBLISHED,
+    FAILED
+}

--- a/payment/src/main/java/com/klp/payment/payment/domain/outbox/PaymentOutbox.java
+++ b/payment/src/main/java/com/klp/payment/payment/domain/outbox/PaymentOutbox.java
@@ -1,0 +1,73 @@
+package com.klp.payment.payment.domain.outbox;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "p_payment_outbox")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PaymentOutbox {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID paymentOutboxId;
+
+    @Column(nullable = false)
+    private UUID orderId;
+
+    @Column(nullable = false)
+    private String eventType;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String payload;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OutboxStatus status;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime publishedAt;
+
+    private int retryCount;
+
+    public PaymentOutbox(UUID orderId, String eventType, String payload) {
+        this.orderId = orderId;
+        this.eventType = eventType;
+        this.payload = payload;
+        this.status = OutboxStatus.PENDING;
+        this.createdAt = LocalDateTime.now();
+        this.retryCount = 0;
+    }
+
+    public static PaymentOutbox create(UUID orderId, String eventType, String payload) {
+        return new PaymentOutbox(orderId, eventType, payload);
+    }
+
+    public void publish() {
+        this.status = OutboxStatus.PUBLISHED;
+        this.publishedAt = LocalDateTime.now();
+    }
+
+    public void fail() {
+        this.status = OutboxStatus.FAILED;
+        this.retryCount++;
+    }
+
+    public void incrementRetry() {
+        this.retryCount++;
+    }
+}

--- a/payment/src/main/java/com/klp/payment/payment/domain/repository/PaymentOutboxRepository.java
+++ b/payment/src/main/java/com/klp/payment/payment/domain/repository/PaymentOutboxRepository.java
@@ -1,0 +1,16 @@
+package com.klp.payment.payment.domain.repository;
+
+import com.klp.payment.payment.domain.outbox.PaymentOutbox;
+import java.util.List;
+import java.util.UUID;
+
+public interface PaymentOutboxRepository {
+
+    PaymentOutbox save(PaymentOutbox outbox);
+
+    List<PaymentOutbox> findPendingEvents(int limit);
+
+    void markAsPublished(UUID paymentOutboxId);
+
+    void markAsFailed(UUID paymentOutboxId);
+}

--- a/payment/src/main/java/com/klp/payment/payment/domain/repository/PaymentRepository.java
+++ b/payment/src/main/java/com/klp/payment/payment/domain/repository/PaymentRepository.java
@@ -20,4 +20,6 @@ public interface PaymentRepository {
     Page<Payment> findByUserId(Long userId, Pageable pageable);
 
     Page<Payment> findByHubId(UUID hubId, Pageable pageable);
+
+    boolean existsByOrderId(UUID orderId);
 }

--- a/payment/src/main/java/com/klp/payment/payment/domain/repository/PaymentRepository.java
+++ b/payment/src/main/java/com/klp/payment/payment/domain/repository/PaymentRepository.java
@@ -22,4 +22,6 @@ public interface PaymentRepository {
     Page<Payment> findByHubId(UUID hubId, Pageable pageable);
 
     boolean existsByOrderId(UUID orderId);
+
+    Optional<Payment> findFirstByOrderIdAndStatusApproved(UUID orderId);
 }

--- a/payment/src/main/java/com/klp/payment/payment/infrastructure/PaymentJpaRepository.java
+++ b/payment/src/main/java/com/klp/payment/payment/infrastructure/PaymentJpaRepository.java
@@ -14,4 +14,6 @@ public interface PaymentJpaRepository extends JpaRepository<Payment, UUID> {
     Page<Payment> findByUserId(Long userId, Pageable pageable);
 
     Page<Payment> findByHubId(UUID hubId, Pageable pageable);
+
+    boolean existsByOrderId(UUID orderId);
 }

--- a/payment/src/main/java/com/klp/payment/payment/infrastructure/PaymentJpaRepository.java
+++ b/payment/src/main/java/com/klp/payment/payment/infrastructure/PaymentJpaRepository.java
@@ -1,7 +1,9 @@
 package com.klp.payment.payment.infrastructure;
 
 import com.klp.payment.payment.domain.entity.Payment;
+import com.klp.payment.payment.domain.enums.PaymentStatus;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,4 +18,6 @@ public interface PaymentJpaRepository extends JpaRepository<Payment, UUID> {
     Page<Payment> findByHubId(UUID hubId, Pageable pageable);
 
     boolean existsByOrderId(UUID orderId);
+
+    Optional<Payment> findFirstByOrderIdAndStatus(UUID orderId, PaymentStatus status);
 }

--- a/payment/src/main/java/com/klp/payment/payment/infrastructure/PaymentRepositoryImpl.java
+++ b/payment/src/main/java/com/klp/payment/payment/infrastructure/PaymentRepositoryImpl.java
@@ -45,4 +45,9 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     public Page<Payment> findByHubId(UUID hubId, Pageable pageable) {
         return paymentJpaRepository.findByHubId(hubId, pageable);
     }
+
+    @Override
+    public boolean existsByOrderId(UUID orderId) {
+        return paymentJpaRepository.existsByOrderId(orderId);
+    }
 }

--- a/payment/src/main/java/com/klp/payment/payment/infrastructure/PaymentRepositoryImpl.java
+++ b/payment/src/main/java/com/klp/payment/payment/infrastructure/PaymentRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.klp.payment.payment.infrastructure;
 
 import com.klp.payment.payment.domain.entity.Payment;
+import com.klp.payment.payment.domain.enums.PaymentStatus;
 import com.klp.payment.payment.domain.repository.PaymentRepository;
 import java.util.List;
 import java.util.Optional;
@@ -49,5 +50,10 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     @Override
     public boolean existsByOrderId(UUID orderId) {
         return paymentJpaRepository.existsByOrderId(orderId);
+    }
+
+    @Override
+    public Optional<Payment> findFirstByOrderIdAndStatusApproved(UUID orderId) {
+        return paymentJpaRepository.findFirstByOrderIdAndStatus(orderId, PaymentStatus.APPROVED);
     }
 }

--- a/payment/src/main/java/com/klp/payment/payment/infrastructure/kafka/config/KafkaConsumerConfig.java
+++ b/payment/src/main/java/com/klp/payment/payment/infrastructure/kafka/config/KafkaConsumerConfig.java
@@ -1,0 +1,108 @@
+package com.klp.payment.payment.infrastructure.kafka.config;
+
+import com.klp.payment.payment.domain.event.OrderCancelledEvent;
+import com.klp.payment.payment.domain.event.OrderCreatedEvent;
+import com.klp.payment.payment.domain.event.PaymentApprovedEvent;
+import com.klp.payment.payment.domain.event.PaymentCancelledEvent;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.serializer.DeserializationException;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.messaging.converter.MessageConversionException;
+import org.springframework.util.backoff.FixedBackOff;
+
+@Slf4j
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    private static final int MAX_RETRY_ATTEMPTS = 3;
+    private static final long RETRY_INTERVAL_MS = 1000L;
+
+    @Bean
+    public ConsumerFactory<String, Object> paymentConsumerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ConsumerConfig.GROUP_ID_CONFIG, "payment-service-group");
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        configProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        configProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        configProps.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 500);
+        configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "com.klp.*");
+        configProps.put(JsonDeserializer.TYPE_MAPPINGS, buildTypeMappings());
+
+        return new DefaultKafkaConsumerFactory<>(configProps);
+    }
+
+    private String buildTypeMappings() {
+        return String.join(",",
+            "OrderCreatedEvent:" + OrderCreatedEvent.class.getName(),
+            "OrderCancelledEvent:" + OrderCancelledEvent.class.getName(),
+            "PaymentApprovedEvent:" + PaymentApprovedEvent.class.getName(),
+            "PaymentCancelledEvent:" + PaymentCancelledEvent.class.getName()
+        );
+    }
+
+    @Bean
+    public DeadLetterPublishingRecoverer paymentDeadLetterPublishingRecoverer(
+        @Qualifier("paymentKafkaTemplate") KafkaTemplate<String, Object> kafkaTemplate
+    ) {
+        return new DeadLetterPublishingRecoverer(kafkaTemplate,
+            (record, exception) -> {
+                log.error("메시지 처리 실패, DLT로 이동: topic={}, error={}", record.topic(), exception.getMessage());
+                return new TopicPartition(KafkaTopicConfig.PAYMENT_DLT, record.partition());
+            });
+    }
+
+    @Bean
+    public DefaultErrorHandler paymentErrorHandler(
+        @Qualifier("paymentDeadLetterPublishingRecoverer") DeadLetterPublishingRecoverer recoverer
+    ) {
+        FixedBackOff backOff = new FixedBackOff(RETRY_INTERVAL_MS, MAX_RETRY_ATTEMPTS);
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, backOff);
+        errorHandler.addNotRetryableExceptions(
+            DeserializationException.class,
+            MessageConversionException.class
+        );
+
+        errorHandler.setRetryListeners((record, ex, deliveryAttempt) -> {
+            log.warn("메시지 처리 재시도: topic={}, attempt={}, error={}", record.topic(), deliveryAttempt, ex.getMessage());
+        });
+
+        return errorHandler;
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> paymentKafkaListenerContainerFactory(
+        @Qualifier("paymentErrorHandler") DefaultErrorHandler errorHandler
+    ) {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory =
+            new ConcurrentKafkaListenerContainerFactory<>();
+
+        factory.setConsumerFactory(paymentConsumerFactory());
+        factory.setConcurrency(3);
+        factory.setCommonErrorHandler(errorHandler);
+
+        return factory;
+    }
+}

--- a/payment/src/main/java/com/klp/payment/payment/infrastructure/kafka/config/KafkaProducerConfig.java
+++ b/payment/src/main/java/com/klp/payment/payment/infrastructure/kafka/config/KafkaProducerConfig.java
@@ -1,0 +1,45 @@
+package com.klp.payment.payment.infrastructure.kafka.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@Slf4j
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, Object> paymentProducerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        configProps.put(ProducerConfig.ACKS_CONFIG, "all");
+        configProps.put(ProducerConfig.RETRIES_CONFIG, 3);
+        configProps.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "snappy");
+        configProps.put(ProducerConfig.BATCH_SIZE_CONFIG, 16384);
+        configProps.put(ProducerConfig.BUFFER_MEMORY_CONFIG, 33554432);
+        configProps.put(ProducerConfig.LINGER_MS_CONFIG, 10);
+        configProps.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, true);
+
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> paymentKafkaTemplate() {
+        return new KafkaTemplate<>(paymentProducerFactory());
+    }
+}

--- a/payment/src/main/java/com/klp/payment/payment/infrastructure/kafka/config/KafkaProducerConfig.java
+++ b/payment/src/main/java/com/klp/payment/payment/infrastructure/kafka/config/KafkaProducerConfig.java
@@ -1,5 +1,8 @@
 package com.klp.payment.payment.infrastructure.kafka.config;
 
+import com.klp.payment.payment.domain.event.PaymentApprovedEvent;
+import com.klp.payment.payment.domain.event.PaymentCancelledEvent;
+import com.klp.payment.payment.domain.event.PaymentFailedEvent;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -34,8 +37,17 @@ public class KafkaProducerConfig {
         configProps.put(ProducerConfig.BUFFER_MEMORY_CONFIG, 33554432);
         configProps.put(ProducerConfig.LINGER_MS_CONFIG, 10);
         configProps.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, true);
+        configProps.put(JsonSerializer.TYPE_MAPPINGS, buildTypeMappings());
 
         return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    private String buildTypeMappings() {
+        return String.join(",",
+            "PaymentApprovedEvent:" + PaymentApprovedEvent.class.getName(),
+            "PaymentFailedEvent:" + PaymentFailedEvent.class.getName(),
+            "PaymentCancelledEvent:" + PaymentCancelledEvent.class.getName()
+        );
     }
 
     @Bean

--- a/payment/src/main/java/com/klp/payment/payment/infrastructure/kafka/config/KafkaTopicConfig.java
+++ b/payment/src/main/java/com/klp/payment/payment/infrastructure/kafka/config/KafkaTopicConfig.java
@@ -1,0 +1,41 @@
+package com.klp.payment.payment.infrastructure.kafka.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+public class KafkaTopicConfig {
+
+    // 구독용
+    public static final String ORDER_TOPIC = "order.topic";
+
+    // 발행용
+    public static final String PAYMENT_TOPIC = "payment.topic";
+
+    // DLT
+    public static final String PAYMENT_DLT = "payment.dlt";
+
+    /**
+     * 결제 이벤트 토픽
+     */
+    @Bean
+    public NewTopic paymentTopic() {
+        return TopicBuilder.name(PAYMENT_TOPIC)
+            .partitions(3)
+            .replicas(1)
+            .build();
+    }
+
+    /**
+     * 결제 DLT 토픽
+     */
+    @Bean
+    public NewTopic paymentDltTopic() {
+        return TopicBuilder.name(PAYMENT_DLT)
+            .partitions(3)
+            .replicas(1)
+            .build();
+    }
+}

--- a/payment/src/main/java/com/klp/payment/payment/infrastructure/kafka/producer/PaymentEventProducer.java
+++ b/payment/src/main/java/com/klp/payment/payment/infrastructure/kafka/producer/PaymentEventProducer.java
@@ -2,6 +2,7 @@ package com.klp.payment.payment.infrastructure.kafka.producer;
 
 import com.klp.payment.payment.domain.event.PaymentApprovedEvent;
 import com.klp.payment.payment.domain.event.PaymentCancelledEvent;
+import com.klp.payment.payment.domain.event.PaymentFailedEvent;
 import com.klp.payment.payment.infrastructure.kafka.config.KafkaTopicConfig;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
@@ -56,6 +57,24 @@ public class PaymentEventProducer {
             } else {
                 log.error("결제 취소 이벤트 발행 실패: orderId={}, paymentId={}, error={}", event.orderId(), event.paymentId(),
                     ex.getMessage());
+            }
+        });
+    }
+
+    /**
+     * 결제 실패 이벤트 발행
+     */
+    public void publishPaymentFailedEvent(PaymentFailedEvent event) {
+        String key = event.orderId().toString();
+
+        CompletableFuture<SendResult<String, Object>> future =
+            kafkaTemplate.send(KafkaTopicConfig.PAYMENT_TOPIC, key, event);
+
+        future.whenComplete((result, ex) -> {
+            if (ex == null) {
+                log.info("결제 실패 이벤트 발행 성공: orderId={}, reason={}", event.orderId(), event.reason());
+            } else {
+                log.error("결제 실패 이벤트 발행 실패: orderId={}, error={}", event.orderId(), ex.getMessage());
             }
         });
     }

--- a/payment/src/main/java/com/klp/payment/payment/infrastructure/kafka/producer/PaymentEventProducer.java
+++ b/payment/src/main/java/com/klp/payment/payment/infrastructure/kafka/producer/PaymentEventProducer.java
@@ -1,0 +1,62 @@
+package com.klp.payment.payment.infrastructure.kafka.producer;
+
+import com.klp.payment.payment.domain.event.PaymentApprovedEvent;
+import com.klp.payment.payment.domain.event.PaymentCancelledEvent;
+import com.klp.payment.payment.infrastructure.kafka.config.KafkaTopicConfig;
+import java.util.concurrent.CompletableFuture;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class PaymentEventProducer {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public PaymentEventProducer(
+        @Qualifier("paymentKafkaTemplate") KafkaTemplate<String, Object> kafkaTemplate
+    ) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    /**
+     * 결제 승인 이벤트 발행
+     */
+    public void publishPaymentApprovedEvent(PaymentApprovedEvent event) {
+        String key = event.orderId().toString();
+
+        CompletableFuture<SendResult<String, Object>> future =
+            kafkaTemplate.send(KafkaTopicConfig.PAYMENT_TOPIC, key, event);
+
+        future.whenComplete((result, ex) -> {
+            if (ex == null) {
+                log.info("결제 승인 이벤트 발행 성공: orderId={}, paymentId={}", event.orderId(), event.paymentId());
+            } else {
+                log.error("결제 승인 이벤트 발행 실패: orderId={}, paymentId={}, error={}", event.orderId(), event.paymentId(),
+                    ex.getMessage());
+            }
+        });
+    }
+
+    /**
+     * 결제 취소 이벤트 발행
+     */
+    public void publishPaymentCancelledEvent(PaymentCancelledEvent event) {
+        String key = event.orderId().toString();
+
+        CompletableFuture<SendResult<String, Object>> future =
+            kafkaTemplate.send(KafkaTopicConfig.PAYMENT_TOPIC, key, event);
+
+        future.whenComplete((result, ex) -> {
+            if (ex == null) {
+                log.info("결제 취소 이벤트 발행 성공: orderId={}, paymentId={}", event.orderId(), event.paymentId());
+            } else {
+                log.error("결제 취소 이벤트 발행 실패: orderId={}, paymentId={}, error={}", event.orderId(), event.paymentId(),
+                    ex.getMessage());
+            }
+        });
+    }
+}

--- a/payment/src/main/java/com/klp/payment/payment/infrastructure/outbox/OutboxJpaRepository.java
+++ b/payment/src/main/java/com/klp/payment/payment/infrastructure/outbox/OutboxJpaRepository.java
@@ -1,0 +1,26 @@
+package com.klp.payment.payment.infrastructure.outbox;
+
+import com.klp.payment.payment.domain.outbox.PaymentOutbox;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface OutboxJpaRepository extends JpaRepository<PaymentOutbox, UUID> {
+
+    @Query("SELECT o FROM PaymentOutbox o WHERE o.status = 'PENDING' ORDER BY o.createdAt ASC LIMIT :limit")
+    List<PaymentOutbox> findPendingEvents(
+        @Param("limit") int limit
+    );
+
+    @Modifying
+    @Query("UPDATE PaymentOutbox o SET o.status = 'PUBLISHED', o.publishedAt = CURRENT_TIMESTAMP WHERE o.paymentOutboxId = :paymentOutboxId")
+    void markAsPublished(UUID paymentOutboxId);
+
+    @Modifying
+    @Query("UPDATE PaymentOutbox o SET o.status = 'FAILED', o.retryCount = o.retryCount + 1 WHERE o.paymentOutboxId = :paymentOutboxId")
+    void markAsFailed(UUID paymentOutboxId);
+
+}

--- a/payment/src/main/java/com/klp/payment/payment/infrastructure/outbox/OutboxRepositoryImpl.java
+++ b/payment/src/main/java/com/klp/payment/payment/infrastructure/outbox/OutboxRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.klp.payment.payment.infrastructure.outbox;
+
+import com.klp.payment.payment.domain.outbox.PaymentOutbox;
+import com.klp.payment.payment.domain.repository.PaymentOutboxRepository;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+public class OutboxRepositoryImpl implements PaymentOutboxRepository {
+
+    private final OutboxJpaRepository outboxJpaRepository;
+
+
+    @Override
+    public PaymentOutbox save(PaymentOutbox outbox) {
+        return outboxJpaRepository.save(outbox);
+    }
+
+    @Override
+    public List<PaymentOutbox> findPendingEvents(int limit) {
+        return outboxJpaRepository.findPendingEvents(limit);
+    }
+
+    @Override
+    @Transactional
+    public void markAsPublished(UUID paymentOutboxId) {
+        outboxJpaRepository.markAsPublished(paymentOutboxId);
+    }
+
+    @Override
+    @Transactional
+    public void markAsFailed(UUID paymentOutboxId) {
+        outboxJpaRepository.markAsFailed(paymentOutboxId);
+    }
+}

--- a/payment/src/main/java/com/klp/payment/payment/infrastructure/outbox/OutboxScheduler.java
+++ b/payment/src/main/java/com/klp/payment/payment/infrastructure/outbox/OutboxScheduler.java
@@ -3,6 +3,7 @@ package com.klp.payment.payment.infrastructure.outbox;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.klp.payment.payment.domain.event.PaymentApprovedEvent;
 import com.klp.payment.payment.domain.event.PaymentCancelledEvent;
+import com.klp.payment.payment.domain.event.PaymentFailedEvent;
 import com.klp.payment.payment.domain.outbox.PaymentOutbox;
 import com.klp.payment.payment.domain.repository.PaymentOutboxRepository;
 import com.klp.payment.payment.infrastructure.kafka.producer.PaymentEventProducer;
@@ -51,6 +52,10 @@ public class OutboxScheduler {
             case "PaymentCancelledEvent" -> {
                 PaymentCancelledEvent event = objectMapper.readValue(payload, PaymentCancelledEvent.class);
                 eventProducer.publishPaymentCancelledEvent(event);
+            }
+            case "PaymentFailedEvent" -> {
+                PaymentFailedEvent event = objectMapper.readValue(payload, PaymentFailedEvent.class);
+                eventProducer.publishPaymentFailedEvent(event);
             }
             default -> throw new IllegalArgumentException("Unknown event type: " + eventType);
         }

--- a/payment/src/main/java/com/klp/payment/payment/infrastructure/outbox/OutboxScheduler.java
+++ b/payment/src/main/java/com/klp/payment/payment/infrastructure/outbox/OutboxScheduler.java
@@ -1,0 +1,58 @@
+package com.klp.payment.payment.infrastructure.outbox;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.klp.payment.payment.domain.event.PaymentApprovedEvent;
+import com.klp.payment.payment.domain.event.PaymentCancelledEvent;
+import com.klp.payment.payment.domain.outbox.PaymentOutbox;
+import com.klp.payment.payment.domain.repository.PaymentOutboxRepository;
+import com.klp.payment.payment.infrastructure.kafka.producer.PaymentEventProducer;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxScheduler {
+
+    private final PaymentOutboxRepository paymentOutboxRepository;
+    private final PaymentEventProducer eventProducer;
+    private final ObjectMapper objectMapper;
+
+    private static final int BATCH_SIZE = 100;
+
+    @Scheduled(fixedDelay = 1000)
+    public void publishPendingEvents() {
+        List<PaymentOutbox> pendingEvents = paymentOutboxRepository.findPendingEvents(BATCH_SIZE);
+
+        for (PaymentOutbox outbox : pendingEvents) {
+            try {
+                publishEvent(outbox);
+                paymentOutboxRepository.markAsPublished(outbox.getPaymentOutboxId());
+                log.info("이벤트 발행 성공: orderId={}, eventType={}", outbox.getOrderId(), outbox.getEventType());
+            } catch (Exception e) {
+                paymentOutboxRepository.markAsFailed(outbox.getPaymentOutboxId());
+                log.error("이벤트 발행 실패: orderId={}, error={}", outbox.getOrderId(), e.getMessage());
+            }
+        }
+    }
+
+    private void publishEvent(PaymentOutbox outbox) throws Exception {
+        String eventType = outbox.getEventType();
+        String payload = outbox.getPayload();
+
+        switch (eventType) {
+            case "PaymentApprovedEvent" -> {
+                PaymentApprovedEvent event = objectMapper.readValue(payload, PaymentApprovedEvent.class);
+                eventProducer.publishPaymentApprovedEvent(event);
+            }
+            case "PaymentCancelledEvent" -> {
+                PaymentCancelledEvent event = objectMapper.readValue(payload, PaymentCancelledEvent.class);
+                eventProducer.publishPaymentCancelledEvent(event);
+            }
+            default -> throw new IllegalArgumentException("Unknown event type: " + eventType);
+        }
+    }
+}

--- a/payment/src/main/resources/application.yml
+++ b/payment/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 9010
+  port: 9020
 
 spring:
   application:

--- a/payment/src/main/resources/logback-spring.xml
+++ b/payment/src/main/resources/logback-spring.xml
@@ -1,0 +1,27 @@
+<configuration>
+
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>
+        date=%d{yyyy-MM-dd HH:mm:ss.SSS} level=%-5level thread=[%thread] logger=%logger -
+        traceId=%X{trace_id:-} spanId=%X{span_id:-} message=%msg%n
+      </pattern>
+    </encoder>
+  </appender>
+
+  <appender name="OpenTelemetryMdc"
+    class="io.opentelemetry.instrumentation.logback.mdc.v1_0.OpenTelemetryAppender">
+    <appender-ref ref="CONSOLE"/>
+  </appender>
+
+  <appender name="OpenTelemetryExporter"
+    class="io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender">
+    <captureMdcAttributes>*</captureMdcAttributes>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="OpenTelemetryMdc"/>
+    <appender-ref ref="OpenTelemetryExporter"/>
+  </root>
+
+</configuration>


### PR DESCRIPTION
## PR 내용
- [config: 결제 관련 Kafka 설정 진행](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/06e08ed2a66666f22d61863c48b9497fb0d31782)
  - 결제 서비스 Kafka 관련 설정을 진행했습니다(Topic, Producer, Listener)
  - 타입 매핑을 기본적으로 이용하도록 구성했습니다.

- [feat: 주문 생성 -> 결제 성공 이벤트 흐름 작성](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/0e57d2b66e9102e6666b636e2157e9eff5958684)
  - 성공 시나리오에 대한 이벤트 처리를 진행했습니다.

- [feat: 결제 실패 이벤트 로직 작성](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/69a1b524d93938e67e0ee7f1fb3891a96a599a42)
  - 결제 실패에 대한 이벤트 처리를 진행했습니다.

- [feat: 결제 취소 이벤트 로직 작성](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/77da46f77d65f65a67e5e574096c9d9868646a9d)
  - 결제 취소에 대한 이벤트 로직을 작성했습니다.

- [config: 결제 서비스 로그 스택 구성](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/71fac4ebece730e604e1d36fb84ebb951080dda6)
  - 결제 서비스에서 OpenTelemtry 로그 파이프라인을 이용할 수 있도록 설정을 진행했습니다.