### PR TITLE
feat: event 이름 변경 및 typemapping 추가

### DIFF
--- a/order/src/main/java/com/klp/order/application/command/CreateOrderCommand.java
+++ b/order/src/main/java/com/klp/order/application/command/CreateOrderCommand.java
@@ -9,7 +9,7 @@ public record CreateOrderCommand(
     UUID supplierId,
     UUID userCouponId,
     String comment,
-    String deliveryAddress,
+    UUID addressId,
     BigDecimal deliveryLatitude,
     BigDecimal deliveryLongitude,
     List<OrderItemCommand> items

--- a/order/src/main/java/com/klp/order/application/facade/OrderFacade.java
+++ b/order/src/main/java/com/klp/order/application/facade/OrderFacade.java
@@ -8,6 +8,7 @@ import com.klp.order.application.query.UserQueryService;
 import com.klp.order.application.service.OrderOutboundRequestService;
 import com.klp.order.application.service.OrderOutboxEventService;
 import com.klp.order.application.service.OrderService;
+import com.klp.order.application.service.UserClient;
 import com.klp.order.domain.entity.idempotencykey.OperationType;
 import com.klp.order.domain.entity.idempotencykey.Target;
 import com.klp.order.domain.entity.order.Order;
@@ -36,19 +37,24 @@ public class OrderFacade {
     private final ProductQueryService productQueryService;
     private final PromotionDiscountService promotionService;
     private final InventoryIntegrationService inventoryService;
+    private final UserClient userClient;
 
     @Transactional
     public Order createOrder(CreateOrderCommand command) {
 
         try {
             // 1. 유저 조회_ 정보 얻기
+            //grade , email 뽑아오기
 //            UserProfile userProfile = userQueryService.getUserProfile(command.userId());
+            //2. userAddressHubId, address  받아오기
+//            UserAddressHubId userAddressHubId = userClient.getUserAddressHubIdByAddressId(
+//                command.addressId());
 
-            // 2. 주문 생성
+            // 3. 주문 생성
             Order order = orderService.createOrder(command);
             log.info("주문 생성 완료 - orderId: {}", order.getOrderId());
 
-            // 3. 상품 존재 확인
+            // 4. 상품 존재 확인
             List<OrderItemCommand> orderItems = command.items();
             int originalPriceTotal = 0;
             for (OrderItemCommand orderItem : orderItems) {
@@ -66,7 +72,7 @@ public class OrderFacade {
 //                productQueryService.getProductById(orderItem.productId());
             }
 
-            // 4. 할인 금액 조회 // 추후 사용 예정
+            // 5. 할인 금액 조회 // 추후 사용 예정
 //            PromotionCalculateRequest calculateRequest = new PromotionCalculateRequest(
 //                userProfile.grade(), originalPriceTotal, command.userCouponId());
 //            PromotionResponse promotionResponse = promotionService.promotionInfo(calculateRequest);
@@ -75,10 +81,11 @@ public class OrderFacade {
             orderService.updateDiscountPrice(
                 order,
                 0,
-                1
+                1,
+                originalPriceTotal - 1
             );
 
-            //5. 이벤트 생성
+            //6. 이벤트 생성
             String InventoryIdempotencyKey = orderOutboundRequestService.generateIdempotencyKey(
                 order.getOrderId(),
                 Target.INVENTORY,
@@ -91,8 +98,10 @@ public class OrderFacade {
                 OperationType.MAKING
             );
 
-            OrderCreatedEvent event = OrderCreatedEvent.from(order, InventoryIdempotencyKey,
-                DeliveryIdempotencyKey);
+            UUID tmpAddressHubId = UUID.randomUUID();
+            OrderCreatedEvent event = OrderCreatedEvent.from(order, "email", "address",
+                InventoryIdempotencyKey,
+                DeliveryIdempotencyKey, tmpAddressHubId);
 
             // Outbox에 이벤트 저장 시도  실패 시 전체 롤백으로 데이터 일관성을 지키도록 구현
             orderOutboxEventService.saveEvent(order.getOrderId(),

--- a/order/src/main/java/com/klp/order/application/service/OrderService.java
+++ b/order/src/main/java/com/klp/order/application/service/OrderService.java
@@ -138,10 +138,11 @@ public class OrderService {
     }
 
     @Transactional
-    public void updateDiscountPrice(Order order, int couponDiscountPrice, int gradeDiscountPrice) {
+    public void updateDiscountPrice(Order order, int couponDiscountPrice, int gradeDiscountPrice,
+        int finalPrice) {
         checkCouponDiscountPrice(couponDiscountPrice);
         checkGradeDiscountPrice(gradeDiscountPrice);
-        order.updateDiscountPrice(couponDiscountPrice, gradeDiscountPrice);
+        order.updateDiscountPrice(couponDiscountPrice, gradeDiscountPrice, finalPrice);
         orderRepository.save(order);
     }
 

--- a/order/src/main/java/com/klp/order/application/service/OrderService.java
+++ b/order/src/main/java/com/klp/order/application/service/OrderService.java
@@ -35,7 +35,7 @@ public class OrderService {
             command.userCouponId(),
             command.supplierId(),
             command.comment(),
-            command.deliveryAddress(),
+            command.addressId(),
             command.deliveryLatitude(),
             command.deliveryLongitude(),
             command.items()

--- a/order/src/main/java/com/klp/order/application/service/UserClient.java
+++ b/order/src/main/java/com/klp/order/application/service/UserClient.java
@@ -1,8 +1,12 @@
 package com.klp.order.application.service;
 
+import com.klp.order.domain.vo.UserAddressHubId;
 import com.klp.order.domain.vo.UserProfile;
+import java.util.UUID;
 
 public interface UserClient {
 
     UserProfile getUserProfileById(Long userId);
+
+    UserAddressHubId getUserAddressHubIdByAddressId(UUID addressId);
 }

--- a/order/src/main/java/com/klp/order/domain/entity/order/Order.java
+++ b/order/src/main/java/com/klp/order/domain/entity/order/Order.java
@@ -180,11 +180,12 @@ public class Order extends BaseEntity {
         return this.cancellation;
     }
 
-    public void updateDiscountPrice(int couponDiscountPrice, int gradeDiscountPrice) {
-        validateDiscounts(couponDiscountPrice, gradeDiscountPrice);
+    public void updateDiscountPrice(int couponDiscountPrice, int gradeDiscountPrice,
+        int finalPrice) {
+        validateDiscounts(couponDiscountPrice, gradeDiscountPrice, finalPrice);
         this.couponDiscountPrice = couponDiscountPrice;
         this.gradeDiscountPrice = gradeDiscountPrice;
-        this.orderPrice = originalPrice - couponDiscountPrice - gradeDiscountPrice;
+        this.orderPrice = finalPrice;
     }
 
     private void validateUserId(Long userId) {
@@ -236,9 +237,12 @@ public class Order extends BaseEntity {
         }
     }
 
-    private void validateDiscounts(int couponDiscount, int gradeDiscount) {
+    private void validateDiscounts(int couponDiscount, int gradeDiscount, int finalPrice) {
         if (userCouponId == null && couponDiscount > 0) {
             throw new BusinessException(OrderErrorCode.COUPON_DISCOUNT_WITHOUT_COUPON);
+        }
+        if (originalPrice - couponDiscount - gradeDiscount != finalPrice) {
+            throw new BusinessException(OrderErrorCode.INVALID_DISCOUNT_AMOUNT);
         }
 
         if (couponDiscount < 0) {

--- a/order/src/main/java/com/klp/order/domain/entity/order/Order.java
+++ b/order/src/main/java/com/klp/order/domain/entity/order/Order.java
@@ -67,8 +67,8 @@ public class Order extends BaseEntity {
     @Column(name = "order_price", nullable = false)
     private int orderPrice;
 
-    @Column(name = "delivery_address", nullable = false)
-    private String deliveryAddress;
+    @Column(name = "address_id", nullable = false)
+    private UUID addressId;
 
     @Column(name = "delivery_latitude", nullable = false, precision = 10, scale = 8)
     private BigDecimal deliveryLatitude;
@@ -91,7 +91,7 @@ public class Order extends BaseEntity {
         UUID userCouponId,
         UUID supplierId,
         String comment,
-        String deliveryAddress,
+        UUID addressId,
         BigDecimal deliveryLatitude,
         BigDecimal deliveryLongitude,
         List<OrderItemCommand> itemCommands
@@ -100,14 +100,14 @@ public class Order extends BaseEntity {
 
         order.validateUserId(userId);
         order.validateSupplierId(supplierId);
-        order.validateDeliveryInfo(deliveryAddress, deliveryLatitude, deliveryLongitude);
+        order.validateDeliveryInfo(addressId, deliveryLatitude, deliveryLongitude);
         order.validateItemCommands(itemCommands);
 
         order.userId = userId;
         order.userCouponId = userCouponId;
         order.supplierId = supplierId;
         order.comment = comment;
-        order.deliveryAddress = deliveryAddress;
+        order.addressId = addressId;
         order.deliveryLatitude = deliveryLatitude;
         order.deliveryLongitude = deliveryLongitude;
         order.orderStatus = OrderStatus.PENDING;
@@ -200,11 +200,11 @@ public class Order extends BaseEntity {
     }
 
     private void validateDeliveryInfo(
-        String deliveryAddress,
+        UUID deliveryAddress,
         BigDecimal deliveryLatitude,
         BigDecimal deliveryLongitude
     ) {
-        if (deliveryAddress == null || deliveryAddress.isBlank()) {
+        if (deliveryAddress == null) {
             throw new BusinessException(OrderErrorCode.DELIVERY_ADDRESS_REQUIRED);
         }
         if (deliveryLatitude == null) {

--- a/order/src/main/java/com/klp/order/domain/entity/order/OrderStatus.java
+++ b/order/src/main/java/com/klp/order/domain/entity/order/OrderStatus.java
@@ -13,6 +13,7 @@ public enum OrderStatus {
     DELIVERY_CREATED_FAILED("배송 생성 중 실패"),
     DELIVERY_SHIPPING("배송 중"),
     DELIVERY_SHIPPING_FAILED("배송 중 상태 변화 중 실패"),
+    DELIVERY_ARRIVED_FAILED("배송 중 상태 변화 중 실패"),
     COMPLETE("완료"),
     CANCELLED("취소됨"),
     FAILED("실패");

--- a/order/src/main/java/com/klp/order/domain/vo/UserAddressHubId.java
+++ b/order/src/main/java/com/klp/order/domain/vo/UserAddressHubId.java
@@ -1,0 +1,9 @@
+package com.klp.order.domain.vo;
+
+import java.util.UUID;
+
+public record UserAddressHubId(
+    UUID userAddressHubId
+) {
+
+}

--- a/order/src/main/java/com/klp/order/domain/vo/UserAddressHubId.java
+++ b/order/src/main/java/com/klp/order/domain/vo/UserAddressHubId.java
@@ -3,7 +3,8 @@ package com.klp.order.domain.vo;
 import java.util.UUID;
 
 public record UserAddressHubId(
-    UUID userAddressHubId
+    UUID userAddressHubId,
+    String address
 ) {
 
 }

--- a/order/src/main/java/com/klp/order/domain/vo/UserProfile.java
+++ b/order/src/main/java/com/klp/order/domain/vo/UserProfile.java
@@ -6,6 +6,7 @@ public record UserProfile(
     String affiliation,
     String slackId,
     String phoneNumber,
+    String email,
     String grade
 ) {
 

--- a/order/src/main/java/com/klp/order/global/config/KafkaConfig.java
+++ b/order/src/main/java/com/klp/order/global/config/KafkaConfig.java
@@ -1,19 +1,15 @@
 package com.klp.order.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
@@ -90,9 +86,31 @@ public class KafkaConfig {
         props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, true);
         props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, Object.class);
         props.put(JsonDeserializer.TYPE_MAPPINGS,
-            "PaymentCompletedEvent:com.klp.order.infrastructure.event.event.PaymentCompletedEvent,"
+            "PaymentApprovedEvent:com.klp.order.infrastructure.event.event.PaymentApprovedEvent," +
+                "PaymentApprovedFailedEvent:com.klp.order.infrastructure.event.event.PaymentApprovedFailedEvent,"
                 +
-                "DeliveryCreatedEvent:com.klp.order.infrastructure.event.event.DeliveryCreatedEvent");
+                "InventoryDeductedEvent:com.klp.order.infrastructure.event.event.InventoryDeductedEvent,"
+                +
+                "InventoryDeductedFailedEvent:com.klp.order.infrastructure.event.event.InventoryDeductedFailedEvent,"
+                +
+                "DeliveryCreatedEvent:com.klp.order.infrastructure.event.event.DeliveryCreatedEvent,"
+                +
+                "DeliveryCreatedFailedEvent:com.klp.order.infrastructure.event.event.DeliveryCreatedFailedEvent,"
+                +
+                "DeliveryShippingEvent:com.klp.order.infrastructure.event.event.DeliveryShippingEvent,"
+                +
+                "DeliveryShippingFailedEvent:com.klp.order.infrastructure.event.event.DeliveryShippingFailedEvent,"
+                +
+                "DeliveryArrivedEvent:com.klp.order.infrastructure.event.event.DeliveryArrivedEvent,"
+                +
+                "DeliveryArrivedFailedEvent:com.klp.order.infrastructure.event.event.DeliveryArrivedFailedEvent,"
+                +
+                "CouponUsedEvent:com.klp.order.infrastructure.event.event.CouponUsedEvent," +
+                "CouponUsedFailedEvent:com.klp.order.infrastructure.event.event.CouponUsedFailedEvent,"
+                +
+                "UserProfileChangedMessage:com.klp.order.infrastructure.event.dto.UserProfileChangedMessage,"
+                +
+                "ProductInfoChangedMessage:com.klp.order.infrastructure.event.dto.ProductInfoChangedMessage");
 
         // 수동 커밋 설정
         props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);

--- a/order/src/main/java/com/klp/order/infrastructure/client/OrderClient.java
+++ b/order/src/main/java/com/klp/order/infrastructure/client/OrderClient.java
@@ -1,5 +1,0 @@
-package com.klp.order.infrastructure.client;
-
-public interface OrderClient {
-
-}

--- a/order/src/main/java/com/klp/order/infrastructure/client/UserClientImpl.java
+++ b/order/src/main/java/com/klp/order/infrastructure/client/UserClientImpl.java
@@ -3,8 +3,10 @@ package com.klp.order.infrastructure.client;
 import com.klp.order.application.service.UserClient;
 import com.klp.order.common.exception.ExternalApiErrorCode;
 import com.klp.order.common.exception.ExternalApiException;
+import com.klp.order.domain.vo.UserAddressHubId;
 import com.klp.order.domain.vo.UserProfile;
 import feign.FeignException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -25,6 +27,19 @@ public class UserClientImpl implements UserClient {
         } catch (FeignException e) {
             log.error("[UserClient] 외부 유저 서비스 호출 중 오류 - userId: {}, status: {}, message: {}",
                 userId, e.status(), e.getMessage());
+            throw new ExternalApiException(ExternalApiErrorCode.USER_SERVICE_UNAVAILABLE);
+        }
+    }
+
+    @Override
+    public UserAddressHubId getUserAddressHubIdByAddressId(UUID addressId) {
+        try {
+            return userFeignClient.getUserAddressHubIdByAddressId(addressId).toVo();
+        } catch (FeignException.NotFound e) {
+            return null;
+        } catch (FeignException e) {
+            log.error("[UserClient] 외부 유저 서비스 호출 중 오류 - addressId: {}, status: {}, message: {}",
+                addressId, e.status(), e.getMessage());
             throw new ExternalApiException(ExternalApiErrorCode.USER_SERVICE_UNAVAILABLE);
         }
     }

--- a/order/src/main/java/com/klp/order/infrastructure/client/UserFeignClient.java
+++ b/order/src/main/java/com/klp/order/infrastructure/client/UserFeignClient.java
@@ -1,7 +1,9 @@
 package com.klp.order.infrastructure.client;
 
 import com.klp.order.global.config.UserFeignClientConfig;
+import com.klp.order.infrastructure.client.dto.user.UserAddressHubIdDto;
 import com.klp.order.infrastructure.client.dto.user.UserProfileDto;
+import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,4 +15,8 @@ public interface UserFeignClient {
 
     @GetMapping("/v1/internal/users/{userId}")
     UserProfileDto getUserProfileById(@PathVariable Long userId);
+
+    @GetMapping("/v1/internal/users/{addressId}")
+    UserAddressHubIdDto getUserAddressHubIdByAddressId(@PathVariable UUID addressId);
+
 }

--- a/order/src/main/java/com/klp/order/infrastructure/client/dto/user/UserAddressHubIdDto.java
+++ b/order/src/main/java/com/klp/order/infrastructure/client/dto/user/UserAddressHubIdDto.java
@@ -4,12 +4,14 @@ import com.klp.order.domain.vo.UserAddressHubId;
 import java.util.UUID;
 
 public record UserAddressHubIdDto(
-    UUID userAddressHubId
+    UUID userAddressHubId,
+    String address
 ) {
 
     public UserAddressHubId toVo() {
         return new UserAddressHubId(
-            userAddressHubId
+            userAddressHubId,
+            address
         );
     }
 }

--- a/order/src/main/java/com/klp/order/infrastructure/client/dto/user/UserAddressHubIdDto.java
+++ b/order/src/main/java/com/klp/order/infrastructure/client/dto/user/UserAddressHubIdDto.java
@@ -1,0 +1,15 @@
+package com.klp.order.infrastructure.client.dto.user;
+
+import com.klp.order.domain.vo.UserAddressHubId;
+import java.util.UUID;
+
+public record UserAddressHubIdDto(
+    UUID userAddressHubId
+) {
+
+    public UserAddressHubId toVo() {
+        return new UserAddressHubId(
+            userAddressHubId
+        );
+    }
+}

--- a/order/src/main/java/com/klp/order/infrastructure/client/dto/user/UserProfileDto.java
+++ b/order/src/main/java/com/klp/order/infrastructure/client/dto/user/UserProfileDto.java
@@ -24,6 +24,7 @@ public record UserProfileDto(
             affiliationName,
             slackId,
             phone,
+            email,
             gradeName
         );
     }

--- a/order/src/main/java/com/klp/order/infrastructure/event/event/CouponUsedEvent.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/event/CouponUsedEvent.java
@@ -2,7 +2,7 @@ package com.klp.order.infrastructure.event.event;
 
 import java.util.UUID;
 
-public record CouponConfirmedEvent(
+public record CouponUsedEvent(
     UUID couponId,
     UUID orderId) {
 

--- a/order/src/main/java/com/klp/order/infrastructure/event/event/CouponUsedEvent.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/event/CouponUsedEvent.java
@@ -1,9 +1,47 @@
 package com.klp.order.infrastructure.event.event;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public record CouponUsedEvent(
-    UUID couponId,
-    UUID orderId) {
+    UUID orderId,
+    Long userId,
+    UUID supplierId,
+    UUID userCouponId,
+    String email,
 
+    int originalPrice,
+    int couponDiscountPrice,
+    int gradeDiscountPrice,
+    int finalOrderPrice,
+
+    UUID addressId,
+    UUID userAddressHubId,
+    String address,
+    BigDecimal deliveryLatitude,
+    BigDecimal deliveryLongitude,
+
+    List<OrderItem> products,
+
+    String inventoryIdempotencyKey,
+    String deliveryIdempotencyKey,
+
+    LocalDateTime createdAt,
+    LocalDateTime occurredAt
+
+) {
+
+    public record OrderItem(
+        UUID orderItemId,
+        UUID productId,
+        String productName,
+        UUID hubId,
+        Integer quantity,
+        int unitPrice,
+        int totalPrice
+    ) {
+
+    }
 }

--- a/order/src/main/java/com/klp/order/infrastructure/event/event/CouponUsedFailedEvent.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/event/CouponUsedFailedEvent.java
@@ -1,10 +1,46 @@
 package com.klp.order.infrastructure.event.event;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public record CouponUsedFailedEvent(
     UUID orderId,
-    UUID couponId
+    Long userId,
+    UUID supplierId,
+    UUID userCouponId,
+    String email,
+
+    int originalPrice,
+    int couponDiscountPrice,
+    int gradeDiscountPrice,
+    int finalOrderPrice,
+
+    UUID addressId,
+    UUID userAddressHubId,
+    String address,
+    BigDecimal deliveryLatitude,
+    BigDecimal deliveryLongitude,
+
+    List<OrderItem> products,
+
+    String inventoryIdempotencyKey,
+    String deliveryIdempotencyKey,
+
+    LocalDateTime createdAt,
+    LocalDateTime occurredAt
 ) {
 
+    public record OrderItem(
+        UUID orderItemId,
+        UUID productId,
+        String productName,
+        UUID hubId,
+        Integer quantity,
+        int unitPrice,
+        int totalPrice
+    ) {
+
+    }
 }

--- a/order/src/main/java/com/klp/order/infrastructure/event/event/CouponUsedFailedEvent.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/event/CouponUsedFailedEvent.java
@@ -2,8 +2,9 @@ package com.klp.order.infrastructure.event.event;
 
 import java.util.UUID;
 
-public record InventoryConfirmedFailedEvent(
-    UUID orderId
+public record CouponUsedFailedEvent(
+    UUID orderId,
+    UUID couponId
 ) {
 
 }

--- a/order/src/main/java/com/klp/order/infrastructure/event/event/DeliveryArrivedEvent.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/event/DeliveryArrivedEvent.java
@@ -1,0 +1,17 @@
+package com.klp.order.infrastructure.event.event;
+
+import java.util.List;
+import java.util.UUID;
+
+public record DeliveryArrivedEvent(
+    UUID orderId,
+    List<DeliveryItem> items
+) {
+
+    public record DeliveryItem(
+        UUID orderItemId,
+        UUID deliveryId
+    ) {
+
+    }
+}

--- a/order/src/main/java/com/klp/order/infrastructure/event/event/DeliveryArrivedEvent.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/event/DeliveryArrivedEvent.java
@@ -1,16 +1,45 @@
 package com.klp.order.infrastructure.event.event;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
 public record DeliveryArrivedEvent(
     UUID orderId,
-    List<DeliveryItem> items
+    Long userId,
+    UUID supplierId,
+    UUID userCouponId,
+    String email,
+
+    int originalPrice,
+    int couponDiscountPrice,
+    int gradeDiscountPrice,
+    int finalOrderPrice,
+
+    UUID addressId,
+    UUID userAddressHubId,
+    String address,
+    BigDecimal deliveryLatitude,
+    BigDecimal deliveryLongitude,
+
+    List<OrderItem> products,
+
+    String inventoryIdempotencyKey,
+    String deliveryIdempotencyKey,
+
+    LocalDateTime createdAt,
+    LocalDateTime occurredAt
 ) {
 
-    public record DeliveryItem(
+    public record OrderItem(
         UUID orderItemId,
-        UUID deliveryId
+        UUID productId,
+        String productName,
+        UUID hubId,
+        Integer quantity,
+        int unitPrice,
+        int totalPrice
     ) {
 
     }

--- a/order/src/main/java/com/klp/order/infrastructure/event/event/DeliveryArrivedFailedEvent.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/event/DeliveryArrivedFailedEvent.java
@@ -1,0 +1,17 @@
+package com.klp.order.infrastructure.event.event;
+
+import java.util.List;
+import java.util.UUID;
+
+public record DeliveryArrivedFailedEvent(
+    UUID orderId,
+    List<DeliveryItem> items
+) {
+
+    public record DeliveryItem(
+        UUID orderItemId,
+        UUID deliveryId
+    ) {
+
+    }
+}

--- a/order/src/main/java/com/klp/order/infrastructure/event/event/DeliveryArrivedFailedEvent.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/event/DeliveryArrivedFailedEvent.java
@@ -1,16 +1,45 @@
 package com.klp.order.infrastructure.event.event;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
 public record DeliveryArrivedFailedEvent(
     UUID orderId,
-    List<DeliveryItem> items
+    Long userId,
+    UUID supplierId,
+    UUID userCouponId,
+    String email,
+
+    int originalPrice,
+    int couponDiscountPrice,
+    int gradeDiscountPrice,
+    int finalOrderPrice,
+
+    UUID addressId,
+    UUID userAddressHubId,
+    String address,
+    BigDecimal deliveryLatitude,
+    BigDecimal deliveryLongitude,
+
+    List<OrderCreatedEvent.OrderItem> products,
+
+    String inventoryIdempotencyKey,
+    String deliveryIdempotencyKey,
+
+    LocalDateTime createdAt,
+    LocalDateTime occurredAt
 ) {
 
-    public record DeliveryItem(
+    public record OrderItem(
         UUID orderItemId,
-        UUID deliveryId
+        UUID productId,
+        String productName,
+        UUID hubId,
+        Integer quantity,
+        int unitPrice,
+        int totalPrice
     ) {
 
     }

--- a/order/src/main/java/com/klp/order/infrastructure/event/event/DeliveryCreatedEvent.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/event/DeliveryCreatedEvent.java
@@ -3,6 +3,10 @@ package com.klp.order.infrastructure.event.event;
 import java.util.List;
 import java.util.UUID;
 
+/*
+ * 이 event만 일단 두겠습니다. 명진님!
+ * 지금 이거를 다른것과 동일하게 바꾸면 빨간불이 많이 뜨는데 커버하기 힘들거 같습니다..
+ * */
 public record DeliveryCreatedEvent(
     UUID orderId,
     List<DeliveryItem> items

--- a/order/src/main/java/com/klp/order/infrastructure/event/event/DeliveryCreatedFailedEvent.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/event/DeliveryCreatedFailedEvent.java
@@ -3,6 +3,10 @@ package com.klp.order.infrastructure.event.event;
 import java.util.List;
 import java.util.UUID;
 
+/*
+ * 이 event만 일단 두겠습니다. 명진님!
+ * 지금 이거를 다른것과 동일하게 바꾸면 빨간불이 많이 뜨는데 커버하기 힘들거 같습니다..
+ * */
 public record DeliveryCreatedFailedEvent(
     UUID orderId,
     List<DeliveryItem> items

--- a/order/src/main/java/com/klp/order/infrastructure/event/event/DeliveryCreatedFailedEvent.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/event/DeliveryCreatedFailedEvent.java
@@ -3,7 +3,7 @@ package com.klp.order.infrastructure.event.event;
 import java.util.List;
 import java.util.UUID;
 
-public record DeliveryCompletedEvent(
+public record DeliveryCreatedFailedEvent(
     UUID orderId,
     List<DeliveryItem> items
 ) {

--- a/order/src/main/java/com/klp/order/infrastructure/event/event/DeliveryShippingEvent.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/event/DeliveryShippingEvent.java
@@ -1,16 +1,45 @@
 package com.klp.order.infrastructure.event.event;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
 public record DeliveryShippingEvent(
     UUID orderId,
-    List<DeliveryItem> items
+    Long userId,
+    UUID supplierId,
+    UUID userCouponId,
+    String email,
+
+    int originalPrice,
+    int couponDiscountPrice,
+    int gradeDiscountPrice,
+    int finalOrderPrice,
+
+    UUID addressId,
+    UUID userAddressHubId,
+    String address,
+    BigDecimal deliveryLatitude,
+    BigDecimal deliveryLongitude,
+
+    List<OrderItem> products,
+
+    String inventoryIdempotencyKey,
+    String deliveryIdempotencyKey,
+
+    LocalDateTime createdAt,
+    LocalDateTime occurredAt
 ) {
 
-    public record DeliveryItem(
+    public record OrderItem(
         UUID orderItemId,
-        UUID deliveryId
+        UUID productId,
+        String productName,
+        UUID hubId,
+        Integer quantity,
+        int unitPrice,
+        int totalPrice
     ) {
 
     }

--- a/order/src/main/java/com/klp/order/infrastructure/event/event/DeliveryShippingFailedEvent.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/event/DeliveryShippingFailedEvent.java
@@ -1,16 +1,45 @@
 package com.klp.order.infrastructure.event.event;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
 public record DeliveryShippingFailedEvent(
     UUID orderId,
-    List<DeliveryItem> items
+    Long userId,
+    UUID supplierId,
+    UUID userCouponId,
+    String email,
+
+    int originalPrice,
+    int couponDiscountPrice,
+    int gradeDiscountPrice,
+    int finalOrderPrice,
+
+    UUID addressId,
+    UUID userAddressHubId,
+    String address,
+    BigDecimal deliveryLatitude,
+    BigDecimal deliveryLongitude,
+
+    List<OrderCreatedEvent.OrderItem> products,
+
+    String inventoryIdempotencyKey,
+    String deliveryIdempotencyKey,
+
+    LocalDateTime createdAt,
+    LocalDateTime occurredAt
 ) {
 
-    public record DeliveryItem(
+    public record OrderItem(
         UUID orderItemId,
-        UUID deliveryId
+        UUID productId,
+        String productName,
+        UUID hubId,
+        Integer quantity,
+        int unitPrice,
+        int totalPrice
     ) {
 
     }

--- a/order/src/main/java/com/klp/order/infrastructure/event/event/DeliveryShippingFailedEvent.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/event/DeliveryShippingFailedEvent.java
@@ -1,0 +1,17 @@
+package com.klp.order.infrastructure.event.event;
+
+import java.util.List;
+import java.util.UUID;
+
+public record DeliveryShippingFailedEvent(
+    UUID orderId,
+    List<DeliveryItem> items
+) {
+
+    public record DeliveryItem(
+        UUID orderItemId,
+        UUID deliveryId
+    ) {
+
+    }
+}

--- a/order/src/main/java/com/klp/order/infrastructure/event/event/InventoryDeductedEvent.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/event/InventoryDeductedEvent.java
@@ -1,9 +1,46 @@
 package com.klp.order.infrastructure.event.event;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public record InventoryDeductedEvent(
-    UUID orderId
+    UUID orderId,
+    Long userId,
+    UUID supplierId,
+    UUID userCouponId,
+    String email,
+
+    int originalPrice,
+    int couponDiscountPrice,
+    int gradeDiscountPrice,
+    int finalOrderPrice,
+
+    UUID addressId,
+    UUID userAddressHubId,
+    String address,
+    BigDecimal deliveryLatitude,
+    BigDecimal deliveryLongitude,
+
+    List<OrderItem> products,
+
+    String inventoryIdempotencyKey,
+    String deliveryIdempotencyKey,
+
+    LocalDateTime createdAt,
+    LocalDateTime occurredAt
 ) {
 
+    public record OrderItem(
+        UUID orderItemId,
+        UUID productId,
+        String productName,
+        UUID hubId,
+        Integer quantity,
+        int unitPrice,
+        int totalPrice
+    ) {
+
+    }
 }

--- a/order/src/main/java/com/klp/order/infrastructure/event/event/InventoryDeductedFailedEvent.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/event/InventoryDeductedFailedEvent.java
@@ -2,9 +2,8 @@ package com.klp.order.infrastructure.event.event;
 
 import java.util.UUID;
 
-public record CouponUseFailedEvent(
-    UUID orderId,
-    UUID couponId
+public record InventoryDeductedFailedEvent(
+    UUID orderId
 ) {
 
 }

--- a/order/src/main/java/com/klp/order/infrastructure/event/event/InventoryDeductedFailedEvent.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/event/InventoryDeductedFailedEvent.java
@@ -1,9 +1,46 @@
 package com.klp.order.infrastructure.event.event;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public record InventoryDeductedFailedEvent(
-    UUID orderId
+    UUID orderId,
+    Long userId,
+    UUID supplierId,
+    UUID userCouponId,
+    String email,
+
+    int originalPrice,
+    int couponDiscountPrice,
+    int gradeDiscountPrice,
+    int finalOrderPrice,
+
+    UUID addressId,
+    UUID userAddressHubId,
+    String address,
+    BigDecimal deliveryLatitude,
+    BigDecimal deliveryLongitude,
+
+    List<OrderItem> products,
+
+    String inventoryIdempotencyKey,
+    String deliveryIdempotencyKey,
+
+    LocalDateTime createdAt,
+    LocalDateTime occurredAt
 ) {
 
+    public record OrderItem(
+        UUID orderItemId,
+        UUID productId,
+        String productName,
+        UUID hubId,
+        Integer quantity,
+        int unitPrice,
+        int totalPrice
+    ) {
+
+    }
 }

--- a/order/src/main/java/com/klp/order/infrastructure/event/event/OrderCreatedEvent.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/event/OrderCreatedEvent.java
@@ -11,25 +11,29 @@ public record OrderCreatedEvent(
     Long userId,
     UUID supplierId,
     UUID userCouponId,
+    String email,
 
     int originalPrice,
     int couponDiscountPrice,
     int gradeDiscountPrice,
     int finalOrderPrice,
 
-    String deliveryAddress,
+    UUID addressId,
+    UUID userAddressHubId,
+    String address,
     BigDecimal deliveryLatitude,
     BigDecimal deliveryLongitude,
 
-    List<ProductDeduction> products,
+    List<OrderItem> products,
 
     String inventoryIdempotencyKey,
     String deliveryIdempotencyKey,
 
+    LocalDateTime createdAt,
     LocalDateTime occurredAt
 ) {
 
-    public record ProductDeduction(
+    public record OrderItem(
         UUID orderItemId,
         UUID productId,
         String productName,
@@ -43,11 +47,14 @@ public record OrderCreatedEvent(
 
     public static OrderCreatedEvent from(
         Order order,
+        String email,
+        String address,
         String inventoryIdempotencyKey,
-        String deliveryIdempotencyKey
+        String deliveryIdempotencyKey,
+        UUID userAddressHubId
     ) {
-        List<ProductDeduction> products = order.getOrderItems().stream()
-            .map(item -> new ProductDeduction(
+        List<OrderItem> orderItems = order.getOrderItems().stream()
+            .map(item -> new OrderItem(
                 item.getOrderItemId(),
                 item.getProductId(),
                 item.getProductName(),
@@ -63,16 +70,20 @@ public record OrderCreatedEvent(
             order.getUserId(),
             order.getSupplierId(),
             order.getUserCouponId(),
+            email,
             order.getOriginalPrice(),
             order.getCouponDiscountPrice(),
             order.getGradeDiscountPrice(),
             order.getOrderPrice(),
-            order.getDeliveryAddress(),
+            order.getAddressId(),
+            userAddressHubId,
+            address,
             order.getDeliveryLatitude(),
             order.getDeliveryLongitude(),
-            products,
+            orderItems,
             inventoryIdempotencyKey,
             deliveryIdempotencyKey,
+            order.getCreatedAt(),
             LocalDateTime.now()
         );
     }

--- a/order/src/main/java/com/klp/order/infrastructure/event/event/PaymentApprovedEvent.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/event/PaymentApprovedEvent.java
@@ -3,7 +3,7 @@ package com.klp.order.infrastructure.event.event;
 import java.util.UUID;
 
 // 아직 결제 쪽이 구현이 안되어있기 때문에 추후에 코드 수정하겠습니다.
-public record PaymentCompletedEvent(
+public record PaymentApprovedEvent(
     UUID orderId,
     UUID paymentId
 ) {

--- a/order/src/main/java/com/klp/order/infrastructure/event/event/PaymentApprovedEvent.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/event/PaymentApprovedEvent.java
@@ -1,11 +1,46 @@
 package com.klp.order.infrastructure.event.event;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
-// 아직 결제 쪽이 구현이 안되어있기 때문에 추후에 코드 수정하겠습니다.
 public record PaymentApprovedEvent(
     UUID orderId,
-    UUID paymentId
+    Long userId,
+    UUID supplierId,
+    UUID userCouponId,
+    String email,
+
+    int originalPrice,
+    int couponDiscountPrice,
+    int gradeDiscountPrice,
+    int finalOrderPrice,
+
+    UUID addressId,
+    UUID userAddressHubId,
+    String address,
+    BigDecimal deliveryLatitude,
+    BigDecimal deliveryLongitude,
+
+    List<OrderItem> products,
+
+    String inventoryIdempotencyKey,
+    String deliveryIdempotencyKey,
+
+    LocalDateTime createdAt,
+    LocalDateTime occurredAt
 ) {
 
+    public record OrderItem(
+        UUID orderItemId,
+        UUID productId,
+        String productName,
+        UUID hubId,
+        Integer quantity,
+        int unitPrice,
+        int totalPrice
+    ) {
+
+    }
 }

--- a/order/src/main/java/com/klp/order/infrastructure/event/event/PaymentApprovedFailedEvent.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/event/PaymentApprovedFailedEvent.java
@@ -1,9 +1,46 @@
 package com.klp.order.infrastructure.event.event;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public record PaymentApprovedFailedEvent(
-    UUID orderId
+    UUID orderId,
+    Long userId,
+    UUID supplierId,
+    UUID userCouponId,
+    String email,
+
+    int originalPrice,
+    int couponDiscountPrice,
+    int gradeDiscountPrice,
+    int finalOrderPrice,
+
+    UUID addressId,
+    UUID userAddressHubId,
+    String address,
+    BigDecimal deliveryLatitude,
+    BigDecimal deliveryLongitude,
+
+    List<OrderItem> products,
+
+    String inventoryIdempotencyKey,
+    String deliveryIdempotencyKey,
+
+    LocalDateTime createdAt,
+    LocalDateTime occurredAt
 ) {
 
+    public record OrderItem(
+        UUID orderItemId,
+        UUID productId,
+        String productName,
+        UUID hubId,
+        Integer quantity,
+        int unitPrice,
+        int totalPrice
+    ) {
+
+    }
 }

--- a/order/src/main/java/com/klp/order/infrastructure/event/event/PaymentApprovedFailedEvent.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/event/PaymentApprovedFailedEvent.java
@@ -2,7 +2,7 @@ package com.klp.order.infrastructure.event.event;
 
 import java.util.UUID;
 
-public record PaymentFailedEvent(
+public record PaymentApprovedFailedEvent(
     UUID orderId
 ) {
 

--- a/order/src/main/java/com/klp/order/infrastructure/event/listener/CouponUsedEventListener.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/listener/CouponUsedEventListener.java
@@ -1,11 +1,10 @@
 package com.klp.order.infrastructure.event.listener;
 
-
 import com.klp.order.application.service.OrderService;
 import com.klp.order.domain.entity.order.Order;
 import com.klp.order.domain.entity.order.OrderStatus;
 import com.klp.order.domain.repository.OrderRepository;
-import com.klp.order.infrastructure.event.event.PaymentFailedEvent;
+import com.klp.order.infrastructure.event.event.CouponUsedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.DltHandler;
@@ -23,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class PaymentFailedEventListener {
+public class CouponUsedEventListener {
 
     private final OrderService orderService;
     private final OrderRepository orderRepository;
@@ -35,38 +34,39 @@ public class PaymentFailedEventListener {
         include = Exception.class,
         topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE
     )
-    // 결제 완료 이벤트를 받으면 배송 생성 요청 이벤트를 발행
     @KafkaListener(
-        topics = "payment.failed",
+        topics = "coupon.topic",
         groupId = "order-service-group",
         containerFactory = "kafkaListenerContainerFactory"
     )
     @Transactional
-    public void handlePaymentCompleted(
-        @Payload PaymentFailedEvent event,
+    public void handleCoupon(
+        @Payload CouponUsedEvent event,
         @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
         @Header(KafkaHeaders.OFFSET) long offset,
         Acknowledgment acknowledgment) {
 
-        log.info("=== 결제 실패 이벤트 수신: orderId={}, partition={}, offset={} ===",
-            event.orderId(), partition, offset);
+        log.info("=== 쿠폰 사용 완료 이벤트 수신: orderId={},couponId={}, partition={}, offset={} ===",
+            event.orderId(), event.couponId(), partition, offset);
 
         try {
             // 1. 주문 조회 후 상태 변경
             Order order = orderService.findById(event.orderId());
             log.info("주문 조회 완료 - orderId: {}", order.getOrderId());
 
-            if (order.getOrderStatus() == OrderStatus.FAILED) {
-                log.info("이미 처리된 결제 실패 이벤트 - orderId: {}", event.orderId());
+            if (order.getOrderStatus() == OrderStatus.COMPLETE
+                || order.getOrderStatus() == OrderStatus.COUPON_CONFIRMED) {
+                log.info("이미 처리된 쿠폰 사용 이벤트 - orderId: {}", event.orderId());
                 if (acknowledgment != null) {
                     acknowledgment.acknowledge();
                 }
                 return;
             }
 
-            order.changeStatus(OrderStatus.PAID_FAILED);
+            order.changeStatus(OrderStatus.COUPON_CONFIRMED);
             orderRepository.save(order);
-            log.info("=== 결제 실패 이벤트 처리 완료: orderId={} ===", event.orderId());
+            log.info("=== 쿠폰 사용 완료 이벤트 처리 완료: orderId={}, couponId={} ===", event.orderId(),
+                event.couponId());
 
             if (acknowledgment != null) {
                 acknowledgment.acknowledge();
@@ -74,23 +74,24 @@ public class PaymentFailedEventListener {
             }
 
         } catch (Exception e) {
-            log.error("결제 실패 이벤트 처리 실패: orderId={}, partition={}, offset={}",
-                event.orderId(), partition, offset, e);
+            log.error("쿠폰 사용 완료 이벤트 처리 실패: orderId={}, couponId={}, partition={}, offset={}",
+                event.orderId(), event.couponId(), partition, offset, e);
             throw e;
         }
     }
 
     // 실패시 자동으로 호출한다고 합니다.
     @DltHandler
-    public void handlePaymentFailedDlt(
-        @Payload PaymentFailedEvent event,
+    public void handleCouponUsedDlt(
+        @Payload CouponUsedEvent event,
         @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
         @Header(KafkaHeaders.EXCEPTION_MESSAGE) String exceptionMessage) {
 
         log.error("========================================");
-        log.error("⚠️ DLT 도착: Payment Failed Event");
+        log.error("⚠️ DLT 도착: Coupon Used Event");
         log.error("⚠️ 수동 처리가 필요합니다!");
         log.error("========================================");
         log.error("orderId={}, error={}", event.orderId(), exceptionMessage);
     }
+
 }

--- a/order/src/main/java/com/klp/order/infrastructure/event/listener/CouponUsedEventListener.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/listener/CouponUsedEventListener.java
@@ -47,7 +47,7 @@ public class CouponUsedEventListener {
         Acknowledgment acknowledgment) {
 
         log.info("=== 쿠폰 사용 완료 이벤트 수신: orderId={},couponId={}, partition={}, offset={} ===",
-            event.orderId(), event.couponId(), partition, offset);
+            event.orderId(), event.userCouponId(), partition, offset);
 
         try {
             // 1. 주문 조회 후 상태 변경
@@ -66,7 +66,7 @@ public class CouponUsedEventListener {
             order.changeStatus(OrderStatus.COUPON_CONFIRMED);
             orderRepository.save(order);
             log.info("=== 쿠폰 사용 완료 이벤트 처리 완료: orderId={}, couponId={} ===", event.orderId(),
-                event.couponId());
+                event.userCouponId());
 
             if (acknowledgment != null) {
                 acknowledgment.acknowledge();
@@ -75,7 +75,7 @@ public class CouponUsedEventListener {
 
         } catch (Exception e) {
             log.error("쿠폰 사용 완료 이벤트 처리 실패: orderId={}, couponId={}, partition={}, offset={}",
-                event.orderId(), event.couponId(), partition, offset, e);
+                event.orderId(), event.userCouponId(), partition, offset, e);
             throw e;
         }
     }

--- a/order/src/main/java/com/klp/order/infrastructure/event/listener/CouponUsedFailedEventListener.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/listener/CouponUsedFailedEventListener.java
@@ -3,8 +3,8 @@ package com.klp.order.infrastructure.event.listener;
 import com.klp.order.application.service.OrderService;
 import com.klp.order.domain.entity.order.Order;
 import com.klp.order.domain.entity.order.OrderStatus;
-import com.klp.order.infrastructure.event.event.DeliveryCompletedEvent;
-import com.klp.order.infrastructure.event.event.DeliveryCreatedEvent;
+import com.klp.order.domain.repository.OrderRepository;
+import com.klp.order.infrastructure.event.event.CouponUsedFailedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.DltHandler;
@@ -22,9 +22,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class DeliveryCompletedEventListener {
+public class CouponUsedFailedEventListener {
 
     private final OrderService orderService;
+    private final OrderRepository orderRepository;
 
     @RetryableTopic(
         attempts = "3",
@@ -34,65 +35,63 @@ public class DeliveryCompletedEventListener {
         topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE
     )
     @KafkaListener(
-        topics = "delivery.completed",
+        topics = "coupon.topic",
         groupId = "order-service-group",
         containerFactory = "kafkaListenerContainerFactory"
     )
     @Transactional
-    public void handleDeliveryCompleted(
-        @Payload DeliveryCompletedEvent event,
+    public void handleCouponUseFailed(
+        @Payload CouponUsedFailedEvent event,
         @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
         @Header(KafkaHeaders.OFFSET) long offset,
         Acknowledgment acknowledgment) {
 
-        log.info("=== 배송 완료 이벤트 수신: orderId={}, partition={}, offset={}, items={} ===",
-            event.orderId(), partition, offset, event.items().size());
+        log.info("=== 쿠폰 사용 실패 이벤트 수신: orderId={},couponId={}, partition={}, offset={} ===",
+            event.orderId(), event.couponId(), partition, offset);
 
         try {
-            // 1. 주문 조회
+            // 1. 주문 조회 후 상태 변경
             Order order = orderService.findById(event.orderId());
-            log.info("주문 조회 완료 - orderId: {}, 현재 상태: {}",
-                order.getOrderId(), order.getOrderStatus());
+            log.info("주문 조회 완료 - orderId: {}", order.getOrderId());
 
-            if (order.getOrderStatus() == OrderStatus.COMPLETE) {
-                log.info("이미 처리된 배송 완료 이벤트 - orderId: {}", event.orderId());
+            if (order.getOrderStatus() == OrderStatus.FAILED
+                || order.getOrderStatus() == OrderStatus.COUPON_CONFIRMED_FAILED) {
+                log.info("이미 처리된 재고 확정 실패 이벤트 - orderId: {}", event.orderId());
                 if (acknowledgment != null) {
                     acknowledgment.acknowledge();
                 }
                 return;
             }
-            order.changeStatus(OrderStatus.COMPLETE);
 
-            // 4. 수동 커밋
+            order.changeStatus(OrderStatus.COUPON_CONFIRMED_FAILED);
+            orderRepository.save(order);
+            log.info("=== 쿠폰 사용 실패 이벤트 처리 완료: orderId={}, couponId={} ===", event.orderId(),
+                event.couponId());
+
             if (acknowledgment != null) {
                 acknowledgment.acknowledge();
                 log.info("오프셋 커밋 완료: orderId={}, offset={}", event.orderId(), offset);
             }
 
-            log.info("=== 배송 완료 이벤트 처리 완료: orderId={}, 상태={} ===",
-                event.orderId(), OrderStatus.DELIVERY_CREATED);
-
         } catch (Exception e) {
-            log.error("배송 완료 이벤트 처리 실패: orderId={}, partition={}, offset={}",
-                event.orderId(), partition, offset, e);
-
-            // 이벤트 처리 실패 시 재시도를 위해 예외를 다시 던짐
-            // DefaultErrorHandler가 재시도 처리
+            log.error("쿠폰 사용 실패 이벤트 처리 실패: orderId={}, couponId={}, partition={}, offset={}",
+                event.orderId(), event.couponId(), partition, offset, e);
             throw e;
         }
     }
 
     // 실패시 자동으로 호출한다고 합니다.
     @DltHandler
-    public void handleDeliveryCreatedDlt(
-        @Payload DeliveryCreatedEvent event,
+    public void handleCouponUseFaileddDlt(
+        @Payload CouponUsedFailedEvent event,
         @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
         @Header(KafkaHeaders.EXCEPTION_MESSAGE) String exceptionMessage) {
 
         log.error("========================================");
-        log.error("⚠️ DLT 도착: Delivery Completed Event");
+        log.error("⚠️ DLT 도착: Coupon Use Failed Event");
         log.error("⚠️ 수동 처리가 필요합니다!");
         log.error("========================================");
         log.error("orderId={}, error={}", event.orderId(), exceptionMessage);
     }
+
 }

--- a/order/src/main/java/com/klp/order/infrastructure/event/listener/CouponUsedFailedEventListener.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/listener/CouponUsedFailedEventListener.java
@@ -47,7 +47,7 @@ public class CouponUsedFailedEventListener {
         Acknowledgment acknowledgment) {
 
         log.info("=== 쿠폰 사용 실패 이벤트 수신: orderId={},couponId={}, partition={}, offset={} ===",
-            event.orderId(), event.couponId(), partition, offset);
+            event.orderId(), event.userCouponId(), partition, offset);
 
         try {
             // 1. 주문 조회 후 상태 변경
@@ -66,7 +66,7 @@ public class CouponUsedFailedEventListener {
             order.changeStatus(OrderStatus.COUPON_CONFIRMED_FAILED);
             orderRepository.save(order);
             log.info("=== 쿠폰 사용 실패 이벤트 처리 완료: orderId={}, couponId={} ===", event.orderId(),
-                event.couponId());
+                event.userCouponId());
 
             if (acknowledgment != null) {
                 acknowledgment.acknowledge();
@@ -75,7 +75,7 @@ public class CouponUsedFailedEventListener {
 
         } catch (Exception e) {
             log.error("쿠폰 사용 실패 이벤트 처리 실패: orderId={}, couponId={}, partition={}, offset={}",
-                event.orderId(), event.couponId(), partition, offset, e);
+                event.orderId(), event.userCouponId(), partition, offset, e);
             throw e;
         }
     }

--- a/order/src/main/java/com/klp/order/infrastructure/event/listener/DeliveryArrivedEventListener.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/listener/DeliveryArrivedEventListener.java
@@ -47,8 +47,8 @@ public class DeliveryArrivedEventListener {
         @Header(KafkaHeaders.OFFSET) long offset,
         Acknowledgment acknowledgment) {
 
-        log.info("=== 배송 완료 이벤트 수신: orderId={}, partition={}, offset={}, items={} ===",
-            event.orderId(), partition, offset, event.items().size());
+        log.info("=== 배송 완료 이벤트 수신: orderId={}, partition={}, offset={}, products={} ===",
+            event.orderId(), partition, offset, event.products().size());
 
         try {
             // 1. 주문 조회

--- a/order/src/main/java/com/klp/order/infrastructure/event/listener/DeliveryArrivedEventListener.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/listener/DeliveryArrivedEventListener.java
@@ -4,7 +4,8 @@ import com.klp.order.application.service.OrderService;
 import com.klp.order.domain.entity.order.Order;
 import com.klp.order.domain.entity.order.OrderStatus;
 import com.klp.order.domain.repository.OrderRepository;
-import com.klp.order.infrastructure.event.event.CouponConfirmedEvent;
+import com.klp.order.infrastructure.event.event.DeliveryArrivedEvent;
+import com.klp.order.infrastructure.event.event.DeliveryCreatedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.DltHandler;
@@ -22,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class CouponEventListener {
+public class DeliveryArrivedEventListener {
 
     private final OrderService orderService;
     private final OrderRepository orderRepository;
@@ -34,64 +35,67 @@ public class CouponEventListener {
         include = Exception.class,
         topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE
     )
-    // 결제 완료 이벤트를 받으면 배송 생성 요청 이벤트를 발행
     @KafkaListener(
-        topics = "coupon.confirmed",
+        topics = "delivery.topic",
         groupId = "order-service-group",
         containerFactory = "kafkaListenerContainerFactory"
     )
     @Transactional
-    public void handleCouponConfirmed(
-        @Payload CouponConfirmedEvent event,
+    public void handleDeliveryArrived(
+        @Payload DeliveryArrivedEvent event,
         @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
         @Header(KafkaHeaders.OFFSET) long offset,
         Acknowledgment acknowledgment) {
 
-        log.info("=== 쿠폰 사용 완료 이벤트 수신: orderId={},couponId={}, partition={}, offset={} ===",
-            event.orderId(), event.couponId(), partition, offset);
+        log.info("=== 배송 완료 이벤트 수신: orderId={}, partition={}, offset={}, items={} ===",
+            event.orderId(), partition, offset, event.items().size());
 
         try {
-            // 1. 주문 조회 후 상태 변경
+            // 1. 주문 조회
             Order order = orderService.findById(event.orderId());
-            log.info("주문 조회 완료 - orderId: {}", order.getOrderId());
+            log.info("주문 조회 완료 - orderId: {}, 현재 상태: {}",
+                order.getOrderId(), order.getOrderStatus());
 
-            if (order.getOrderStatus() == OrderStatus.COMPLETE
-                || order.getOrderStatus() == OrderStatus.COUPON_CONFIRMED) {
-                log.info("이미 처리된 쿠폰 사용 이벤트 - orderId: {}", event.orderId());
+            if (order.getOrderStatus() == OrderStatus.COMPLETE) {
+                log.info("이미 처리된 배송 완료 이벤트 - orderId: {}", event.orderId());
                 if (acknowledgment != null) {
                     acknowledgment.acknowledge();
                 }
                 return;
             }
+            order.changeStatus(OrderStatus.COMPLETE);
+            orderRepository.save(order);
 
-            order.changeStatus(OrderStatus.COUPON_CONFIRMED);
-            log.info("=== 쿠폰 사용 완료 이벤트 처리 완료: orderId={}, couponId={} ===", event.orderId(),
-                event.couponId());
-
+            // 4. 수동 커밋
             if (acknowledgment != null) {
                 acknowledgment.acknowledge();
                 log.info("오프셋 커밋 완료: orderId={}, offset={}", event.orderId(), offset);
             }
 
+            log.info("=== 배송 완료 이벤트 처리 완료: orderId={}, 상태={} ===",
+                event.orderId(), OrderStatus.COMPLETE);
+
         } catch (Exception e) {
-            log.error("쿠폰 사용 완료 이벤트 처리 실패: orderId={}, couponId={}, partition={}, offset={}",
-                event.orderId(), event.couponId(), partition, offset, e);
+            log.error("배송 완료 이벤트 처리 실패: orderId={}, partition={}, offset={}",
+                event.orderId(), partition, offset, e);
+
+            // 이벤트 처리 실패 시 재시도를 위해 예외를 다시 던짐
+            // DefaultErrorHandler가 재시도 처리
             throw e;
         }
     }
 
     // 실패시 자동으로 호출한다고 합니다.
     @DltHandler
-    public void handleCouponConfirmedDlt(
-        @Payload CouponConfirmedEvent event,
+    public void handleDeliveryArrivedDlt(
+        @Payload DeliveryCreatedEvent event,
         @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
         @Header(KafkaHeaders.EXCEPTION_MESSAGE) String exceptionMessage) {
 
         log.error("========================================");
-        log.error("⚠️ DLT 도착: Coupon Confirmed Event");
+        log.error("⚠️ DLT 도착: Delivery Arrived Event");
         log.error("⚠️ 수동 처리가 필요합니다!");
         log.error("========================================");
         log.error("orderId={}, error={}", event.orderId(), exceptionMessage);
     }
-
 }

--- a/order/src/main/java/com/klp/order/infrastructure/event/listener/DeliveryArrivedFailedEventListener.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/listener/DeliveryArrivedFailedEventListener.java
@@ -47,8 +47,8 @@ public class DeliveryArrivedFailedEventListener {
         @Header(KafkaHeaders.OFFSET) long offset,
         Acknowledgment acknowledgment) {
 
-        log.info("=== 배송 완료 실패 이벤트 수신: orderId={}, partition={}, offset={}, items={} ===",
-            event.orderId(), partition, offset, event.items().size());
+        log.info("=== 배송 완료 실패 이벤트 수신: orderId={}, partition={}, offset={}, products={} ===",
+            event.orderId(), partition, offset, event.products().size());
 
         try {
             // 1. 주문 조회

--- a/order/src/main/java/com/klp/order/infrastructure/event/listener/DeliveryArrivedFailedEventListener.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/listener/DeliveryArrivedFailedEventListener.java
@@ -4,8 +4,8 @@ import com.klp.order.application.service.OrderService;
 import com.klp.order.domain.entity.order.Order;
 import com.klp.order.domain.entity.order.OrderStatus;
 import com.klp.order.domain.repository.OrderRepository;
-import com.klp.order.infrastructure.event.event.DeliveryCreatedEvent;
-import com.klp.order.infrastructure.event.event.DeliveryShippingEvent;
+import com.klp.order.infrastructure.event.event.DeliveryArrivedFailedEvent;
+import com.klp.order.infrastructure.event.event.DeliveryCreatedFailedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.DltHandler;
@@ -23,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class DeliveryShippingEventListener {
+public class DeliveryArrivedFailedEventListener {
 
     private final OrderService orderService;
     private final OrderRepository orderRepository;
@@ -41,13 +41,13 @@ public class DeliveryShippingEventListener {
         containerFactory = "kafkaListenerContainerFactory"
     )
     @Transactional
-    public void handleDeliveryShipping(
-        @Payload DeliveryShippingEvent event,
+    public void handleDeliveryArrivedFailed(
+        @Payload DeliveryArrivedFailedEvent event,
         @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
         @Header(KafkaHeaders.OFFSET) long offset,
         Acknowledgment acknowledgment) {
 
-        log.info("=== 배송 중 이벤트 수신: orderId={}, partition={}, offset={}, items={} ===",
+        log.info("=== 배송 완료 실패 이벤트 수신: orderId={}, partition={}, offset={}, items={} ===",
             event.orderId(), partition, offset, event.items().size());
 
         try {
@@ -56,14 +56,15 @@ public class DeliveryShippingEventListener {
             log.info("주문 조회 완료 - orderId: {}, 현재 상태: {}",
                 order.getOrderId(), order.getOrderStatus());
 
-            if (order.getOrderStatus() == OrderStatus.DELIVERY_SHIPPING) {
-                log.info("이미 처리된 배송 중 이벤트 - orderId: {}", event.orderId());
+            if (order.getOrderStatus() == OrderStatus.FAILED
+                || order.getOrderStatus() == OrderStatus.DELIVERY_ARRIVED_FAILED) {
+                log.info("이미 처리된 배송 완료 실패 이벤트 - orderId: {}", event.orderId());
                 if (acknowledgment != null) {
                     acknowledgment.acknowledge();
                 }
                 return;
             }
-            order.changeStatus(OrderStatus.DELIVERY_SHIPPING);
+            order.changeStatus(OrderStatus.DELIVERY_ARRIVED_FAILED);
             orderRepository.save(order);
 
             // 4. 수동 커밋
@@ -72,11 +73,11 @@ public class DeliveryShippingEventListener {
                 log.info("오프셋 커밋 완료: orderId={}, offset={}", event.orderId(), offset);
             }
 
-            log.info("=== 배송 중 이벤트 처리 완료: orderId={}, 상태={} ===",
-                event.orderId(), OrderStatus.DELIVERY_CREATED);
+            log.info("=== 배송 완료 실패 이벤트 처리 완료: orderId={}, 상태={} ===",
+                event.orderId(), OrderStatus.DELIVERY_ARRIVED_FAILED);
 
         } catch (Exception e) {
-            log.error("배송 중 이벤트 처리 실패: orderId={}, partition={}, offset={}",
+            log.error("배송 완료 이벤트 처리 실패: orderId={}, partition={}, offset={}",
                 event.orderId(), partition, offset, e);
 
             // 이벤트 처리 실패 시 재시도를 위해 예외를 다시 던짐
@@ -87,13 +88,13 @@ public class DeliveryShippingEventListener {
 
     // 실패시 자동으로 호출한다고 합니다.
     @DltHandler
-    public void handleDeliveryCreatedDlt(
-        @Payload DeliveryCreatedEvent event,
+    public void handleDeliveryArrivedFailedDlt(
+        @Payload DeliveryCreatedFailedEvent event,
         @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
         @Header(KafkaHeaders.EXCEPTION_MESSAGE) String exceptionMessage) {
 
         log.error("========================================");
-        log.error("⚠️ DLT 도착: Delivery Shipping Event");
+        log.error("⚠️ DLT 도착: Delivery Arrived Failed Event");
         log.error("⚠️ 수동 처리가 필요합니다!");
         log.error("========================================");
         log.error("orderId={}, error={}", event.orderId(), exceptionMessage);

--- a/order/src/main/java/com/klp/order/infrastructure/event/listener/DeliveryCreatedEventListener.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/listener/DeliveryCreatedEventListener.java
@@ -39,7 +39,7 @@ public class DeliveryCreatedEventListener {
         topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE
     )
     @KafkaListener(
-        topics = "delivery.created",
+        topics = "delivery.topic",
         groupId = "order-service-group",
         containerFactory = "kafkaListenerContainerFactory"
     )

--- a/order/src/main/java/com/klp/order/infrastructure/event/listener/DeliveryCreatedFailedEventListener.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/listener/DeliveryCreatedFailedEventListener.java
@@ -4,8 +4,7 @@ import com.klp.order.application.service.OrderService;
 import com.klp.order.domain.entity.order.Order;
 import com.klp.order.domain.entity.order.OrderStatus;
 import com.klp.order.domain.repository.OrderRepository;
-import com.klp.order.infrastructure.event.event.DeliveryCreatedEvent;
-import com.klp.order.infrastructure.event.event.DeliveryShippingEvent;
+import com.klp.order.infrastructure.event.event.DeliveryCreatedFailedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.DltHandler;
@@ -23,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class DeliveryShippingEventListener {
+public class DeliveryCreatedFailedEventListener {
 
     private final OrderService orderService;
     private final OrderRepository orderRepository;
@@ -41,13 +40,13 @@ public class DeliveryShippingEventListener {
         containerFactory = "kafkaListenerContainerFactory"
     )
     @Transactional
-    public void handleDeliveryShipping(
-        @Payload DeliveryShippingEvent event,
+    public void handleDeliveryCreatedFailed(
+        @Payload DeliveryCreatedFailedEvent event,
         @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
         @Header(KafkaHeaders.OFFSET) long offset,
         Acknowledgment acknowledgment) {
 
-        log.info("=== 배송 중 이벤트 수신: orderId={}, partition={}, offset={}, items={} ===",
+        log.info("=== 배송 생성 실패 이벤트 수신: orderId={}, partition={}, offset={}, items={} ===",
             event.orderId(), partition, offset, event.items().size());
 
         try {
@@ -56,14 +55,18 @@ public class DeliveryShippingEventListener {
             log.info("주문 조회 완료 - orderId: {}, 현재 상태: {}",
                 order.getOrderId(), order.getOrderStatus());
 
-            if (order.getOrderStatus() == OrderStatus.DELIVERY_SHIPPING) {
-                log.info("이미 처리된 배송 중 이벤트 - orderId: {}", event.orderId());
+            if (order.getOrderStatus() == OrderStatus.DELIVERY_CREATED_FAILED ||
+                order.getOrderStatus() == OrderStatus.FAILED
+            ) {
+                log.info("이미 처리된 배송 생성 실패 이벤트 - orderId: {}", event.orderId());
                 if (acknowledgment != null) {
                     acknowledgment.acknowledge();
                 }
                 return;
             }
-            order.changeStatus(OrderStatus.DELIVERY_SHIPPING);
+
+            // 3. 주문 상태를 DELIVERY_CREATED로 변경
+            order.changeStatus(OrderStatus.DELIVERY_CREATED_FAILED);
             orderRepository.save(order);
 
             // 4. 수동 커밋
@@ -72,11 +75,11 @@ public class DeliveryShippingEventListener {
                 log.info("오프셋 커밋 완료: orderId={}, offset={}", event.orderId(), offset);
             }
 
-            log.info("=== 배송 중 이벤트 처리 완료: orderId={}, 상태={} ===",
-                event.orderId(), OrderStatus.DELIVERY_CREATED);
+            log.info("=== 배송 생성 실패 이벤트 처리 완료: orderId={}, 상태={} ===",
+                event.orderId(), OrderStatus.DELIVERY_CREATED_FAILED);
 
         } catch (Exception e) {
-            log.error("배송 중 이벤트 처리 실패: orderId={}, partition={}, offset={}",
+            log.error("배송 생성 실패 이벤트 처리 실패: orderId={}, partition={}, offset={}",
                 event.orderId(), partition, offset, e);
 
             // 이벤트 처리 실패 시 재시도를 위해 예외를 다시 던짐
@@ -87,13 +90,13 @@ public class DeliveryShippingEventListener {
 
     // 실패시 자동으로 호출한다고 합니다.
     @DltHandler
-    public void handleDeliveryCreatedDlt(
-        @Payload DeliveryCreatedEvent event,
+    public void handleDeliveryCreatedFailedDlt(
+        @Payload DeliveryCreatedFailedEvent event,
         @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
         @Header(KafkaHeaders.EXCEPTION_MESSAGE) String exceptionMessage) {
 
         log.error("========================================");
-        log.error("⚠️ DLT 도착: Delivery Shipping Event");
+        log.error("⚠️ DLT 도착: Delivery Created Failed Event");
         log.error("⚠️ 수동 처리가 필요합니다!");
         log.error("========================================");
         log.error("orderId={}, error={}", event.orderId(), exceptionMessage);

--- a/order/src/main/java/com/klp/order/infrastructure/event/listener/DeliveryShippingEventListener.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/listener/DeliveryShippingEventListener.java
@@ -47,8 +47,8 @@ public class DeliveryShippingEventListener {
         @Header(KafkaHeaders.OFFSET) long offset,
         Acknowledgment acknowledgment) {
 
-        log.info("=== 배송 중 이벤트 수신: orderId={}, partition={}, offset={}, items={} ===",
-            event.orderId(), partition, offset, event.items().size());
+        log.info("=== 배송 중 이벤트 수신: orderId={}, partition={}, offset={}, products={} ===",
+            event.orderId(), partition, offset, event.products().size());
 
         try {
             // 1. 주문 조회

--- a/order/src/main/java/com/klp/order/infrastructure/event/listener/DeliveryShippingFailedEventListener.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/listener/DeliveryShippingFailedEventListener.java
@@ -4,7 +4,8 @@ import com.klp.order.application.service.OrderService;
 import com.klp.order.domain.entity.order.Order;
 import com.klp.order.domain.entity.order.OrderStatus;
 import com.klp.order.domain.repository.OrderRepository;
-import com.klp.order.infrastructure.event.event.CouponUseFailedEvent;
+import com.klp.order.infrastructure.event.event.DeliveryCreatedFailedEvent;
+import com.klp.order.infrastructure.event.event.DeliveryShippingFailedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.DltHandler;
@@ -22,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class CouponUseFailedEventListener {
+public class DeliveryShippingFailedEventListener {
 
     private final OrderService orderService;
     private final OrderRepository orderRepository;
@@ -35,62 +36,68 @@ public class CouponUseFailedEventListener {
         topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE
     )
     @KafkaListener(
-        topics = "coupon.use.failed",
+        topics = "delivery.topic",
         groupId = "order-service-group",
         containerFactory = "kafkaListenerContainerFactory"
     )
     @Transactional
-    public void handleCouponUseFailed(
-        @Payload CouponUseFailedEvent event,
+    public void handleDeliveryShippingFailed(
+        @Payload DeliveryShippingFailedEvent event,
         @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
         @Header(KafkaHeaders.OFFSET) long offset,
         Acknowledgment acknowledgment) {
 
-        log.info("=== 쿠폰 사용 실패 이벤트 수신: orderId={},couponId={}, partition={}, offset={} ===",
-            event.orderId(), event.couponId(), partition, offset);
+        log.info("=== 배송 중 실패 이벤트 수신: orderId={}, partition={}, offset={}, items={} ===",
+            event.orderId(), partition, offset, event.items().size());
 
         try {
-            // 1. 주문 조회 후 상태 변경
+            // 1. 주문 조회
             Order order = orderService.findById(event.orderId());
-            log.info("주문 조회 완료 - orderId: {}", order.getOrderId());
+            log.info("주문 조회 완료 - orderId: {}, 현재 상태: {}",
+                order.getOrderId(), order.getOrderStatus());
 
-            if (order.getOrderStatus() == OrderStatus.FAILED
-                || order.getOrderStatus() == OrderStatus.COUPON_CONFIRMED_FAILED) {
-                log.info("이미 처리된 재고 확정 실패 이벤트 - orderId: {}", event.orderId());
+            if (order.getOrderStatus() == OrderStatus.DELIVERY_SHIPPING_FAILED ||
+                order.getOrderStatus().equals(OrderStatus.FAILED)
+            ) {
+                log.info("이미 처리된 배송 중 실패 이벤트 - orderId: {}", event.orderId());
                 if (acknowledgment != null) {
                     acknowledgment.acknowledge();
                 }
                 return;
             }
+            order.changeStatus(OrderStatus.DELIVERY_SHIPPING_FAILED);
+            orderRepository.save(order);
 
-            order.changeStatus(OrderStatus.COUPON_CONFIRMED_FAILED);
-            log.info("=== 쿠폰 사용 실패 이벤트 처리 완료: orderId={}, couponId={} ===", event.orderId(),
-                event.couponId());
-
+            // 4. 수동 커밋
             if (acknowledgment != null) {
                 acknowledgment.acknowledge();
                 log.info("오프셋 커밋 완료: orderId={}, offset={}", event.orderId(), offset);
             }
 
+            log.info("=== 배송 중 실패 이벤트 처리 완료: orderId={}, 상태={} ===",
+                event.orderId(), OrderStatus.DELIVERY_CREATED_FAILED);
+
         } catch (Exception e) {
-            log.error("쿠폰 사용 실패 이벤트 처리 실패: orderId={}, couponId={}, partition={}, offset={}",
-                event.orderId(), event.couponId(), partition, offset, e);
+            log.error("배송 중 실패 이벤트 처리 실패: orderId={}, partition={}, offset={}",
+                event.orderId(), partition, offset, e);
+
+            // 이벤트 처리 실패 시 재시도를 위해 예외를 다시 던짐
+            // DefaultErrorHandler가 재시도 처리
             throw e;
         }
     }
 
     // 실패시 자동으로 호출한다고 합니다.
     @DltHandler
-    public void handleCouponUseFaileddDlt(
-        @Payload CouponUseFailedEvent event,
+    public void handleDeliveryCreatedFailedDlt(
+        @Payload DeliveryCreatedFailedEvent event,
         @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
         @Header(KafkaHeaders.EXCEPTION_MESSAGE) String exceptionMessage) {
 
         log.error("========================================");
-        log.error("⚠️ DLT 도착: Coupon Use Failed Event");
+        log.error("⚠️ DLT 도착: Delivery Shipping Failed Event");
         log.error("⚠️ 수동 처리가 필요합니다!");
         log.error("========================================");
         log.error("orderId={}, error={}", event.orderId(), exceptionMessage);
     }
-
 }

--- a/order/src/main/java/com/klp/order/infrastructure/event/listener/DeliveryShippingFailedEventListener.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/listener/DeliveryShippingFailedEventListener.java
@@ -47,8 +47,8 @@ public class DeliveryShippingFailedEventListener {
         @Header(KafkaHeaders.OFFSET) long offset,
         Acknowledgment acknowledgment) {
 
-        log.info("=== 배송 중 실패 이벤트 수신: orderId={}, partition={}, offset={}, items={} ===",
-            event.orderId(), partition, offset, event.items().size());
+        log.info("=== 배송 중 실패 이벤트 수신: orderId={}, partition={}, offset={}, products={} ===",
+            event.orderId(), partition, offset, event.products().size());
 
         try {
             // 1. 주문 조회

--- a/order/src/main/java/com/klp/order/infrastructure/event/listener/InventoryDeductedEventListener.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/listener/InventoryDeductedEventListener.java
@@ -22,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class InventoryEventListener {
+public class InventoryDeductedEventListener {
 
     private final OrderService orderService;
     private final OrderRepository orderRepository;
@@ -34,9 +34,8 @@ public class InventoryEventListener {
         include = Exception.class,
         topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE
     )
-    // 결제 완료 이벤트를 받으면 배송 생성 요청 이벤트를 발행
     @KafkaListener(
-        topics = "Inventory.deducted",
+        topics = "inventory.topic",
         groupId = "order-service-group",
         containerFactory = "kafkaListenerContainerFactory"
     )

--- a/order/src/main/java/com/klp/order/infrastructure/event/listener/InventoryDeductedFailedEventListener.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/listener/InventoryDeductedFailedEventListener.java
@@ -1,11 +1,10 @@
 package com.klp.order.infrastructure.event.listener;
 
-
 import com.klp.order.application.service.OrderService;
 import com.klp.order.domain.entity.order.Order;
 import com.klp.order.domain.entity.order.OrderStatus;
 import com.klp.order.domain.repository.OrderRepository;
-import com.klp.order.infrastructure.event.event.PaymentCompletedEvent;
+import com.klp.order.infrastructure.event.event.InventoryDeductedFailedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.DltHandler;
@@ -23,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class PaymentEventListener {
+public class InventoryDeductedFailedEventListener {
 
     private final OrderService orderService;
     private final OrderRepository orderRepository;
@@ -35,20 +34,19 @@ public class PaymentEventListener {
         include = Exception.class,
         topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE
     )
-    // 결제 완료 이벤트를 받으면 배송 생성 요청 이벤트를 발행
     @KafkaListener(
-        topics = "payment.completed",
+        topics = "inventory.topic",
         groupId = "order-service-group",
         containerFactory = "kafkaListenerContainerFactory"
     )
     @Transactional
-    public void handlePaymentCompleted(
-        @Payload PaymentCompletedEvent event,
+    public void handleInventoryDeductedFailed(
+        @Payload InventoryDeductedFailedEvent event,
         @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
         @Header(KafkaHeaders.OFFSET) long offset,
         Acknowledgment acknowledgment) {
 
-        log.info("=== 결제 완료 이벤트 수신: orderId={}, partition={}, offset={} ===",
+        log.info("=== 재고 확정 실패 이벤트 수신: orderId={}, partition={}, offset={} ===",
             event.orderId(), partition, offset);
 
         try {
@@ -56,17 +54,18 @@ public class PaymentEventListener {
             Order order = orderService.findById(event.orderId());
             log.info("주문 조회 완료 - orderId: {}", order.getOrderId());
 
-            if (order.getOrderStatus() == OrderStatus.PAID) {
-                log.info("이미 처리된 결제 완료 이벤트 - orderId: {}", event.orderId());
+            if (order.getOrderStatus() == OrderStatus.FAILED
+                || order.getOrderStatus() == OrderStatus.STOCK_CONFIRMED_FAILED) {
+                log.info("이미 처리된 재고 확정 실패 이벤트 - orderId: {}", event.orderId());
                 if (acknowledgment != null) {
                     acknowledgment.acknowledge();
                 }
                 return;
             }
 
-            order.changeStatus(OrderStatus.PAID);
+            order.changeStatus(OrderStatus.STOCK_CONFIRMED_FAILED);
             orderRepository.save(order);
-            log.info("=== 결제 완료 이벤트 처리 완료: orderId={} ===", event.orderId());
+            log.info("=== 재고 확정 실패 이벤트 처리 완료: orderId={} ===", event.orderId());
 
             if (acknowledgment != null) {
                 acknowledgment.acknowledge();
@@ -74,7 +73,7 @@ public class PaymentEventListener {
             }
 
         } catch (Exception e) {
-            log.error("결제 완료 이벤트 처리 실패: orderId={}, partition={}, offset={}",
+            log.error("재고 확정 실패 이벤트 처리 실패: orderId={}, partition={}, offset={}",
                 event.orderId(), partition, offset, e);
             throw e;
         }
@@ -82,13 +81,13 @@ public class PaymentEventListener {
 
     // 실패시 자동으로 호출한다고 합니다.
     @DltHandler
-    public void handlePaymentCompletedDlt(
-        @Payload PaymentCompletedEvent event,
+    public void handleInventoryDeductedFailedEventDlt(
+        @Payload InventoryDeductedFailedEvent event,
         @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
         @Header(KafkaHeaders.EXCEPTION_MESSAGE) String exceptionMessage) {
 
         log.error("========================================");
-        log.error("⚠️ DLT 도착: Payment Completed Event");
+        log.error("⚠️ DLT 도착: Inventory Confirmed Failed Event");
         log.error("⚠️ 수동 처리가 필요합니다!");
         log.error("========================================");
         log.error("orderId={}, error={}", event.orderId(), exceptionMessage);

--- a/order/src/main/java/com/klp/order/infrastructure/event/listener/PaymentApprovedEventListener.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/listener/PaymentApprovedEventListener.java
@@ -1,11 +1,11 @@
 package com.klp.order.infrastructure.event.listener;
 
+
 import com.klp.order.application.service.OrderService;
 import com.klp.order.domain.entity.order.Order;
 import com.klp.order.domain.entity.order.OrderStatus;
 import com.klp.order.domain.repository.OrderRepository;
-import com.klp.order.infrastructure.event.event.DeliveryCreatedEvent;
-import com.klp.order.infrastructure.event.event.DeliveryShippingEvent;
+import com.klp.order.infrastructure.event.event.PaymentApprovedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.DltHandler;
@@ -23,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class DeliveryShippingEventListener {
+public class PaymentApprovedEventListener {
 
     private final OrderService orderService;
     private final OrderRepository orderRepository;
@@ -36,64 +36,58 @@ public class DeliveryShippingEventListener {
         topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE
     )
     @KafkaListener(
-        topics = "delivery.topic",
+        topics = "payment.topic",
         groupId = "order-service-group",
         containerFactory = "kafkaListenerContainerFactory"
     )
     @Transactional
-    public void handleDeliveryShipping(
-        @Payload DeliveryShippingEvent event,
+    public void handlePaymentApproved(
+        @Payload PaymentApprovedEvent event,
         @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
         @Header(KafkaHeaders.OFFSET) long offset,
         Acknowledgment acknowledgment) {
 
-        log.info("=== 배송 중 이벤트 수신: orderId={}, partition={}, offset={}, items={} ===",
-            event.orderId(), partition, offset, event.items().size());
+        log.info("=== 결제 완료 이벤트 수신: orderId={}, partition={}, offset={} ===",
+            event.orderId(), partition, offset);
 
         try {
-            // 1. 주문 조회
+            // 1. 주문 조회 후 상태 변경
             Order order = orderService.findById(event.orderId());
-            log.info("주문 조회 완료 - orderId: {}, 현재 상태: {}",
-                order.getOrderId(), order.getOrderStatus());
+            log.info("주문 조회 완료 - orderId: {}", order.getOrderId());
 
-            if (order.getOrderStatus() == OrderStatus.DELIVERY_SHIPPING) {
-                log.info("이미 처리된 배송 중 이벤트 - orderId: {}", event.orderId());
+            if (order.getOrderStatus() == OrderStatus.PAID) {
+                log.info("이미 처리된 결제 완료 이벤트 - orderId: {}", event.orderId());
                 if (acknowledgment != null) {
                     acknowledgment.acknowledge();
                 }
                 return;
             }
-            order.changeStatus(OrderStatus.DELIVERY_SHIPPING);
-            orderRepository.save(order);
 
-            // 4. 수동 커밋
+            order.changeStatus(OrderStatus.PAID);
+            orderRepository.save(order);
+            log.info("=== 결제 완료 이벤트 처리 완료: orderId={} ===", event.orderId());
+
             if (acknowledgment != null) {
                 acknowledgment.acknowledge();
                 log.info("오프셋 커밋 완료: orderId={}, offset={}", event.orderId(), offset);
             }
 
-            log.info("=== 배송 중 이벤트 처리 완료: orderId={}, 상태={} ===",
-                event.orderId(), OrderStatus.DELIVERY_CREATED);
-
         } catch (Exception e) {
-            log.error("배송 중 이벤트 처리 실패: orderId={}, partition={}, offset={}",
+            log.error("결제 완료 이벤트 처리 실패: orderId={}, partition={}, offset={}",
                 event.orderId(), partition, offset, e);
-
-            // 이벤트 처리 실패 시 재시도를 위해 예외를 다시 던짐
-            // DefaultErrorHandler가 재시도 처리
             throw e;
         }
     }
 
     // 실패시 자동으로 호출한다고 합니다.
     @DltHandler
-    public void handleDeliveryCreatedDlt(
-        @Payload DeliveryCreatedEvent event,
+    public void handlePaymentApprovedDlt(
+        @Payload PaymentApprovedEvent event,
         @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
         @Header(KafkaHeaders.EXCEPTION_MESSAGE) String exceptionMessage) {
 
         log.error("========================================");
-        log.error("⚠️ DLT 도착: Delivery Shipping Event");
+        log.error("⚠️ DLT 도착: Payment Approved Event");
         log.error("⚠️ 수동 처리가 필요합니다!");
         log.error("========================================");
         log.error("orderId={}, error={}", event.orderId(), exceptionMessage);

--- a/order/src/main/java/com/klp/order/infrastructure/event/listener/PaymentApprovedFailedEventListener.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/listener/PaymentApprovedFailedEventListener.java
@@ -1,10 +1,11 @@
 package com.klp.order.infrastructure.event.listener;
 
+
 import com.klp.order.application.service.OrderService;
 import com.klp.order.domain.entity.order.Order;
 import com.klp.order.domain.entity.order.OrderStatus;
 import com.klp.order.domain.repository.OrderRepository;
-import com.klp.order.infrastructure.event.event.InventoryConfirmedFailedEvent;
+import com.klp.order.infrastructure.event.event.PaymentApprovedFailedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.DltHandler;
@@ -22,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class InventoryConfirmedFailedEventListener {
+public class PaymentApprovedFailedEventListener {
 
     private final OrderService orderService;
     private final OrderRepository orderRepository;
@@ -35,18 +36,18 @@ public class InventoryConfirmedFailedEventListener {
         topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE
     )
     @KafkaListener(
-        topics = "Inventory.confirmed.failed",
+        topics = "payment.topic",
         groupId = "order-service-group",
         containerFactory = "kafkaListenerContainerFactory"
     )
     @Transactional
-    public void handleInventoryConfirmedFailed(
-        @Payload InventoryConfirmedFailedEvent event,
+    public void handlePaymentApprovedFailed(
+        @Payload PaymentApprovedFailedEvent event,
         @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
         @Header(KafkaHeaders.OFFSET) long offset,
         Acknowledgment acknowledgment) {
 
-        log.info("=== 재고 확정 실패 이벤트 수신: orderId={}, partition={}, offset={} ===",
+        log.info("=== 결제 실패 이벤트 수신: orderId={}, partition={}, offset={} ===",
             event.orderId(), partition, offset);
 
         try {
@@ -55,17 +56,17 @@ public class InventoryConfirmedFailedEventListener {
             log.info("주문 조회 완료 - orderId: {}", order.getOrderId());
 
             if (order.getOrderStatus() == OrderStatus.FAILED
-                || order.getOrderStatus() == OrderStatus.STOCK_CONFIRMED_FAILED) {
-                log.info("이미 처리된 재고 확정 실패 이벤트 - orderId: {}", event.orderId());
+                || order.getOrderStatus() == OrderStatus.PAID_FAILED) {
+                log.info("이미 처리된 결제 실패 이벤트 - orderId: {}", event.orderId());
                 if (acknowledgment != null) {
                     acknowledgment.acknowledge();
                 }
                 return;
             }
 
-            order.changeStatus(OrderStatus.STOCK_CONFIRMED_FAILED);
+            order.changeStatus(OrderStatus.PAID_FAILED);
             orderRepository.save(order);
-            log.info("=== 재고 확정 실패 이벤트 처리 완료: orderId={} ===", event.orderId());
+            log.info("=== 결제 실패 이벤트 처리 완료: orderId={} ===", event.orderId());
 
             if (acknowledgment != null) {
                 acknowledgment.acknowledge();
@@ -73,7 +74,7 @@ public class InventoryConfirmedFailedEventListener {
             }
 
         } catch (Exception e) {
-            log.error("재고 확정 실패 이벤트 처리 실패: orderId={}, partition={}, offset={}",
+            log.error("결제 실패 이벤트 처리 실패: orderId={}, partition={}, offset={}",
                 event.orderId(), partition, offset, e);
             throw e;
         }
@@ -81,13 +82,13 @@ public class InventoryConfirmedFailedEventListener {
 
     // 실패시 자동으로 호출한다고 합니다.
     @DltHandler
-    public void handleInventoryConfirmedFailedEventDlt(
-        @Payload InventoryConfirmedFailedEvent event,
+    public void handlePaymentFailedDlt(
+        @Payload PaymentApprovedFailedEvent event,
         @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
         @Header(KafkaHeaders.EXCEPTION_MESSAGE) String exceptionMessage) {
 
         log.error("========================================");
-        log.error("⚠️ DLT 도착: Inventory Confirmed Failed Event");
+        log.error("⚠️ DLT 도착: Payment Failed Event");
         log.error("⚠️ 수동 처리가 필요합니다!");
         log.error("========================================");
         log.error("orderId={}, error={}", event.orderId(), exceptionMessage);

--- a/order/src/main/java/com/klp/order/presentation/controller/KafkaTestController.java
+++ b/order/src/main/java/com/klp/order/presentation/controller/KafkaTestController.java
@@ -2,7 +2,7 @@
 //
 //import com.klp.order.infrastructure.event.event.DeliveryCreatedEvent;
 //import com.klp.order.infrastructure.event.event.DeliveryCreatedEvent.DeliveryItem;
-//import com.klp.order.infrastructure.event.event.PaymentCompletedEvent;
+//import com.klp.order.infrastructure.event.event.PaymentApprovedEvent;
 //import java.util.List;
 //import java.util.UUID;
 //import lombok.RequiredArgsConstructor;
@@ -25,7 +25,7 @@
 //    public String publishPaymentCompleted(@PathVariable UUID orderId) {
 //        log.info("=== Payment Completed 이벤트 테스트 발행: orderId={} ===", orderId);
 //
-//        PaymentCompletedEvent event = new PaymentCompletedEvent(
+//        PaymentApprovedEvent event = new PaymentApprovedEvent(
 //            orderId,
 //            UUID.randomUUID()
 //        );

--- a/order/src/main/java/com/klp/order/presentation/dto/order/request/create/CreateOrderRequest.java
+++ b/order/src/main/java/com/klp/order/presentation/dto/order/request/create/CreateOrderRequest.java
@@ -19,19 +19,19 @@ public record CreateOrderRequest(
     @NotNull(message = "사용자 ID는 필수입니다.")
     Long userId,
 
-    @Schema(description = "공급 업체 ID", example = "UUID", required = true)
+    @Schema(description = "공급 업체 ID", example = "3b8d1f7e-6c4a-4d2b-9e5f-7a3c6b9d2e4f", required = true)
     @NotNull(message = "공급 업체 ID는 필수입니다.")
     UUID supplierId,
 
-    @Schema(description = "사용자 쿠폰 ID", example = "UUID")
+    @Schema(description = "사용자 쿠폰 ID", example = "d7f3c8a2-4b91-4e3d-9f6a-2c1e5b8d4a7f")
     UUID userCouponId,
 
     @Schema(description = "주문 코멘트", example = "빠른 배송 부탁드립니다.")
     String comment,
 
-    @Schema(description = "배송지 주소", example = "그대의 마음 속", required = true)
+    @Schema(description = "배송지 주소 Id", example = "6e2a9f5c-1d84-4c6b-a3e7-8f0b2d5c9e1a", required = true)
     @NotBlank(message = "배송지 주소는 필수입니다.")
-    String deliveryAddress,
+    UUID addressId,
 
     @Schema(description = "배송지 위도", example = "37.5665", required = true)
     @NotNull(message = "배송지 위도는 필수입니다.")
@@ -64,7 +64,7 @@ public record CreateOrderRequest(
             supplierId,
             userCouponId,
             comment,
-            deliveryAddress,
+            addressId,
             deliveryLatitude,
             deliveryLongitude,
             itemCommands

--- a/order/src/main/java/com/klp/order/presentation/dto/order/request/update/ChangeOrderStatusRequest.java
+++ b/order/src/main/java/com/klp/order/presentation/dto/order/request/update/ChangeOrderStatusRequest.java
@@ -12,8 +12,11 @@ public record ChangeOrderStatusRequest(
         example = "PAID",
         required = true,
         allowableValues = {
-            "PENDING", "CREATED", "PAID", "STOCK_CONFIRMED",
-            "COUPON_CONFIRMED", "DELIVERY_CREATED", "DELIVERY_SHIPPING",
+            "PENDING", "CREATED", "PAID", "PAID_FAILED", "STOCK_CONFIRMED",
+            "STOCK_CONFIRMED_FAILED",
+            "COUPON_CONFIRMED", "COUPON_CONFIRMED_FAILED", "DELIVERY_CREATED",
+            "DELIVERY_CREATED_FAILED",
+            "DELIVERY_SHIPPING", "DELIVERY_SHIPPING_FAILED",
             "COMPLETE", "CANCELLED", "FAILED"
         }
     )

--- a/order/src/main/java/com/klp/order/presentation/dto/order/response/create/CreateOrderResponse.java
+++ b/order/src/main/java/com/klp/order/presentation/dto/order/response/create/CreateOrderResponse.java
@@ -13,16 +13,16 @@ import java.util.stream.Collectors;
 
 @Schema(description = "주문 생성 응답")
 public record CreateOrderResponse(
-    @Schema(description = "주문 ID", example = "UUID")
+    @Schema(description = "주문 ID", example = "a9f2e7d4-3c8b-4f1a-b6e5-9d2c7f4a8e1b")
     UUID orderId,
 
     @Schema(description = "사용자 ID", example = "1")
     Long userId,
 
-    @Schema(description = "공급 업체 ID", example = "UUID")
+    @Schema(description = "공급 업체 ID", example = "5c3d8f1a-9e4b-4d7c-a2f6-1b8e5d9c3a7f")
     UUID supplierId,
 
-    @Schema(description = "사용자 쿠폰 ID", example = "UUID")
+    @Schema(description = "사용자 쿠폰 ID", example = "f1b6d9e2-7a4c-4e8f-9d3b-6c2a5f8e1d4a")
     UUID userCouponId,
 
     @Schema(description = "주문 코멘트", example = "빠른 배송 부탁드립니다.")
@@ -43,8 +43,8 @@ public record CreateOrderResponse(
     @Schema(description = "최종 주문 금액", example = "2800000")
     int orderPrice,
 
-    @Schema(description = "배송지 주소", example = "내 마음 속")
-    String deliveryAddress,
+    @Schema(description = "배송지 주소", example = "8e4a2c7f-6d9b-4f3e-a1c5-9f7d2e6b4a8c")
+    UUID addressId,
 
     @Schema(description = "배송지 위도", example = "37.5665")
     BigDecimal deliveryLatitude,
@@ -93,7 +93,7 @@ public record CreateOrderResponse(
             order.getCouponDiscountPrice(),
             order.getGradeDiscountPrice(),
             order.getOrderPrice(),
-            order.getDeliveryAddress(),
+            order.getAddressId(),
             order.getDeliveryLatitude(),
             order.getDeliveryLongitude(),
             orderItemResponses,

--- a/order/src/main/java/com/klp/order/presentation/dto/order/response/get/GetOneOrderResponse.java
+++ b/order/src/main/java/com/klp/order/presentation/dto/order/response/get/GetOneOrderResponse.java
@@ -13,16 +13,16 @@ import java.util.stream.Collectors;
 
 @Schema(description = "주문 상세 조회 응답")
 public record GetOneOrderResponse(
-    @Schema(description = "주문 ID", example = "UUID")
+    @Schema(description = "주문 ID", example = "a9f2e7d4-3c8b-4f1a-b6e5-9d2c7f4a8e1b")
     UUID orderId,
 
-    @Schema(description = "공급 업체 ID", example = "UUID")
+    @Schema(description = "공급 업체 ID", example = "5c3d8f1a-9e4b-4d7c-a2f6-1b8e5d9c3a7f")
     UUID supplierId,
 
     @Schema(description = "사용자 ID", example = "1")
     Long userId,
 
-    @Schema(description = "사용자 쿠폰 ID", example = "UUID")
+    @Schema(description = "사용자 쿠폰 ID", example = "f1b6d9e2-7a4c-4e8f-9d3b-6c2a5f8e1d4a")
     UUID userCouponId,
 
     @Schema(description = "주문 코멘트", example = "빠른 배송 부탁드립니다.")
@@ -43,8 +43,8 @@ public record GetOneOrderResponse(
     @Schema(description = "최종 주문 금액", example = "2800000")
     int orderPrice,
 
-    @Schema(description = "배송지 주소", example = "내 마음 속")
-    String deliveryAddress,
+    @Schema(description = "배송지 주소", example = "8e4a2c7f-6d9b-4f3e-a1c5-9f7d2e6b4a8c")
+    UUID addressId,
 
     @Schema(description = "배송지 위도", example = "37.5665")
     BigDecimal deliveryLatitude,
@@ -87,7 +87,7 @@ public record GetOneOrderResponse(
             order.getCouponDiscountPrice(),
             order.getGradeDiscountPrice(),
             order.getOrderPrice(),
-            order.getDeliveryAddress(),
+            order.getAddressId(),
             order.getDeliveryLatitude(),
             order.getDeliveryLongitude(),
             orderItemResponses,

--- a/order/src/main/java/com/klp/order/presentation/dto/order/response/update/UpdateOrderResponse.java
+++ b/order/src/main/java/com/klp/order/presentation/dto/order/response/update/UpdateOrderResponse.java
@@ -13,16 +13,16 @@ import java.util.stream.Collectors;
 
 @Schema(description = "주문 수정 응답")
 public record UpdateOrderResponse(
-    @Schema(description = "주문 ID", example = "UUID")
+    @Schema(description = "주문 ID", example = "a9f2e7d4-3c8b-4f1a-b6e5-9d2c7f4a8e1b")
     UUID orderId,
 
-    @Schema(description = "공급 업체 ID", example = "UUID")
+    @Schema(description = "공급 업체 ID", example = "5c3d8f1a-9e4b-4d7c-a2f6-1b8e5d9c3a7f")
     UUID supplierId,
 
     @Schema(description = "사용자 ID", example = "1")
     Long userId,
 
-    @Schema(description = "사용자 쿠폰 ID", example = "UUID")
+    @Schema(description = "사용자 쿠폰 ID", example = "f1b6d9e2-7a4c-4e8f-9d3b-6c2a5f8e1d4a")
     UUID userCouponId,
 
     @Schema(description = "주문 코멘트", example = "배송 전 연락 부탁드립니다.")
@@ -43,8 +43,8 @@ public record UpdateOrderResponse(
     @Schema(description = "최종 주문 금액", example = "2800000")
     int orderPrice,
 
-    @Schema(description = "배송지 주소", example = "그대의 마음 속")
-    String deliveryAddress,
+    @Schema(description = "배송지 주소", example = "8e4a2c7f-6d9b-4f3e-a1c5-9f7d2e6b4a8c")
+    UUID addressId,
 
     @Schema(description = "배송지 위도", example = "37.5665")
     BigDecimal deliveryLatitude,
@@ -87,7 +87,7 @@ public record UpdateOrderResponse(
             order.getCouponDiscountPrice(),
             order.getGradeDiscountPrice(),
             order.getOrderPrice(),
-            order.getDeliveryAddress(),
+            order.getAddressId(),
             order.getDeliveryLatitude(),
             order.getDeliveryLongitude(),
             orderItemResponses,


### PR DESCRIPTION
1. 설계 대로 이벤트 클래스명 변경
2. kafka Config에 typemapping 추가
3. 전체적인 흐름을 변경하였습니다.

각 FeignClient를 통해 필요한 정보들을 모아서 facade에서 조립 후 event에 사용하게 됩니다.
하지만 각 client가 미완성이기 때문에 잠깐 주석 처리하였고 잠깐 임시 데이터를 삽입했습니다.!