### PR TITLE
feat: 유저 주소지 관련 기능 작성

### DIFF
--- a/user/src/main/java/com/klp/user/application/UserFacade.java
+++ b/user/src/main/java/com/klp/user/application/UserFacade.java
@@ -350,6 +350,12 @@ public class UserFacade {
     @Transactional(readOnly = true)
     public UserAddressHubResponse getUserAddressHub(UUID userAddressId) {
         UserAddress userAddress = userAddressService.getUserAddress(userAddressId);
-        return new UserAddressHubResponse(userAddress.getHubId());
+        String address;
+        if (userAddress.getDetail() == null) {
+            address = userAddress.getAddress();
+        } else {
+            address = userAddress.getAddress() + " " + userAddress.getDetail();
+        }
+        return new UserAddressHubResponse(userAddress.getHubId(), address);
     }
 }

--- a/user/src/main/java/com/klp/user/application/UserFacade.java
+++ b/user/src/main/java/com/klp/user/application/UserFacade.java
@@ -23,6 +23,7 @@ import com.klp.user.presentation.dto.response.DriverDetailResponse;
 import com.klp.user.presentation.dto.response.DriverInfo;
 import com.klp.user.presentation.dto.response.HubDriverListResponse;
 import com.klp.user.presentation.dto.response.LogisticsDriverListResponse;
+import com.klp.user.presentation.dto.response.UserAddressHubResponse;
 import com.klp.user.presentation.dto.response.UserAddressListResponse;
 import com.klp.user.presentation.dto.response.UserAddressResponse;
 import com.klp.user.presentation.dto.response.UserDetailResponse;
@@ -341,5 +342,14 @@ public class UserFacade {
     public void deleteUserAddress(UUID userAddressId, Long userId) {
         userAddressService.deleteUserAddress(userAddressId, userId);
         log.info("회원 주소 삭제 완료 - addressId: {}, deletedBy: {}", userAddressId, userId);
+    }
+
+    /**
+     * 회원 주소의 허브 ID 조회
+     */
+    @Transactional(readOnly = true)
+    public UserAddressHubResponse getUserAddressHub(UUID userAddressId) {
+        UserAddress userAddress = userAddressService.getUserAddress(userAddressId);
+        return new UserAddressHubResponse(userAddress.getHubId());
     }
 }

--- a/user/src/main/java/com/klp/user/application/UserFacade.java
+++ b/user/src/main/java/com/klp/user/application/UserFacade.java
@@ -11,7 +11,9 @@ import com.klp.user.domain.enums.UserRole;
 import com.klp.user.domain.exception.ExternalApiException;
 import com.klp.user.domain.exception.UserErrorCode;
 import com.klp.user.infrastructure.client.CompanyClient;
+import com.klp.user.infrastructure.client.HubClient;
 import com.klp.user.infrastructure.client.PromotionClient;
+import com.klp.user.infrastructure.client.dto.request.NearestHubRequest;
 import com.klp.user.infrastructure.client.dto.response.CompanyListResponse;
 import com.klp.user.infrastructure.client.dto.response.CompanyResponse;
 import com.klp.user.infrastructure.client.dto.response.DefaultGradeResponse;
@@ -44,6 +46,7 @@ public class UserFacade {
     private final UserGradeService userGradeService;
     private final UserAddressService userAddressService;
     private final CompanyClient companyClient;
+    private final HubClient hubClient;
     private final PromotionClient promotionClient;
 
     /**
@@ -265,13 +268,34 @@ public class UserFacade {
     }
 
     /**
-     * 회원 주소 생성(요청으로 자신 주소 근처 hubId를 받음)
+     * 회원 주소 생성 (위경도 기반으로 가장 가까운 허브 자동 조회)
      */
     @Transactional
-    public void createUserAddress(UserAddressCreateCommand command) {
-        User user = userService.findNotDeletedUser(command.userId());
+    public void createUserAddress(Long userId, Double latitude, Double longitude,
+        String address, String detail, boolean isDefault) {
+        User user = userService.findNotDeletedUser(userId);
+
+        UUID hubId = getNearestHubId(latitude, longitude);
+
+        UserAddressCreateCommand command = new UserAddressCreateCommand(
+            userId, hubId, address, detail, isDefault, latitude, longitude
+        );
         userAddressService.createUserAddress(user, command);
-        log.info("회원 주소 생성 완료 - userId: {}", command.userId());
+        log.info("회원 주소 생성 완료 - userId: {}, hubId: {}", userId, hubId);
+    }
+
+    /**
+     * 가장 가까운 허브 ID 조회 (Hub 서비스)
+     */
+    private UUID getNearestHubId(Double latitude, Double longitude) {
+        try {
+            NearestHubRequest request = new NearestHubRequest(latitude, longitude);
+            return hubClient.getNearestHub(request).hubId();
+        } catch (Exception e) {
+            log.error("가까운 허브 조회 실패 - latitude: {}, longitude: {}", latitude, longitude, e);
+            throw new BusinessException(UserErrorCode.INTERNAL_SERVER_ERROR,
+                "가까운 허브 조회 중 오류가 발생했습니다.");
+        }
     }
 
     /**
@@ -296,12 +320,18 @@ public class UserFacade {
     }
 
     /**
-     * 회원 주소 수정
+     * 회원 주소 수정 (위경도 기반으로 가장 가까운 허브 자동 조회)
      */
     @Transactional
-    public void updateUserAddress(UUID userAddressId, UserAddressCreateCommand command) {
+    public void updateUserAddress(UUID userAddressId, Long userId, Double latitude, Double longitude,
+        String address, String detail, boolean isDefault) {
+        UUID hubId = getNearestHubId(latitude, longitude);
+
+        UserAddressCreateCommand command = new UserAddressCreateCommand(
+            userId, hubId, address, detail, isDefault, latitude, longitude
+        );
         userAddressService.updateUserAddress(userAddressId, command);
-        log.info("회원 주소 수정 완료 - addressId: {}", userAddressId);
+        log.info("회원 주소 수정 완료 - addressId: {}, hubId: {}", userAddressId, hubId);
     }
 
     /**

--- a/user/src/main/java/com/klp/user/infrastructure/client/HubClient.java
+++ b/user/src/main/java/com/klp/user/infrastructure/client/HubClient.java
@@ -1,0 +1,14 @@
+package com.klp.user.infrastructure.client;
+
+import com.klp.user.infrastructure.client.dto.request.NearestHubRequest;
+import com.klp.user.infrastructure.client.dto.response.NearestHubResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "hub-service", contextId = "hubClient")
+public interface HubClient {
+
+    @PostMapping("/v1/internal/hubs/nearest")
+    NearestHubResponse getNearestHub(@RequestBody NearestHubRequest request);
+}

--- a/user/src/main/java/com/klp/user/infrastructure/client/dto/request/NearestHubRequest.java
+++ b/user/src/main/java/com/klp/user/infrastructure/client/dto/request/NearestHubRequest.java
@@ -1,0 +1,7 @@
+package com.klp.user.infrastructure.client.dto.request;
+
+public record NearestHubRequest(
+    Double latitude,
+    Double longitude
+) {
+}

--- a/user/src/main/java/com/klp/user/infrastructure/client/dto/response/NearestHubResponse.java
+++ b/user/src/main/java/com/klp/user/infrastructure/client/dto/response/NearestHubResponse.java
@@ -1,0 +1,8 @@
+package com.klp.user.infrastructure.client.dto.response;
+
+import java.util.UUID;
+
+public record NearestHubResponse(
+    UUID hubId
+) {
+}

--- a/user/src/main/java/com/klp/user/presentation/UserAddressController.java
+++ b/user/src/main/java/com/klp/user/presentation/UserAddressController.java
@@ -51,7 +51,14 @@ public class UserAddressController implements UserAddressControllerDoc {
         @PathVariable(name = "userId") Long userId,
         @Valid @RequestBody UserAddressCreateRequest request
     ) {
-        userFacade.createUserAddress(request.toCommand(userId));
+        userFacade.createUserAddress(
+            userId,
+            request.latitude(),
+            request.longitude(),
+            request.address(),
+            request.detail(),
+            request.isDefault()
+        );
         return ResponseEntity.ok().build();
     }
 
@@ -62,7 +69,15 @@ public class UserAddressController implements UserAddressControllerDoc {
         @PathVariable(name = "addressId") UUID addressId,
         @Valid @RequestBody UserAddressCreateRequest request
     ) {
-        userFacade.updateUserAddress(addressId, request.toCommand(userId));
+        userFacade.updateUserAddress(
+            addressId,
+            userId,
+            request.latitude(),
+            request.longitude(),
+            request.address(),
+            request.detail(),
+            request.isDefault()
+        );
         return ResponseEntity.ok().build();
     }
 

--- a/user/src/main/java/com/klp/user/presentation/UserInternalController.java
+++ b/user/src/main/java/com/klp/user/presentation/UserInternalController.java
@@ -4,6 +4,7 @@ import com.klp.user.application.UserFacade;
 import com.klp.user.presentation.dto.response.DriverDetailResponse;
 import com.klp.user.presentation.dto.response.HubDriverListResponse;
 import com.klp.user.presentation.dto.response.LogisticsDriverListResponse;
+import com.klp.user.presentation.dto.response.UserAddressHubResponse;
 import com.klp.user.presentation.dto.response.UserDetailResponse;
 import io.swagger.v3.oas.annotations.Hidden;
 import java.util.UUID;
@@ -22,6 +23,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserInternalController {
 
     private final UserFacade userFacade;
+
+    @GetMapping("/{addressId}")
+    public ResponseEntity<UserAddressHubResponse> getUserAddressHub(
+        @PathVariable UUID addressId
+    ) {
+        UserAddressHubResponse response = userFacade.getUserAddressHub(addressId);
+        return ResponseEntity.ok().body(response);
+    }
 
     @GetMapping("/{userId}")
     public ResponseEntity<UserDetailResponse> getUserDetails(

--- a/user/src/main/java/com/klp/user/presentation/dto/request/UserAddressCreateRequest.java
+++ b/user/src/main/java/com/klp/user/presentation/dto/request/UserAddressCreateRequest.java
@@ -7,8 +7,6 @@ import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 public record UserAddressCreateRequest(
-    @NotNull(message = "허브 ID는 필수 입력값입니다")
-    UUID hubId,
     @NotBlank(message = "주소는 필수 입력값입니다")
     String address,
     String detail,
@@ -20,7 +18,7 @@ public record UserAddressCreateRequest(
     Double longitude
 ) {
 
-    public UserAddressCreateCommand toCommand(Long userId) {
+    public UserAddressCreateCommand toCommand(Long userId, UUID hubId) {
         return new UserAddressCreateCommand(userId, hubId, address, detail, isDefault, latitude, longitude);
     }
 }

--- a/user/src/main/java/com/klp/user/presentation/dto/response/UserAddressHubResponse.java
+++ b/user/src/main/java/com/klp/user/presentation/dto/response/UserAddressHubResponse.java
@@ -3,7 +3,8 @@ package com.klp.user.presentation.dto.response;
 import java.util.UUID;
 
 public record UserAddressHubResponse(
-    UUID userAddressHubId
+    UUID userAddressHubId,
+    String address
 ) {
 
 }

--- a/user/src/main/java/com/klp/user/presentation/dto/response/UserAddressHubResponse.java
+++ b/user/src/main/java/com/klp/user/presentation/dto/response/UserAddressHubResponse.java
@@ -1,0 +1,9 @@
+package com.klp.user.presentation.dto.response;
+
+import java.util.UUID;
+
+public record UserAddressHubResponse(
+    UUID userAddressHubId
+) {
+
+}


### PR DESCRIPTION
## PR 내용
- [feat: 주소 위,경도를 이용해 근처 허브id를 조회해서 저장하도록 변경](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/28d00214994a24e1a749fdc9f4490b749df97ae3)
  - 주소지 저장 시, 위도 경도 근처의 허브 ID를 조회해서 저장하도록 설정

- [feat: userAddressId를 받아서 근처 hubId 반환하는 기능 작성](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/9ad477e2da6d191e33ff7449656524fd43b68be9)
  - 주문 생성 시, userAddressId를 받아서 저장된 담당 hubId를 반환하는 기능 구현