### PR TITLE
feat: 회원가입 문제 해결

### DIFF
--- a/auth-service/src/main/java/com/klp/authservice/auth/domain/enums/AffiliationType.java
+++ b/auth-service/src/main/java/com/klp/authservice/auth/domain/enums/AffiliationType.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum AffiliationType {
     LOGISTICS("물류 회사"),
     COMPANY("업체"),
-    HUB("허브");
+    HUB("허브"),
+    CUSTOMER("고객");
 
     private final String description;
 }

--- a/user/src/main/java/com/klp/global/exception/HubFeignErrorDecoder.java
+++ b/user/src/main/java/com/klp/global/exception/HubFeignErrorDecoder.java
@@ -1,0 +1,58 @@
+package com.klp.global.exception;
+
+import com.klp.user.domain.exception.ExternalApiErrorCode;
+import com.klp.user.domain.exception.ExternalApiException;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class HubFeignErrorDecoder implements ErrorDecoder {
+
+    private final ErrorDecoder errorDecoder = new Default();
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        int status = response.status();
+
+        return switch (status) {
+
+            // 5xx - 외부 서비스 장애
+            case 500, 502, 503, 504 -> {
+                log.error("[HubFeignErrorDecoder] 허브 서비스 장애 발생. method={}, status={}",
+                    methodKey, status);
+                yield new ExternalApiException(ExternalApiErrorCode.HUB_SERVICE_UNAVAILABLE);
+            }
+
+            // 4xx - 클라이언트 오류
+            case 400 -> {
+                log.warn("[HubFeignErrorDecoder] 잘못된 요청. method={}, status=400", methodKey);
+                yield new ExternalApiException(ExternalApiErrorCode.HUB_SERVICE_BAD_REQUEST);
+            }
+            case 401 -> {
+                log.warn("[HubFeignErrorDecoder] 인증 실패. method={}, status=401", methodKey);
+                yield new ExternalApiException(ExternalApiErrorCode.HUB_SERVICE_UNAUTHORIZED);
+            }
+            case 403 -> {
+                log.warn("[HubFeignErrorDecoder] 인가 거부. method={}, status=403", methodKey);
+                yield new ExternalApiException(ExternalApiErrorCode.HUB_SERVICE_FORBIDDEN);
+            }
+            case 404 -> {
+                log.warn("[HubFeignErrorDecoder] 허브 정보 없음. method={}, status=404", methodKey);
+                yield new ExternalApiException(ExternalApiErrorCode.HUB_NOT_FOUND);
+            }
+
+            // 기타 오류
+            default -> {
+                if (status >= 400 && status < 500) {
+                    log.warn("[HubFeignErrorDecoder] 기타 4xx 오류. method={}, status={}",
+                        methodKey, status);
+                    yield new ExternalApiException(ExternalApiErrorCode.HUB_SERVICE_BAD_REQUEST);
+                }
+                log.error("[HubFeignErrorDecoder] 예상치 못한 오류. method={}, status={}",
+                    methodKey, status);
+                yield errorDecoder.decode(methodKey, response);
+            }
+        };
+    }
+}

--- a/user/src/main/java/com/klp/user/application/UserFacade.java
+++ b/user/src/main/java/com/klp/user/application/UserFacade.java
@@ -215,7 +215,7 @@ public class UserFacade {
     private String getAffiliationName(User user) {
         return switch (user.getAffiliationType()) {
             case CUSTOMER -> "고객";
-            case LOGISTICS -> "KLP 물류"; // DB에 저장된 값 사용
+            case LOGISTICS -> "KLP 물류";
             case HUB -> getHubName(user.getAffiliationId());
             case COMPANY -> getCompanyName(user.getAffiliationId());
         };

--- a/user/src/main/java/com/klp/user/application/UserFacade.java
+++ b/user/src/main/java/com/klp/user/application/UserFacade.java
@@ -17,6 +17,7 @@ import com.klp.user.infrastructure.client.dto.request.NearestHubRequest;
 import com.klp.user.infrastructure.client.dto.response.CompanyListResponse;
 import com.klp.user.infrastructure.client.dto.response.CompanyResponse;
 import com.klp.user.infrastructure.client.dto.response.DefaultGradeResponse;
+import com.klp.user.infrastructure.client.dto.response.GetHubIdResponse;
 import com.klp.user.presentation.dto.request.UserCreateRequest;
 import com.klp.user.presentation.dto.request.UserUpdateRequest;
 import com.klp.user.presentation.dto.response.DriverDetailResponse;
@@ -49,6 +50,8 @@ public class UserFacade {
     private final CompanyClient companyClient;
     private final HubClient hubClient;
     private final PromotionClient promotionClient;
+
+    private static final String UNKNOWN_AFFILIATION_NAME = "알 수 없음";
 
     /**
      * 회원가입 플로우 - PENDING 상태로 생성
@@ -207,64 +210,87 @@ public class UserFacade {
     }
 
     /**
-     * 소속명 조회 (Company 서비스)
+     * 소속명 조회
      */
     private String getAffiliationName(User user) {
-        if (user.getAffiliationType() == AffiliationType.CUSTOMER) {
-            return "고객";
-        }
+        return switch (user.getAffiliationType()) {
+            case CUSTOMER -> "고객";
+            case LOGISTICS -> "KLP 물류"; // DB에 저장된 값 사용
+            case HUB -> getHubName(user.getAffiliationId());
+            case COMPANY -> getCompanyName(user.getAffiliationId());
+        };
+    }
 
-        if (user.getAffiliationId() == null) {
-            log.warn("affiliationId가 null입니다 - userId: {}", user.getUserId());
-            throw new BusinessException(UserErrorCode.INVALID_AFFILIATION);
+    private String getHubName(UUID hubId) {
+        if (hubId == null) {
+            return UNKNOWN_AFFILIATION_NAME;
         }
-
         try {
-            CompanyResponse companyResponse = companyClient.getCompanyById(user.getAffiliationId());
+            return hubClient.getHubById(hubId).name();
+        } catch (Exception e) {
+            log.error("허브 정보 조회 실패 - hubId: {}", hubId, e);
+            return UNKNOWN_AFFILIATION_NAME;
+        }
+    }
+
+    private String getCompanyName(UUID companyId) {
+        if (companyId == null) {
+            return UNKNOWN_AFFILIATION_NAME;
+        }
+        try {
+            CompanyResponse companyResponse = companyClient.getCompanyById(companyId);
             return companyResponse.name();
         } catch (ExternalApiException e) {
-            log.error("업체 정보 조회 실패 - affiliationId: {}, errorCode: {}",
-                user.getAffiliationId(), e.getErrorCode().name());
+            log.error("업체 정보 조회 실패 - companyId: {}, errorCode: {}", companyId, e.getErrorCode().name());
             throw e;
         } catch (Exception e) {
-            log.error("예상치 못한 예외 발생 - affiliationId: {}", user.getAffiliationId(), e);
-            throw new BusinessException(UserErrorCode.INTERNAL_SERVER_ERROR,
-                "업체 정보 조회 중 예상치 못한 오류가 발생했습니다.");
+            log.error("예상치 못한 예외 발생 - companyId: {}", companyId, e);
+            throw new BusinessException(UserErrorCode.INTERNAL_SERVER_ERROR, "업체 정보 조회 중 예상치 못한 오류가 발생했습니다.");
         }
     }
 
     /**
-     * 소속 ID 조회 (Company 서비스)
+     * 소속 ID 조회 (타입별로 다른 서비스 호출)
      */
     private UUID getAffiliationId(String affiliationName, AffiliationType affiliationType) {
-        if (affiliationType == AffiliationType.CUSTOMER) {
-            return null;
-        }
+        return switch (affiliationType) {
+            case CUSTOMER, LOGISTICS -> null;
+            case HUB -> getHubIdByName(affiliationName);
+            case COMPANY -> getCompanyIdByName(affiliationName);
+        };
+    }
 
+    private UUID getHubIdByName(String hubName) {
         try {
-            CompanyListResponse response = companyClient.getCompaniesByName(affiliationName);
+            GetHubIdResponse response = hubClient.getHubByName(hubName);
+            log.debug("허브 ID 조회 성공 - hubName: {}, hubId: {}", hubName, response.hubId());
+            return response.hubId();
+        } catch (Exception e) {
+            log.error("허브 정보 조회 실패 - hubName: {}", hubName, e);
+            throw new BusinessException(UserErrorCode.BAD_REQUEST, "해당 이름의 허브를 찾을 수 없습니다: " + hubName);
+        }
+    }
+
+    private UUID getCompanyIdByName(String companyName) {
+        try {
+            CompanyListResponse response = companyClient.getCompaniesByName(companyName);
 
             if (response.companies().isEmpty()) {
-                log.warn("업체 정보를 찾을 수 없음 - affiliationName: {}", affiliationName);
-                throw new BusinessException(UserErrorCode.BAD_REQUEST,
-                    "해당 이름의 업체를 찾을 수 없습니다: " + affiliationName);
+                log.warn("업체 정보를 찾을 수 없음 - companyName: {}", companyName);
+                throw new BusinessException(UserErrorCode.BAD_REQUEST, "해당 이름의 업체를 찾을 수 없습니다: " + companyName);
             }
 
             UUID companyId = response.companies().get(0).companyId();
-            log.debug("업체 ID 조회 성공 - affiliationName: {}, companyId: {}", affiliationName,
-                companyId);
+            log.debug("업체 ID 조회 성공 - companyName: {}, companyId: {}", companyName, companyId);
             return companyId;
-
         } catch (BusinessException e) {
             throw e;
         } catch (ExternalApiException e) {
-            log.error("업체 정보 조회 실패 - affiliationName: {}, errorCode: {}",
-                affiliationName, e.getErrorCode().name());
+            log.error("업체 정보 조회 실패 - companyName: {}, errorCode: {}", companyName, e.getErrorCode().name());
             throw e;
         } catch (Exception e) {
-            log.error("예상치 못한 예외 발생 - affiliationName: {}", affiliationName, e);
-            throw new BusinessException(UserErrorCode.INTERNAL_SERVER_ERROR,
-                "업체 정보 조회 중 예상치 못한 오류가 발생했습니다.");
+            log.error("예상치 못한 예외 발생 - companyName: {}", companyName, e);
+            throw new BusinessException(UserErrorCode.INTERNAL_SERVER_ERROR, "업체 정보 조회 중 예상치 못한 오류가 발생했습니다.");
         }
     }
 

--- a/user/src/main/java/com/klp/user/domain/entity/User.java
+++ b/user/src/main/java/com/klp/user/domain/entity/User.java
@@ -89,7 +89,6 @@ public class User extends BaseEntity {
         String email,
         UserRole role
     ) {
-        validateNotNull(affiliationId, "소속 ID는 필수입니다.");
         validateNotNull(affiliationType, "소속 타입은 필수입니다.");
         validateNotNull(role, "권한은 필수입니다.");
         validateNotBlank(name, "이름은 필수입니다.");
@@ -98,11 +97,20 @@ public class User extends BaseEntity {
         validateNotBlank(phone, "전화번호는 필수입니다.");
         validateNotBlank(email, "이메일은 필수입니다.");
         validateRoleAndAffiliationType(role, affiliationType);
+        validateAffiliationId(affiliationId, affiliationType);
 
         User user = new User(affiliationId, affiliationType, name, password, slackId, phone, email,
             role);
         user.status = UserStatus.PENDING;
         return user;
+    }
+
+    private static void validateAffiliationId(UUID affiliationId, AffiliationType affiliationType) {
+        if (affiliationType == AffiliationType.HUB || affiliationType == AffiliationType.COMPANY) {
+            if (affiliationId == null) {
+                throw new BusinessException(UserErrorCode.BAD_REQUEST, "소속 ID는 필수입니다.");
+            }
+        }
     }
 
     private static void validateNotNull(Object o, String message) {

--- a/user/src/main/java/com/klp/user/domain/exception/ExternalApiErrorCode.java
+++ b/user/src/main/java/com/klp/user/domain/exception/ExternalApiErrorCode.java
@@ -19,7 +19,13 @@ public enum ExternalApiErrorCode implements ErrorCode {
     PROMOTION_SERVICE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "프로모션 서비스 호출 시 잘못된 요청입니다."),
     PROMOTION_SERVICE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "프로모션 서비스 인증에 실패했습니다."),
     PROMOTION_SERVICE_FORBIDDEN(HttpStatus.FORBIDDEN, "프로모션 서비스 접근 권한이 없습니다."),
-    USER_GRADE_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 등급 정보를 찾을 수 없습니다.");
+    USER_GRADE_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 등급 정보를 찾을 수 없습니다."),
+
+    HUB_SERVICE_UNAVAILABLE(HttpStatus.BAD_GATEWAY, "허브 서비스 호출 중 오류가 발생했습니다."),
+    HUB_SERVICE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "허브 서비스 호출 시 잘못된 요청입니다."),
+    HUB_SERVICE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "허브 서비스 인증에 실패했습니다."),
+    HUB_SERVICE_FORBIDDEN(HttpStatus.FORBIDDEN, "허브 서비스 접근 권한이 없습니다."),
+    HUB_NOT_FOUND(HttpStatus.NOT_FOUND, "허브 정보를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/user/src/main/java/com/klp/user/global/config/HubFeignClientConfig.java
+++ b/user/src/main/java/com/klp/user/global/config/HubFeignClientConfig.java
@@ -1,0 +1,15 @@
+package com.klp.user.global.config;
+
+import com.klp.global.exception.HubFeignErrorDecoder;
+import feign.codec.ErrorDecoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class HubFeignClientConfig {
+
+    @Bean
+    public ErrorDecoder hubFeignErrorDecoder() {
+        return new HubFeignErrorDecoder();
+    }
+}

--- a/user/src/main/java/com/klp/user/infrastructure/client/HubClient.java
+++ b/user/src/main/java/com/klp/user/infrastructure/client/HubClient.java
@@ -1,5 +1,6 @@
 package com.klp.user.infrastructure.client;
 
+import com.klp.user.global.config.HubFeignClientConfig;
 import com.klp.user.infrastructure.client.dto.response.GetHubIdResponse;
 import com.klp.user.infrastructure.client.dto.response.HubDetailResponse;
 import java.util.UUID;
@@ -12,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@FeignClient(name = "hub-service", contextId = "hubClient")
+@FeignClient(name = "hub-service", configuration = HubFeignClientConfig.class)
 public interface HubClient {
 
     @GetMapping("/v1/hubs/by-name")

--- a/user/src/main/java/com/klp/user/infrastructure/client/HubClient.java
+++ b/user/src/main/java/com/klp/user/infrastructure/client/HubClient.java
@@ -1,14 +1,25 @@
 package com.klp.user.infrastructure.client;
 
+import com.klp.user.infrastructure.client.dto.response.GetHubIdResponse;
+import com.klp.user.infrastructure.client.dto.response.HubDetailResponse;
+import java.util.UUID;
 import com.klp.user.infrastructure.client.dto.request.NearestHubRequest;
 import com.klp.user.infrastructure.client.dto.response.NearestHubResponse;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @FeignClient(name = "hub-service", contextId = "hubClient")
 public interface HubClient {
 
+    @GetMapping("/v1/hubs/by-name")
+    GetHubIdResponse getHubByName(@RequestParam("name") String hubName);
+
+    @GetMapping("/v1/hubs/{hubId}")
+    HubDetailResponse getHubById(@PathVariable("hubId") UUID hubId);
     @PostMapping("/v1/internal/hubs/nearest")
     NearestHubResponse getNearestHub(@RequestBody NearestHubRequest request);
 }

--- a/user/src/main/java/com/klp/user/infrastructure/client/HubClient.java
+++ b/user/src/main/java/com/klp/user/infrastructure/client/HubClient.java
@@ -1,17 +1,17 @@
 package com.klp.user.infrastructure.client;
 
 import com.klp.user.global.config.HubFeignClientConfig;
+import com.klp.user.infrastructure.client.dto.request.NearestHubRequest;
 import com.klp.user.infrastructure.client.dto.response.GetHubIdResponse;
 import com.klp.user.infrastructure.client.dto.response.HubDetailResponse;
-import java.util.UUID;
-import com.klp.user.infrastructure.client.dto.request.NearestHubRequest;
 import com.klp.user.infrastructure.client.dto.response.NearestHubResponse;
+import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "hub-service", configuration = HubFeignClientConfig.class)
 public interface HubClient {
@@ -21,6 +21,7 @@ public interface HubClient {
 
     @GetMapping("/v1/hubs/{hubId}")
     HubDetailResponse getHubById(@PathVariable("hubId") UUID hubId);
+
     @PostMapping("/v1/internal/hubs/nearest")
     NearestHubResponse getNearestHub(@RequestBody NearestHubRequest request);
 }

--- a/user/src/main/java/com/klp/user/infrastructure/client/dto/response/GetHubIdResponse.java
+++ b/user/src/main/java/com/klp/user/infrastructure/client/dto/response/GetHubIdResponse.java
@@ -1,0 +1,10 @@
+package com.klp.user.infrastructure.client.dto.response;
+
+import java.util.UUID;
+
+public record GetHubIdResponse(
+    UUID hubId,
+    String hubName
+) {
+
+}

--- a/user/src/main/java/com/klp/user/infrastructure/client/dto/response/HubDetailResponse.java
+++ b/user/src/main/java/com/klp/user/infrastructure/client/dto/response/HubDetailResponse.java
@@ -1,0 +1,13 @@
+package com.klp.user.infrastructure.client.dto.response;
+
+import java.util.UUID;
+
+public record HubDetailResponse(
+    UUID hubId,
+    String name,
+    Double latitude,
+    Double longitude,
+    String address,
+    String status
+) {
+}


### PR DESCRIPTION
## PR 내용
- [feat: 인증 도메인 소속 타입에 CUSTOMER 추가](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/0b376c06b7acb20ec1e53ac93b97194eb10e0fe4)
  - 회원 서비스에는 고객이 존재하지만, 인증 서비스에느 존재하지 않아 회원가입 시 요청이 문제가 되던 부분을 수정했습니다.

- [feat: 회원가입 로직 문제 해결](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/c6b264f508673f46e319e232e0c6a742c8b09480)
  - 소속 타입에 따라 afiilationId를 저장하는 부분 오류를 수정했습니다.
  - HUB, COMPANY의 경우 실제로 DB에 존재하는 업체의 이름, ID를 사용하도록 수정했습니다.
  - LOGISTICS, CUSTOMER의 경우 null로 저장되도록 하며, 상세 조회 시 LOGISTICS 소속은 `KLP 물류`를 반환하도록 설정했습니다.