### PR TITLE
feat: 알림 서비스 Kafka 설정

### DIFF
--- a/notification/src/main/java/com/klp/notification/messaging/application/listener/DeliveryEventListener.java
+++ b/notification/src/main/java/com/klp/notification/messaging/application/listener/DeliveryEventListener.java
@@ -1,0 +1,59 @@
+package com.klp.notification.messaging.application.listener;
+
+import com.klp.notification.ai.application.AIService;
+import com.klp.notification.ai.application.command.GenerateMessageCommand;
+import com.klp.notification.messaging.domain.event.DeliveryCreatedEvent;
+import com.klp.notification.messaging.infrastructure.config.KafkaTopicConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaHandler;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@KafkaListener(
+    topics = KafkaTopicConfig.DELIVERY_CREATED_TOPIC,
+    groupId = "notification-service-group",
+    containerFactory = "notificationKafkaListenerContainerFactory"
+)
+public class DeliveryEventListener {
+
+    private final AIService aiService;
+
+    @KafkaHandler
+    public void handleDeliveryCreated(DeliveryCreatedEvent event) {
+        log.info("배송 생성 이벤트 수신: deliveryId={}, orderId={}", event.deliveryId(), event.orderId());
+
+        try {
+            GenerateMessageCommand command = new GenerateMessageCommand(
+                event.driverSlackId(),
+                event.orderId(),
+                event.ordererName(),
+                event.ordererEmail(),
+                event.orderTime(),
+                event.productName(),
+                event.quantity(),
+                event.requirements(),
+                event.departureHubName(),
+                event.transitHubNames(),
+                event.destinationAddress(),
+                event.driverName(),
+                event.driverEmail(),
+                event.workingHours()
+            );
+
+            aiService.fromTextInput(command);
+            log.info("AI 메시지 생성 요청 완료: driverSlackId={}", event.driverSlackId());
+        } catch (Exception e) {
+            log.error("배송 생성 알림 처리 실패: deliveryId={}, error={}", event.deliveryId(), e.getMessage());
+            throw e;
+        }
+    }
+
+    @KafkaHandler(isDefault = true)
+    public void handleUnknown(Object event) {
+        log.warn("알 수 없는 이벤트 타입 수신: {}", event.getClass().getSimpleName());
+    }
+}

--- a/notification/src/main/java/com/klp/notification/messaging/domain/event/DeliveryCreatedEvent.java
+++ b/notification/src/main/java/com/klp/notification/messaging/domain/event/DeliveryCreatedEvent.java
@@ -1,0 +1,28 @@
+package com.klp.notification.messaging.domain.event;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Delivery 서비스에서 발행하는 배송 생성 이벤트 (구독용)
+ */
+public record DeliveryCreatedEvent(
+    UUID deliveryId,
+    UUID orderId,
+    String driverSlackId,
+    String ordererName,
+    String ordererEmail,
+    LocalDateTime orderTime,
+    String productName,
+    Integer quantity,
+    String requirements,
+    String departureHubName,
+    List<String> transitHubNames,
+    String destinationAddress,
+    String driverName,
+    String driverEmail,
+    String workingHours,
+    LocalDateTime occurredAt
+) {
+}

--- a/notification/src/main/java/com/klp/notification/messaging/infrastructure/config/KafkaConsumerConfig.java
+++ b/notification/src/main/java/com/klp/notification/messaging/infrastructure/config/KafkaConsumerConfig.java
@@ -1,0 +1,105 @@
+package com.klp.notification.messaging.infrastructure.config;
+
+import com.klp.notification.messaging.domain.event.DeliveryCreatedEvent;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.serializer.DeserializationException;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.messaging.converter.MessageConversionException;
+import org.springframework.util.backoff.FixedBackOff;
+
+@Slf4j
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    private static final int MAX_RETRY_ATTEMPTS = 3;
+    private static final long RETRY_INTERVAL_MS = 1000L;
+
+    @Bean
+    public ConsumerFactory<String, Object> notificationConsumerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ConsumerConfig.GROUP_ID_CONFIG, "notification-service-group");
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        configProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        configProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        configProps.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 500);
+        configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "com.klp.*");
+        configProps.put(JsonDeserializer.TYPE_MAPPINGS, buildTypeMappings());
+
+        return new DefaultKafkaConsumerFactory<>(configProps);
+    }
+
+    private String buildTypeMappings() {
+        return String.join(",",
+            "DeliveryCreatedEvent:" + DeliveryCreatedEvent.class.getName()
+        );
+    }
+
+    @Bean
+    public DeadLetterPublishingRecoverer notificationDeadLetterPublishingRecoverer(
+        @Qualifier("notificationKafkaTemplate") KafkaTemplate<String, Object> kafkaTemplate
+    ) {
+        return new DeadLetterPublishingRecoverer(kafkaTemplate,
+            (record, exception) -> {
+                log.error("메시지 처리 실패, DLT로 이동: topic={}, error={}", 
+                    record.topic(), exception.getMessage());
+                return new TopicPartition(KafkaTopicConfig.NOTIFICATION_DLT, record.partition());
+            });
+    }
+
+    @Bean
+    public DefaultErrorHandler notificationErrorHandler(
+        @Qualifier("notificationDeadLetterPublishingRecoverer") DeadLetterPublishingRecoverer recoverer
+    ) {
+        FixedBackOff backOff = new FixedBackOff(RETRY_INTERVAL_MS, MAX_RETRY_ATTEMPTS);
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, backOff);
+        
+        errorHandler.addNotRetryableExceptions(
+            DeserializationException.class,
+            MessageConversionException.class
+        );
+
+        errorHandler.setRetryListeners((record, ex, deliveryAttempt) -> {
+            log.warn("메시지 처리 재시도: topic={}, attempt={}, error={}", 
+                record.topic(), deliveryAttempt, ex.getMessage());
+        });
+
+        return errorHandler;
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> notificationKafkaListenerContainerFactory(
+        @Qualifier("notificationErrorHandler") DefaultErrorHandler errorHandler
+    ) {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory =
+            new ConcurrentKafkaListenerContainerFactory<>();
+
+        factory.setConsumerFactory(notificationConsumerFactory());
+        factory.setConcurrency(3);
+        factory.setCommonErrorHandler(errorHandler);
+
+        return factory;
+    }
+}

--- a/notification/src/main/java/com/klp/notification/messaging/infrastructure/config/KafkaProducerConfig.java
+++ b/notification/src/main/java/com/klp/notification/messaging/infrastructure/config/KafkaProducerConfig.java
@@ -1,0 +1,38 @@
+package com.klp.notification.messaging.infrastructure.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, Object> notificationProducerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        configProps.put(ProducerConfig.ACKS_CONFIG, "all");
+        configProps.put(ProducerConfig.RETRIES_CONFIG, 3);
+
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> notificationKafkaTemplate() {
+        return new KafkaTemplate<>(notificationProducerFactory());
+    }
+}

--- a/notification/src/main/java/com/klp/notification/messaging/infrastructure/config/KafkaTopicConfig.java
+++ b/notification/src/main/java/com/klp/notification/messaging/infrastructure/config/KafkaTopicConfig.java
@@ -1,0 +1,21 @@
+package com.klp.notification.messaging.infrastructure.config;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+
+@Configuration
+public class KafkaTopicConfig {
+
+    public static final String DELIVERY_CREATED_TOPIC = "delivery.topic";
+    public static final String NOTIFICATION_DLT = "notification.dlt";
+
+    @Bean
+    public NewTopic notificationDltTopic() {
+        return TopicBuilder.name(NOTIFICATION_DLT)
+            .partitions(3)
+            .replicas(1)
+            .build();
+    }
+}


### PR DESCRIPTION
## PR 내용
- [feat: 알림 서비스 Kafka 설정](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/5b64cbf0e79fdac9878255bee25190af9f445228)
  - 알림 서비스 관련 Kafka 설정을 진행했습니다.
  - 알림 서비스는 이벤트 체인 맨 마지막으로 따로 발행하는 메시지가 DLT밖에 없어 아웃박스를 적용하지 않았습니다.