### PR TITLE
feat: 상품 카테고리를 적용하여 유사도 수치 개선

### DIFF
--- a/ai/src/main/java/com/klp/ai/global/config/OpenAiConfig.java
+++ b/ai/src/main/java/com/klp/ai/global/config/OpenAiConfig.java
@@ -34,14 +34,14 @@ public class OpenAiConfig {
 
     @Bean
     @Primary
-    public ChatModel ollamaChatModel(
+    public ChatModel openAiChatModel(
         @Value("${spring.ai.openai.api-key}") String apiKey,
-        @Value("${spring.ai.openai.embedding.options.model:text-embedding-3-small}") String model
+        @Value("${spring.ai.openai.chat.options.model:gpt-4o-mini}") String chatModel
     ) {
         OpenAiApi openAiApi = OpenAiApi.builder().apiKey(apiKey).build();
         return OpenAiChatModel.builder()
             .openAiApi(openAiApi)
-            .defaultOptions(OpenAiChatOptions.builder().model(model).build())
+            .defaultOptions(OpenAiChatOptions.builder().model(chatModel).build())
             .build();
     }
 }

--- a/ai/src/main/java/com/klp/ai/global/config/RedisConfig.java
+++ b/ai/src/main/java/com/klp/ai/global/config/RedisConfig.java
@@ -1,5 +1,9 @@
 package com.klp.ai.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -40,7 +44,7 @@ public class RedisConfig {
     @Bean
     public RedisCacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
         var keySerializer = new StringRedisSerializer();
-        var valueSerializer = new GenericJackson2JsonRedisSerializer();
+        var valueSerializer = new GenericJackson2JsonRedisSerializer(cacheObjectMapper());
 
         RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
             .entryTtl(Duration.ofMinutes(10))
@@ -56,5 +60,18 @@ public class RedisConfig {
             .cacheDefaults(defaultConfig)
             .withInitialCacheConfigurations(cacheConfigurations)
             .build();
+    }
+
+    private ObjectMapper cacheObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        BasicPolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
+            .allowIfSubType(Object.class)
+            .build();
+        mapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL);
+
+        return mapper;
     }
 }

--- a/ai/src/main/java/com/klp/ai/global/config/RedisConfig.java
+++ b/ai/src/main/java/com/klp/ai/global/config/RedisConfig.java
@@ -1,9 +1,5 @@
 package com.klp.ai.global.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -14,7 +10,7 @@ import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.JdkSerializationRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -23,8 +19,8 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 public class RedisConfig {
 
     private static final String KEY_PREFIX = "ai-cache:";
-    private static final Duration RECOMMENDATION_CACHE_TTL = Duration.ofMinutes(30);
-    private static final Duration VECTOR_SEARCH_CACHE_TTL = Duration.ofMinutes(10);
+    private static final Duration RECOMMENDATION_CACHE_TTL = Duration.ofMinutes(10);
+    private static final Duration VECTOR_SEARCH_CACHE_TTL = Duration.ofMinutes(30);
 
     @Bean
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
@@ -33,9 +29,8 @@ public class RedisConfig {
 
         template.setKeySerializer(new StringRedisSerializer());
         template.setHashKeySerializer(new StringRedisSerializer());
-
-        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
-        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setValueSerializer(new JdkSerializationRedisSerializer());
+        template.setHashValueSerializer(new JdkSerializationRedisSerializer());
 
         template.afterPropertiesSet();
         return template;
@@ -43,13 +38,14 @@ public class RedisConfig {
 
     @Bean
     public RedisCacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
-        var keySerializer = new StringRedisSerializer();
-        var valueSerializer = new GenericJackson2JsonRedisSerializer(cacheObjectMapper());
-
         RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
             .entryTtl(Duration.ofMinutes(10))
-            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(keySerializer))
-            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(valueSerializer))
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())
+            )
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(new JdkSerializationRedisSerializer())
+            )
             .prefixCacheNameWith(KEY_PREFIX);
 
         Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
@@ -60,18 +56,5 @@ public class RedisConfig {
             .cacheDefaults(defaultConfig)
             .withInitialCacheConfigurations(cacheConfigurations)
             .build();
-    }
-
-    private ObjectMapper cacheObjectMapper() {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(new JavaTimeModule());
-        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-
-        BasicPolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
-            .allowIfSubType(Object.class)
-            .build();
-        mapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL);
-
-        return mapper;
     }
 }

--- a/ai/src/main/java/com/klp/ai/global/config/RedisConfig.java
+++ b/ai/src/main/java/com/klp/ai/global/config/RedisConfig.java
@@ -1,14 +1,26 @@
 package com.klp.ai.global.config;
 
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+@EnableCaching
 @Configuration
 public class RedisConfig {
+
+    private static final String KEY_PREFIX = "ai-cache:";
+    private static final Duration RECOMMENDATION_CACHE_TTL = Duration.ofMinutes(30);
+    private static final Duration VECTOR_SEARCH_CACHE_TTL = Duration.ofMinutes(10);
 
     @Bean
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
@@ -23,5 +35,26 @@ public class RedisConfig {
 
         template.afterPropertiesSet();
         return template;
+    }
+
+    @Bean
+    public RedisCacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
+        var keySerializer = new StringRedisSerializer();
+        var valueSerializer = new GenericJackson2JsonRedisSerializer();
+
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofMinutes(10))
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(keySerializer))
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(valueSerializer))
+            .prefixCacheNameWith(KEY_PREFIX);
+
+        Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+        cacheConfigurations.put("recommendation", defaultConfig.entryTtl(RECOMMENDATION_CACHE_TTL));
+        cacheConfigurations.put("vector-search", defaultConfig.entryTtl(VECTOR_SEARCH_CACHE_TTL));
+
+        return RedisCacheManager.builder(connectionFactory)
+            .cacheDefaults(defaultConfig)
+            .withInitialCacheConfigurations(cacheConfigurations)
+            .build();
     }
 }

--- a/ai/src/main/java/com/klp/ai/recommendation/application/RecommendationFacade.java
+++ b/ai/src/main/java/com/klp/ai/recommendation/application/RecommendationFacade.java
@@ -92,7 +92,6 @@ public class RecommendationFacade {
 
             List<RecommendationResult> results = llmService.generateRecommendations(context, availableCandidates);
 
-            // similarityScore 높은 순으로 정렬
             List<RecommendationResult> sortedResults = results.stream()
                 .sorted((a, b) -> Double.compare(b.similarityScore(), a.similarityScore()))
                 .toList();

--- a/ai/src/main/java/com/klp/ai/recommendation/application/RecommendationFacade.java
+++ b/ai/src/main/java/com/klp/ai/recommendation/application/RecommendationFacade.java
@@ -16,6 +16,8 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -34,6 +36,7 @@ public class RecommendationFacade {
     /**
      * 주문 ID 기반 추천 생성
      */
+    @Cacheable(value = "recommendation", key = "#orderId.toString() + ':' + #limit")
     public List<RecommendationResult> getRecommendations(
         UUID orderId,
         Long userId,
@@ -147,5 +150,21 @@ public class RecommendationFacade {
             .limit(5)
             .map(RecommendationResult::from)
             .toList();
+    }
+
+    /**
+     * 특정 주문의 추천 캐시 삭제
+     */
+    @CacheEvict(value = "recommendation", key = "#orderId.toString()")
+    public void evictRecommendationCache(UUID orderId) {
+        log.info("추천 캐시 삭제: orderId={}", orderId);
+    }
+
+    /**
+     * 모든 추천 캐시 삭제
+     */
+    @CacheEvict(value = "recommendation", allEntries = true)
+    public void evictAllRecommendationCache() {
+        log.info("전체 추천 캐시 삭제");
     }
 }

--- a/ai/src/main/java/com/klp/ai/recommendation/application/RecommendationFacade.java
+++ b/ai/src/main/java/com/klp/ai/recommendation/application/RecommendationFacade.java
@@ -40,6 +40,8 @@ public class RecommendationFacade {
         UUID userHubId,
         int limit
     ) {
+        log.info("추천 요청: orderId={}, userId={}", orderId, userId);
+        
         List<OrderedProduct> orderedProducts = orderDataService.getOrderedProducts(orderId);
 
         List<RecommendationResult> recommendations = generateRecommendations(
@@ -58,7 +60,7 @@ public class RecommendationFacade {
         List<OrderedProduct> orderedProducts
     ) {
         if (orderedProducts.isEmpty()) {
-            log.warn("주문 상품이 없어 추천을 생성할 수 없습니다: userId={}", userId);
+            log.warn("주문 상품이 없어 추천 불가: userId={}", userId);
             return Collections.emptyList();
         }
 
@@ -66,8 +68,9 @@ public class RecommendationFacade {
 
         try {
             List<ProductCandidate> candidates = searchCandidates(orderedProducts);
+            
             if (candidates.isEmpty()) {
-                log.info("유사 상품을 찾을 수 없습니다: userId={}", userId);
+                log.warn("유사 상품 없음: userId={}", userId);
                 return Collections.emptyList();
             }
 
@@ -78,15 +81,18 @@ public class RecommendationFacade {
             List<ProductCandidate> enrichedCandidates = enrichCandidates(candidates, context.userHub());
 
             availableCandidates = filterByInventory(enrichedCandidates);
+            
             if (availableCandidates.isEmpty()) {
-                log.info("재고가 있는 상품이 없습니다: userId={}", userId);
+                log.warn("재고 있는 상품 없음: userId={}", userId);
                 return Collections.emptyList();
             }
 
-            return llmService.generateRecommendations(context, availableCandidates);
+            List<RecommendationResult> results = llmService.generateRecommendations(context, availableCandidates);
+            log.info("추천 완료: userId={}, 결과={} 개", userId, results.size());
+            return results;
 
         } catch (Exception e) {
-            log.error("추천 생성 실패: userId={}, error={}", userId, e.getMessage(), e);
+            log.error("추천 생성 실패: userId={}", userId, e);
             return fallbackToVectorResults(availableCandidates);
         }
     }

--- a/ai/src/main/java/com/klp/ai/recommendation/application/RecommendationFacade.java
+++ b/ai/src/main/java/com/klp/ai/recommendation/application/RecommendationFacade.java
@@ -41,7 +41,7 @@ public class RecommendationFacade {
         int limit
     ) {
         log.info("추천 요청: orderId={}, userId={}", orderId, userId);
-        
+
         List<OrderedProduct> orderedProducts = orderDataService.getOrderedProducts(orderId);
 
         List<RecommendationResult> recommendations = generateRecommendations(
@@ -68,7 +68,7 @@ public class RecommendationFacade {
 
         try {
             List<ProductCandidate> candidates = searchCandidates(orderedProducts);
-            
+
             if (candidates.isEmpty()) {
                 log.warn("유사 상품 없음: userId={}", userId);
                 return Collections.emptyList();
@@ -81,15 +81,21 @@ public class RecommendationFacade {
             List<ProductCandidate> enrichedCandidates = enrichCandidates(candidates, context.userHub());
 
             availableCandidates = filterByInventory(enrichedCandidates);
-            
+
             if (availableCandidates.isEmpty()) {
                 log.warn("재고 있는 상품 없음: userId={}", userId);
                 return Collections.emptyList();
             }
 
             List<RecommendationResult> results = llmService.generateRecommendations(context, availableCandidates);
-            log.info("추천 완료: userId={}, 결과={} 개", userId, results.size());
-            return results;
+
+            // similarityScore 높은 순으로 정렬
+            List<RecommendationResult> sortedResults = results.stream()
+                .sorted((a, b) -> Double.compare(b.similarityScore(), a.similarityScore()))
+                .toList();
+
+            log.info("추천 완료: userId={}, 결과={} 개", userId, sortedResults.size());
+            return sortedResults;
 
         } catch (Exception e) {
             log.error("추천 생성 실패: userId={}", userId, e);
@@ -137,12 +143,9 @@ public class RecommendationFacade {
         }
 
         return candidates.stream()
+            .sorted((a, b) -> Double.compare(b.similarityScore(), a.similarityScore()))
             .limit(5)
-            .map(c -> RecommendationResult.from(
-                c,
-                c.similarityScore(),
-                "고객님께 추천하는 상품입니다."
-            ))
+            .map(RecommendationResult::from)
             .toList();
     }
 }

--- a/ai/src/main/java/com/klp/ai/recommendation/application/dto/LlmRecommendationResponse.java
+++ b/ai/src/main/java/com/klp/ai/recommendation/application/dto/LlmRecommendationResponse.java
@@ -1,13 +1,11 @@
 package com.klp.ai.recommendation.application.dto;
 
-import java.util.UUID;
-
 public record LlmRecommendationResponse(
-    String productId,
+    Integer index,
     String reason
 ) {
 
-    public UUID getProductIdAsUUID() {
-        return UUID.fromString(productId);
+    public boolean hasValidIndex() {
+        return index != null && index > 0;
     }
 }

--- a/ai/src/main/java/com/klp/ai/recommendation/application/dto/RecommendationResult.java
+++ b/ai/src/main/java/com/klp/ai/recommendation/application/dto/RecommendationResult.java
@@ -1,5 +1,6 @@
 package com.klp.ai.recommendation.application.dto;
 
+import java.io.Serializable;
 import java.util.UUID;
 
 public record RecommendationResult(
@@ -12,7 +13,7 @@ public record RecommendationResult(
     double averageRating,
     int reviewCount,
     double similarityScore
-) {
+) implements Serializable {
 
     public static RecommendationResult from(ProductCandidate candidate) {
         return new RecommendationResult(

--- a/ai/src/main/java/com/klp/ai/recommendation/application/dto/RecommendationResult.java
+++ b/ai/src/main/java/com/klp/ai/recommendation/application/dto/RecommendationResult.java
@@ -11,11 +11,10 @@ public record RecommendationResult(
     int inventory,
     double averageRating,
     int reviewCount,
-    double score,
-    String reason
+    double similarityScore
 ) {
 
-    public static RecommendationResult from(ProductCandidate candidate, double score, String reason) {
+    public static RecommendationResult from(ProductCandidate candidate) {
         return new RecommendationResult(
             candidate.productId(),
             candidate.productName(),
@@ -25,8 +24,7 @@ public record RecommendationResult(
             candidate.inventory(),
             candidate.averageRating(),
             candidate.reviewCount(),
-            score,
-            reason
+            candidate.similarityScore()
         );
     }
 }

--- a/ai/src/main/java/com/klp/ai/recommendation/application/service/EmbeddingService.java
+++ b/ai/src/main/java/com/klp/ai/recommendation/application/service/EmbeddingService.java
@@ -42,6 +42,14 @@ public class EmbeddingService {
         }
     }
 
+    public void generateAllEmbeddings() {
+        log.info("모든 상품 임베딩 생성 시작");
+        List<UUID> allProductIds = hubClient.getAllProductIds();
+        log.info("총 {} 개 상품의 임베딩 생성 시작", allProductIds.size());
+        generateAndSaveEmbeddings(allProductIds);
+        log.info("모든 상품 임베딩 생성 완료");
+    }
+
     private void saveProductEmbedding(ProductResponse product) {
         String productIdStr = product.productId().toString();
 
@@ -53,6 +61,7 @@ public class EmbeddingService {
         Map<String, Object> metadata = new HashMap<>();
         metadata.put("productId", productIdStr);
         metadata.put("productName", product.productName());
+        metadata.put("category", product.category() != null ? product.category() : "기타");
         metadata.put("hubId", product.hubId().toString());
         metadata.put("hubName", hub.name());
         metadata.put("latitude", hub.latitude());
@@ -77,8 +86,10 @@ public class EmbeddingService {
     }
 
     private String createEmbeddingText(ProductResponse product, HubResponse hub) {
-        return String.format("상품: %s, 허브: %s, 지역: %s",
+        String category = product.category() != null ? product.category() : "기타";
+        return String.format("상품: %s, 카테고리: %s, 허브: %s, 지역: %s",
             product.productName(),
+            category,
             hub.name(),
             hub.address()
         );

--- a/ai/src/main/java/com/klp/ai/recommendation/application/service/LlmService.java
+++ b/ai/src/main/java/com/klp/ai/recommendation/application/service/LlmService.java
@@ -84,8 +84,7 @@ public class LlmService {
 
                 seenIndices.add(r.index());
                 ProductCandidate candidate = candidates.get(idx);
-                String cleanedReason = cleanReason(r.reason());
-                results.add(RecommendationResult.from(candidate, candidate.similarityScore(), cleanedReason));
+                results.add(RecommendationResult.from(candidate));
             }
 
             return results;
@@ -122,15 +121,4 @@ public class LlmService {
         return content.trim();
     }
 
-    /**
-     * LLM 응답에서 비한국어/비영어 문자 제거
-     */
-    private String cleanReason(String reason) {
-        if (reason == null) {
-            return "고객님께 추천드리는 상품입니다.";
-        }
-        // 한글, 영문, 숫자, 기본 문장부호만 허용
-        String cleaned = reason.replaceAll("[^가-힣a-zA-Z0-9\\s.,!?%°~\\-()]", "").trim();
-        return cleaned.isEmpty() ? "고객님께 추천드리는 상품입니다." : cleaned;
-    }
 }

--- a/ai/src/main/java/com/klp/ai/recommendation/application/service/LlmService.java
+++ b/ai/src/main/java/com/klp/ai/recommendation/application/service/LlmService.java
@@ -10,11 +10,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
@@ -69,46 +65,61 @@ public class LlmService {
                 }
             );
 
-            Map<UUID, ProductCandidate> candidateMap = candidates.stream()
-                .collect(Collectors.toMap(ProductCandidate::productId, Function.identity()));
-
-            // 중복 제거: productId 기준으로 첫 번째 항목만 유지
-            Set<UUID> seenProductIds = new HashSet<>();
+            Set<Integer> seenIndices = new HashSet<>();
             List<RecommendationResult> results = new ArrayList<>();
 
             for (LlmRecommendationResponse r : llmResponses) {
-                UUID productId = r.getProductIdAsUUID();
-                if (productId != null && candidateMap.containsKey(productId) && !seenProductIds.contains(productId)) {
-                    seenProductIds.add(productId);
-                    ProductCandidate candidate = candidateMap.get(productId);
-                    String cleanedReason = cleanReason(r.reason());
-                    results.add(RecommendationResult.from(candidate, candidate.similarityScore(), cleanedReason));
+                if (!r.hasValidIndex()) {
+                    continue;
                 }
+
+                int idx = r.index() - 1;
+                if (idx < 0 || idx >= candidates.size()) {
+                    continue;
+                }
+
+                if (seenIndices.contains(r.index())) {
+                    continue;
+                }
+
+                seenIndices.add(r.index());
+                ProductCandidate candidate = candidates.get(idx);
+                String cleanedReason = cleanReason(r.reason());
+                results.add(RecommendationResult.from(candidate, candidate.similarityScore(), cleanedReason));
             }
 
             return results;
         } catch (Exception e) {
-            log.error("LLM 응답 파싱 실패: response={}", response, e);
+            log.error("LLM 응답 파싱 실패", e);
             throw new RuntimeException("LLM 응답 파싱 실패", e);
         }
     }
 
     private String extractJsonContent(String response) {
-        if (response.contains("```json")) {
-            int start = response.indexOf("```json") + 7;
-            int end = response.indexOf("```", start);
+        String content = response;
+
+        if (content.contains("```json")) {
+            int start = content.indexOf("```json") + 7;
+            int end = content.indexOf("```", start);
             if (end > start) {
-                return response.substring(start, end).trim();
+                content = content.substring(start, end).trim();
+            }
+        } else if (content.contains("```")) {
+            int start = content.indexOf("```") + 3;
+            int end = content.indexOf("```", start);
+            if (end > start) {
+                content = content.substring(start, end).trim();
             }
         }
-        if (response.contains("```")) {
-            int start = response.indexOf("```") + 3;
-            int end = response.indexOf("```", start);
-            if (end > start) {
-                return response.substring(start, end).trim();
-            }
-        }
-        return response.trim();
+
+        // JSON 주석 제거 (// 스타일)
+        content = content.replaceAll("//.*", "");
+        // JSON 주석 제거 (/* */ 스타일)
+        content = content.replaceAll("/\\*.*?\\*/", "");
+        // 빈 줄 정리
+        content = content.replaceAll("(?m)^\\s*$[\r\n]*", "");
+
+        return content.trim();
     }
 
     /**

--- a/ai/src/main/java/com/klp/ai/recommendation/application/service/OrderDataService.java
+++ b/ai/src/main/java/com/klp/ai/recommendation/application/service/OrderDataService.java
@@ -17,13 +17,18 @@ public class OrderDataService {
     private final OrderClient orderClient;
 
     public List<OrderedProduct> getOrderedProducts(UUID orderId) {
-        OrderResponse order = orderClient.getOrder(orderId);
+        try {
+            OrderResponse order = orderClient.getOrder(orderId);
 
-        return order.orderItems().stream()
-            .map(item -> new OrderedProduct(
-                item.productId(),
-                item.productName()
-            ))
-            .toList();
+            return order.orderItems().stream()
+                .map(item -> new OrderedProduct(
+                    item.productId(),
+                    item.productName()
+                ))
+                .toList();
+        } catch (Exception e) {
+            log.error("주문 조회 실패: orderId={}", orderId, e);
+            return List.of();
+        }
     }
 }

--- a/ai/src/main/java/com/klp/ai/recommendation/application/service/PromptBuilder.java
+++ b/ai/src/main/java/com/klp/ai/recommendation/application/service/PromptBuilder.java
@@ -78,13 +78,12 @@ public class PromptBuilder {
 
         for (int i = 0; i < candidates.size(); i++) {
             ProductCandidate c = candidates.get(i);
-            sb.append(String.format("%d. %s\n", i + 1, c.productName()));
+            sb.append(String.format("%d. %s (index: %d)\n", i + 1, c.productName(), i + 1));
             sb.append(String.format("   - 허브: %s (거리: %.1fkm)\n", c.hubName(), c.distance()));
             sb.append(String.format("   - 재고: %d개%s\n", c.inventory(), c.isLowStock() ? " ⚠️ 재고 부족" : ""));
             sb.append(String.format("   - 평점: %.1f (%d개 리뷰)%s\n",
                 c.averageRating(), c.reviewCount(),
                 c.isHighlyRated() ? " ⭐ 인기상품" : ""));
-            sb.append(String.format("   - productId: %s\n", c.productId()));
         }
 
         return sb.toString();
@@ -97,11 +96,15 @@ public class PromptBuilder {
             ```json
             [
               {
-                "productId": "uuid-string",
+                "index": 1,
                 "reason": "추천 이유를 자연스러운 한국어로 작성"
               }
             ]
             ```
+            
+            중요:
+            - index는 위 후보 상품 목록의 번호(1부터 시작)를 사용하세요
+            - JSON만 출력하고 다른 설명은 하지 마세요
             
             추천 이유 작성 시:
             - 반드시 한국어로만 작성 (영어, 태국어 등 다른 언어 사용 금지)

--- a/ai/src/main/java/com/klp/ai/recommendation/application/service/VectorSearchService.java
+++ b/ai/src/main/java/com/klp/ai/recommendation/application/service/VectorSearchService.java
@@ -5,12 +5,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class VectorSearchService {

--- a/ai/src/main/java/com/klp/ai/recommendation/infrastructure/client/feign/HubClient.java
+++ b/ai/src/main/java/com/klp/ai/recommendation/infrastructure/client/feign/HubClient.java
@@ -4,6 +4,7 @@ import com.klp.ai.global.config.HubFeignClientConfig;
 import com.klp.ai.recommendation.infrastructure.client.feign.dto.response.HubResponse;
 import com.klp.ai.recommendation.infrastructure.client.feign.dto.response.InventoryResponse;
 import com.klp.ai.recommendation.infrastructure.client.feign.dto.response.ProductResponse;
+import java.util.List;
 import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,4 +21,7 @@ public interface HubClient {
 
     @GetMapping("/v1/inventories/{productId}")
     InventoryResponse getInventory(@PathVariable UUID productId);
+
+    @GetMapping("/v1/internal/products/ids")
+    List<UUID> getAllProductIds();
 }

--- a/ai/src/main/java/com/klp/ai/recommendation/infrastructure/client/feign/OrderClient.java
+++ b/ai/src/main/java/com/klp/ai/recommendation/infrastructure/client/feign/OrderClient.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "order-service", url = "${clients.order.url:}", configuration = OrderFeignClientConfig.class)
 public interface OrderClient {

--- a/ai/src/main/java/com/klp/ai/recommendation/infrastructure/client/feign/dto/response/ProductResponse.java
+++ b/ai/src/main/java/com/klp/ai/recommendation/infrastructure/client/feign/dto/response/ProductResponse.java
@@ -6,7 +6,8 @@ public record ProductResponse(
     UUID productId,
     UUID hubId,
     String companyName,
-    String productName
+    String productName,
+    String category
 ) {
 
 }

--- a/ai/src/main/java/com/klp/ai/recommendation/presentation/EmbeddingController.java
+++ b/ai/src/main/java/com/klp/ai/recommendation/presentation/EmbeddingController.java
@@ -33,4 +33,11 @@ public class EmbeddingController implements EmbeddingControllerDoc {
         embeddingService.generateAndSaveEmbeddings(productIds);
         return ResponseEntity.ok("배치 임베딩 생성 완료: " + productIds.size() + "개");
     }
+
+    @PostMapping("/products/all")
+    @PreAuthorize("hasAnyRole('MASTER', 'HUB')")
+    public ResponseEntity<String> generateAllEmbeddings() {
+        embeddingService.generateAllEmbeddings();
+        return ResponseEntity.ok("모든 상품 임베딩 생성 완료");
+    }
 }

--- a/ai/src/main/java/com/klp/ai/recommendation/presentation/RecommendationController.java
+++ b/ai/src/main/java/com/klp/ai/recommendation/presentation/RecommendationController.java
@@ -34,8 +34,6 @@ public class RecommendationController implements RecommendationControllerDoc {
             orderId, userId, userHubId, limit
         );
 
-        return ResponseEntity.ok(
-            RecommendationResponse.of(orderId, recommendations)
-        );
+        return ResponseEntity.ok().body(RecommendationResponse.of(orderId, recommendations));
     }
 }

--- a/ai/src/main/java/com/klp/ai/recommendation/presentation/dto/response/RecommendationResponse.java
+++ b/ai/src/main/java/com/klp/ai/recommendation/presentation/dto/response/RecommendationResponse.java
@@ -19,15 +19,14 @@ public record RecommendationResponse(
         int inventory,
         double averageRating,
         int reviewCount,
-        double score,
-        String reason
+        double similarityScore
     ) {
 
         public static RecommendationItem from(RecommendationResult r) {
             return new RecommendationItem(
                 r.productId(), r.productName(),
                 r.hubName(), r.distance(), r.inventory(),
-                r.averageRating(), r.reviewCount(), r.score(), r.reason()
+                r.averageRating(), r.reviewCount(), r.similarityScore()
             );
         }
     }

--- a/hub/src/main/java/com/klp/hub/product/application/ProductService.java
+++ b/hub/src/main/java/com/klp/hub/product/application/ProductService.java
@@ -14,6 +14,7 @@ import com.klp.hub.product.exception.ProductErrorCode;
 import com.klp.hub.product.presentation.dto.ProductResponse;
 import com.klp.hub.product.presentation.dto.ProductUpdateResponse;
 import com.klp.hub.product.presentation.dto.ProductsPageRowResponse;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,13 +47,19 @@ public class ProductService {
             product.getId(),
             inventory.hubId(),
             company.name(),
-            product.getName()
+            product.getName(),
+            product.getCategoryDisplayName()
         );
     }
 
     @Transactional(readOnly = true)
     public Page<ProductsPageRowResponse> getProductsByPageable(Pageable pageable) {
         return productRepository.findAllByPageable(pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public List<UUID> getAllProductIds() {
+        return productRepository.findAllProductIds();
     }
 
     @Transactional

--- a/hub/src/main/java/com/klp/hub/product/domain/Product.java
+++ b/hub/src/main/java/com/klp/hub/product/domain/Product.java
@@ -27,7 +27,16 @@ public class Product extends BaseEntity {
     @Column(name = "name", nullable = false)
     private String name;
 
+    @Comment("카테고리")
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category")
+    private ProductCategory category;
+
     public Product(UUID companyId, String name) {
+        this(companyId, name, null);
+    }
+
+    public Product(UUID companyId, String name, ProductCategory category) {
         validateName(name);
 
         if (companyId == null) {
@@ -35,12 +44,21 @@ public class Product extends BaseEntity {
         }
         this.name = name;
         this.companyId = companyId;
+        this.category = category;
     }
 
     public void updateName(String name) {
         validateName(name);
 
         this.name = name;
+    }
+
+    public void updateCategory(ProductCategory category) {
+        this.category = category;
+    }
+
+    public String getCategoryDisplayName() {
+        return category != null ? category.getDisplayName() : "기타";
     }
 
     private void validateName(String name) {

--- a/hub/src/main/java/com/klp/hub/product/domain/ProductCategory.java
+++ b/hub/src/main/java/com/klp/hub/product/domain/ProductCategory.java
@@ -1,0 +1,25 @@
+package com.klp.hub.product.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProductCategory {
+    ELECTRONICS("전자제품"),
+    HOME_APPLIANCE("생활가전"),
+    KITCHEN_APPLIANCE("주방가전"),
+    FURNITURE("가구"),
+    FOOD("식품"),
+    BEVERAGE("음료"),
+    CLOTHING("의류"),
+    COMPUTER_PARTS("컴퓨터부품"),
+    COMPUTER_PERIPHERAL("컴퓨터주변기기"),
+    AUTO_PARTS("자동차부품"),
+    ELECTRONIC_PARTS("전자부품"),
+    PHARMACEUTICAL("의약품"),
+    INDUSTRIAL("산업재"),
+    ETC("기타");
+
+    private final String displayName;
+}

--- a/hub/src/main/java/com/klp/hub/product/domain/repository/ProductRepository.java
+++ b/hub/src/main/java/com/klp/hub/product/domain/repository/ProductRepository.java
@@ -5,6 +5,7 @@ import com.klp.hub.product.presentation.dto.ProductsPageRowResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -14,4 +15,6 @@ public interface ProductRepository {
     Page<ProductsPageRowResponse> findAllByPageable(Pageable pageable);
 
     Product save(Product product);
+
+    List<UUID> findAllProductIds();
 }

--- a/hub/src/main/java/com/klp/hub/product/infrastructure/repository/ProductRepositoryImpl.java
+++ b/hub/src/main/java/com/klp/hub/product/infrastructure/repository/ProductRepositoryImpl.java
@@ -58,6 +58,15 @@ public class ProductRepositoryImpl implements ProductRepository {
         return productJpaRepository.save(product);
     }
 
+    @Override
+    public List<UUID> findAllProductIds() {
+        return queryFactory
+                .select(qProduct.id)
+                .from(qProduct)
+                .where(qProduct.deletedAt.isNull())
+                .fetch();
+    }
+
     private ConstructorExpression<ProductsPageRowResponse> getProductListRowProjection() {
         return Projections.constructor(
                 ProductsPageRowResponse.class,

--- a/hub/src/main/java/com/klp/hub/product/presentation/controller/ProductInternalController.java
+++ b/hub/src/main/java/com/klp/hub/product/presentation/controller/ProductInternalController.java
@@ -1,0 +1,28 @@
+package com.klp.hub.product.presentation.controller;
+
+import com.klp.hub.product.application.ProductService;
+import io.swagger.v3.oas.annotations.Hidden;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/v1/internal/products")
+@Hidden
+public class ProductInternalController {
+
+    private final ProductService productService;
+
+    @GetMapping("/ids")
+    public ResponseEntity<List<UUID>> getAllProductIds() {
+        List<UUID> productIds = productService.getAllProductIds();
+        return ResponseEntity.ok().body(productIds);
+    }
+}

--- a/hub/src/main/java/com/klp/hub/product/presentation/dto/ProductResponse.java
+++ b/hub/src/main/java/com/klp/hub/product/presentation/dto/ProductResponse.java
@@ -6,6 +6,7 @@ public record ProductResponse(
         UUID productId,
         UUID hubId,
         String companyName,
-        String productName
+        String productName,
+        String category
 ) {
 }

--- a/hub/src/test/java/com/klp/hub/product/presentation/controller/ProductControllerTest.java
+++ b/hub/src/test/java/com/klp/hub/product/presentation/controller/ProductControllerTest.java
@@ -58,7 +58,7 @@ class ProductControllerTest {
         void getProductById() throws Exception {
             UUID productId = UUID.randomUUID();
             when(productService.getProductById(productId))
-                .thenReturn(new ProductResponse(productId, UUID.randomUUID(), "업체명", "상품명"));
+                .thenReturn(new ProductResponse(productId, UUID.randomUUID(), "업체명", "상품명", "전자제품/이어폰"));
 
             mockMvc.perform(get("/v1/products/{productId}", productId))
                 .andExpect(status().isOk())


### PR DESCRIPTION
## PR 내용
- [feat: 카테고리를 추가한 RAG 파이프라인 작성](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/f73c0d8872d1c9df5283ace758e0eccc49189f91)
  - 기존 카테고리가 포함되어 있지 않은 데이터의 경우, 단순히 상품 이름만을 이용해 AI가 문맥적인 흐름을 파악하기가 힘들었습니다.
  - 유사도 또한, 휴대폰 주문시 동일한 휴대폰이어도 단순 이름만이므로 0.5의 유사도를 넘기지 못해 정확한 파악이 안된다고 생각했습니다.
  - Product에 Category를 추가해 AI가 카테고리 문맥을 파악할 수 있도록 설정했습니다.
<img width="919" height="489" alt="유사도개선" src="https://github.com/user-attachments/assets/28e5b663-41ed-4ea9-8a1b-a826bb6f2d4a" />

- [feat: reason필드가 불필요하다고 판단해 제거](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/8b0be656fa247ca27c77d6a4195f71d736f5f43d)
  - 위 사진에서 볼 수 있듯이, 날씨와 시간대 등의 데이터를 넘김에도 전자기기에 올바르지 않은 reason을 억지로 생성하는 느낌이 들어 유사도 수치만 측정하도록 했습니다.