### PR TITLE
fix: FeignClient 응답에 맞게 배송 커맨드 객체 수정

### DIFF
--- a/delivery/src/main/java/com/klp/delivery/delivery/application/command/DriverCommand.java
+++ b/delivery/src/main/java/com/klp/delivery/delivery/application/command/DriverCommand.java
@@ -1,6 +1,6 @@
 package com.klp.delivery.delivery.application.command;
 
-import com.klp.delivery.delivery.infrastructure.client.dto.DriverResponse;
+import com.klp.delivery.delivery.infrastructure.client.dto.DriverInfo;
 import java.util.List;
 
 public record DriverCommand(
@@ -10,7 +10,7 @@ public record DriverCommand(
     String phone,
     String email
 ) {
-    public static DriverCommand of(DriverResponse response) {
+    public static DriverCommand of(DriverInfo response) {
         return new DriverCommand(
             response.userId(),
             response.username(),
@@ -20,7 +20,7 @@ public record DriverCommand(
         );
     }
 
-    public static List<DriverCommand> from(List<DriverResponse> deliveries) {
+    public static List<DriverCommand> from(List<DriverInfo> deliveries) {
         return deliveries.stream()
             .map(DriverCommand::of)
             .toList();

--- a/delivery/src/main/java/com/klp/delivery/delivery/application/facade/DeliveryFacade.java
+++ b/delivery/src/main/java/com/klp/delivery/delivery/application/facade/DeliveryFacade.java
@@ -65,6 +65,7 @@ public class DeliveryFacade {
             List<DriverCommand> driverList = driverService.findArrivalHubDrivers(
                 UUID.fromString(arrivalHubInfo.hubId().toString()));
 
+            log.info("업체 배송 담당자 조회 ={}", driverList);
             // 업체 배송 담당자 지정
             DriverCommand driverCommand = DriverSelector.pickRandomDriver(driverList);
 

--- a/delivery/src/main/java/com/klp/delivery/delivery/application/service/DeliveryRouteService.java
+++ b/delivery/src/main/java/com/klp/delivery/delivery/application/service/DeliveryRouteService.java
@@ -13,7 +13,7 @@ import com.klp.delivery.delivery.application.util.DriverSelector;
 import com.klp.delivery.delivery.domain.entity.DeliveryRoute;
 import com.klp.delivery.delivery.domain.repository.DeliveryRouteRepository;
 import com.klp.delivery.delivery.exception.DeliveryErrorCode;
-import com.klp.delivery.delivery.infrastructure.client.dto.DriverResponse;
+import com.klp.delivery.delivery.infrastructure.client.dto.DriverInfo;
 import com.klp.delivery.global.exception.BusinessException;
 import com.klp.delivery.routeplan.presentation.dto.response.GetRoutePlanDetailResponse;
 import java.util.List;
@@ -82,8 +82,9 @@ public class DeliveryRouteService {
                         .orElseThrow(() -> new BusinessException(NO_ROUTE_PLAN_FOUND));
 
                 // 물류배송담당자 조회
-                List<DriverResponse> driverList = driverClientService.findLogisticsDrivers();
+                List<DriverInfo> driverList = driverClientService.findLogisticsDrivers().drivers();
 
+                log.info("물류 배송담당자 ={}", driverList);
                 DriverCommand driver = DriverSelector.pickRandomDriver(
                     DriverCommand.from(driverList));
 
@@ -231,7 +232,7 @@ public class DeliveryRouteService {
         }
 
         // 그 외에는 물류 배송 담당자 선택
-        List<DriverResponse> driverList = driverClientService.findLogisticsDrivers();
+        List<DriverInfo> driverList = driverClientService.findLogisticsDrivers().drivers();
         DriverCommand driver = DriverSelector.pickRandomDriver(DriverCommand.from(driverList));
         log.info("물류 배송 담당자 선택: driverId={}, currentStatus={}, newStatus={}",
             driver.userId(), currentStatus, newStatus);

--- a/delivery/src/main/java/com/klp/delivery/delivery/application/service/DriverClientService.java
+++ b/delivery/src/main/java/com/klp/delivery/delivery/application/service/DriverClientService.java
@@ -1,14 +1,16 @@
 package com.klp.delivery.delivery.application.service;
 
-import com.klp.delivery.delivery.infrastructure.client.dto.DriverResponse;
+import com.klp.delivery.delivery.infrastructure.client.dto.DriverInfo;
+import com.klp.delivery.delivery.infrastructure.client.dto.HubDriverListResponse;
+import com.klp.delivery.delivery.infrastructure.client.dto.LogisticsDriverListResponse;
 import java.util.List;
 import java.util.UUID;
 
 public interface DriverClientService {
 
-    List<DriverResponse> findArrivalHubDrivers(UUID receiverId);
+    HubDriverListResponse findArrivalHubDrivers(UUID receiverId);
 
-    DriverResponse findDriverAtArrivalHub(Long receiverId);
+    DriverInfo findDriverAtArrivalHub(Long receiverId);
 
-    List<DriverResponse> findLogisticsDrivers();
+    LogisticsDriverListResponse findLogisticsDrivers();
 }

--- a/delivery/src/main/java/com/klp/delivery/delivery/application/service/DriverService.java
+++ b/delivery/src/main/java/com/klp/delivery/delivery/application/service/DriverService.java
@@ -19,7 +19,7 @@ public class DriverService {
 
     public List<DriverCommand> findArrivalHubDrivers(UUID hubId) {
         try {
-            return DriverCommand.from(driverClientService.findArrivalHubDrivers(hubId));
+            return DriverCommand.from(driverClientService.findArrivalHubDrivers(hubId).drivers());
         } catch (Exception e) {
             log.error("배송 담당자들 조회 실패: {}", e.getMessage(), e);
             throw new BusinessException(DeliveryErrorCode.EXTERNAL_API_ERROR, "배송 담당자 조회에 실패했습니다.");
@@ -37,7 +37,7 @@ public class DriverService {
 
     public List<DriverCommand> findLogisticsDrivers() {
         try {
-            return DriverCommand.from(driverClientService.findLogisticsDrivers());
+            return DriverCommand.from(driverClientService.findLogisticsDrivers().drivers());
         } catch (Exception e) {
             log.error("물류 배송 담당자들 조회 실패: {}", e.getMessage(), e);
             throw new BusinessException(DeliveryErrorCode.EXTERNAL_API_ERROR,

--- a/delivery/src/main/java/com/klp/delivery/delivery/infrastructure/client/DriverClientServiceServiceImpl.java
+++ b/delivery/src/main/java/com/klp/delivery/delivery/infrastructure/client/DriverClientServiceServiceImpl.java
@@ -1,8 +1,9 @@
 package com.klp.delivery.delivery.infrastructure.client;
 
 import com.klp.delivery.delivery.application.service.DriverClientService;
-import com.klp.delivery.delivery.infrastructure.client.dto.DriverResponse;
-import java.util.List;
+import com.klp.delivery.delivery.infrastructure.client.dto.DriverInfo;
+import com.klp.delivery.delivery.infrastructure.client.dto.HubDriverListResponse;
+import com.klp.delivery.delivery.infrastructure.client.dto.LogisticsDriverListResponse;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -15,17 +16,17 @@ public class DriverClientServiceServiceImpl implements DriverClientService {
     private final DriverFeignClient driverFeignClient;
 
     @Override
-    public List<DriverResponse> findArrivalHubDrivers(UUID hubId) {
+    public HubDriverListResponse findArrivalHubDrivers(UUID hubId) {
         return driverFeignClient.findArrivalHubDrivers(hubId);
     }
 
     @Override
-    public DriverResponse findDriverAtArrivalHub(Long receiverId) {
+    public DriverInfo findDriverAtArrivalHub(Long receiverId) {
         return driverFeignClient.findDriverAtArrivalHub(receiverId);
     }
 
     @Override
-    public List<DriverResponse> findLogisticsDrivers() {
+    public LogisticsDriverListResponse findLogisticsDrivers() {
         return driverFeignClient.findLogisticsDrivers();
     }
 }

--- a/delivery/src/main/java/com/klp/delivery/delivery/infrastructure/client/DriverFeignClient.java
+++ b/delivery/src/main/java/com/klp/delivery/delivery/infrastructure/client/DriverFeignClient.java
@@ -1,9 +1,10 @@
 package com.klp.delivery.delivery.infrastructure.client;
 
-import com.klp.delivery.delivery.infrastructure.client.dto.DriverResponse;
+import com.klp.delivery.delivery.infrastructure.client.dto.DriverInfo;
+import com.klp.delivery.delivery.infrastructure.client.dto.HubDriverListResponse;
+import com.klp.delivery.delivery.infrastructure.client.dto.LogisticsDriverListResponse;
 import com.klp.delivery.global.config.DeliveryFeignClientConfig;
 import com.klp.delivery.global.config.FeignTracingConfig;
-import java.util.List;
 import java.util.UUID;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,12 +17,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface DriverFeignClient {
 
     @GetMapping("/v1/internal/users/driver/{hubId}")
-    List<DriverResponse> findArrivalHubDrivers(@PathVariable("hubId") UUID hubId);
+    HubDriverListResponse findArrivalHubDrivers(@PathVariable("hubId") UUID hubId);
 
     @GetMapping("/v1/internal/users/driver")
-    DriverResponse findDriverAtArrivalHub(@RequestParam("id") Long driverId);
+    DriverInfo findDriverAtArrivalHub(@RequestParam("id") Long driverId);
 
     @GetMapping("/v1/internal/users/driver/logistics")
-    List<DriverResponse> findLogisticsDrivers();
+    LogisticsDriverListResponse findLogisticsDrivers();
 
 }

--- a/delivery/src/main/java/com/klp/delivery/delivery/infrastructure/client/dto/DriverInfo.java
+++ b/delivery/src/main/java/com/klp/delivery/delivery/infrastructure/client/dto/DriverInfo.java
@@ -1,6 +1,6 @@
 package com.klp.delivery.delivery.infrastructure.client.dto;
 
-public record DriverResponse(
+public record DriverInfo(
     Long userId,
     String username,
     String slackId,

--- a/delivery/src/main/java/com/klp/delivery/delivery/infrastructure/client/dto/HubDriverListResponse.java
+++ b/delivery/src/main/java/com/klp/delivery/delivery/infrastructure/client/dto/HubDriverListResponse.java
@@ -1,0 +1,11 @@
+package com.klp.delivery.delivery.infrastructure.client.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record HubDriverListResponse(
+    UUID hubId,
+    List<DriverInfo> drivers
+) {
+
+}

--- a/delivery/src/main/java/com/klp/delivery/delivery/infrastructure/client/dto/LogisticsDriverListResponse.java
+++ b/delivery/src/main/java/com/klp/delivery/delivery/infrastructure/client/dto/LogisticsDriverListResponse.java
@@ -1,0 +1,9 @@
+package com.klp.delivery.delivery.infrastructure.client.dto;
+
+import java.util.List;
+
+public record LogisticsDriverListResponse(
+    List<DriverInfo> drivers
+) {
+
+}

--- a/delivery/src/main/java/com/klp/delivery/delivery/infrastructure/listener/InventoryEventListener.java
+++ b/delivery/src/main/java/com/klp/delivery/delivery/infrastructure/listener/InventoryEventListener.java
@@ -75,7 +75,7 @@ public class InventoryEventListener {
         Acknowledgment acknowledgment) {
 
         log.info("=== 재고 복구 이벤트 수신: orderId={}, partition={}, offset={}, cancelReason={} ===",
-            event.orderId(), partition, offset, event.cancelReason());
+            event.orderId(), partition, offset, event.reason());
 
         try {
             Long deletedBy = event.userId() != null ? event.userId() : 0L;


### PR DESCRIPTION
- FeignClient 응답에 맞게 배송 커맨드 객체 수정

이전 PR에서 잘못 포함된 커밋을 제거하고 브랜치 히스토리를 정리하여 새 PR로 요청합니다!
(https://github.com/Kim-Lee-Park/KimLeePark-Logistics/pull/218)