### PR TITLE
feat: docker-compose 설정 변경(db 이미지, kafka 모드 zookeeper -> kraft)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       TZ: Asia/Seoul
     volumes:
       - klp_postgres_auth_data:/var/lib/postgresql
-      - ./init-sql/extensions.sql:/docker-entrypoint-initdb.d/00-extensions.sql:ro
     ports:
       - "5432:5432"
     networks:
@@ -25,7 +24,6 @@ services:
       TZ: Asia/Seoul
     volumes:
       - klp_postgres_user_data:/var/lib/postgresql
-      - ./init-sql/extensions.sql:/docker-entrypoint-initdb.d/00-extensions.sql:ro
     ports:
       - "5433:5432"
     networks:
@@ -41,7 +39,6 @@ services:
       TZ: Asia/Seoul
     volumes:
       - klp_postgres_hub_data:/var/lib/postgresql
-      - ./init-sql/extensions.sql:/docker-entrypoint-initdb.d/00-extensions.sql:ro
     ports:
       - "5434:5432"
     networks:
@@ -57,7 +54,6 @@ services:
       TZ: Asia/Seoul
     volumes:
       - klp_postgres_delivery_data:/var/lib/postgresql
-      - ./init-sql/extensions.sql:/docker-entrypoint-initdb.d/00-extensions.sql:ro
     ports:
       - "5435:5432"
     networks:
@@ -73,7 +69,6 @@ services:
       TZ: Asia/Seoul
     volumes:
       - klp_postgres_order_data:/var/lib/postgresql
-      - ./init-sql/extensions.sql:/docker-entrypoint-initdb.d/00-extensions.sql:ro
     ports:
       - "5436:5432"
     networks:
@@ -89,7 +84,6 @@ services:
       TZ: Asia/Seoul
     volumes:
       - klp_postgres_notification_data:/var/lib/postgresql
-      - ./init-sql/extensions.sql:/docker-entrypoint-initdb.d/00-extensions.sql:ro
     ports:
       - "5437:5432"
     networks:
@@ -105,7 +99,6 @@ services:
       TZ: Asia/Seoul
     volumes:
       - klp_postgres_promotion_data:/var/lib/postgresql
-      - ./init-sql/extensions.sql:/docker-entrypoint-initdb.d/00-extensions.sql:ro
     ports:
       - "5438:5432"
     networks:
@@ -121,7 +114,6 @@ services:
       TZ: Asia/Seoul
     volumes:
       - klp_postgres_payment_data:/var/lib/postgresql
-      - ./init-sql/extensions.sql:/docker-entrypoint-initdb.d/00-extensions.sql:ro
     ports:
       - "5439:5432"
     networks:
@@ -153,42 +145,32 @@ services:
     networks:
       - db-net
 
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.9.4
-    container_name: zookeeper-klp
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-    ports:
-      - "2181:2181"
-    volumes:
-      - klp-zookeeper-data:/var/lib/zookeeper/data
-      - klp-zookeeper-logs:/var/lib/zookeeper/log
-    networks:
-      - db-net
-
   kafka:
-    image: confluentinc/cp-kafka:7.9.4
+    image: confluentinc/cp-kafka:8.1.1
     container_name: kafka-klp
-    depends_on:
-      - zookeeper
     ports:
       - "9092:9092"
       - "29092:29092"
+      - "9093:9093"
       - "9404:9404"
       - "9999:9999"
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:29092,PLAINTEXT_HOST://0.0.0.0:9092
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: 'broker,controller'
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1@kafka:9093'
+      KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT'
+      KAFKA_LISTENERS: 'PLAINTEXT://kafka:29092,CONTROLLER://kafka:9093,PLAINTEXT_HOST://0.0.0.0:9092'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092'
+      KAFKA_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
+      CLUSTER_ID: 'ugP2VOBGQ-CRY1OrnCY7fg'
+      KAFKA_LOG_DIRS: '/var/lib/kafka/data'
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_MIN_INSYNC_REPLICAS: 1
       KAFKA_DEFAULT_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_OPTS: >-
         -javaagent:/opt/jmx-exporter/jmx_prometheus_javaagent-0.20.0.jar=9404:/opt/jmx-exporter/kafka-jmx.yml
       KAFKA_JMX_PORT: 9999
@@ -204,7 +186,6 @@ services:
     container_name: kafka-ui-klp
     depends_on:
       - kafka
-      - zookeeper
     ports:
       - "8989:8080"
     environment:
@@ -230,6 +211,4 @@ volumes:
   klp_postgres_payment_data:
   klp_postgres_ai_data:
   klp_redis_data:
-  klp-zookeeper-data:
-  klp-zookeeper-logs:
   klp-kafka-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres-auth:
-    image: pgvector/pgvector:0.8.1-pg18-trixie
+    image: postgres:18
     container_name: postgres-auth-klp
     environment:
       POSTGRES_USER: kimleepark
@@ -16,7 +16,7 @@ services:
       - db-net
 
   postgres-user:
-    image: pgvector/pgvector:0.8.1-pg18-trixie
+    image: postgres:18
     container_name: postgres-user-klp
     environment:
       POSTGRES_USER: kimleepark
@@ -32,7 +32,7 @@ services:
       - db-net
 
   postgres-hub:
-    image: pgvector/pgvector:0.8.1-pg18-trixie
+    image: postgres:18
     container_name: postgres-hub-klp
     environment:
       POSTGRES_USER: kimleepark
@@ -48,7 +48,7 @@ services:
       - db-net
 
   postgres-delivery:
-    image: pgvector/pgvector:0.8.1-pg18-trixie
+    image: postgres:18
     container_name: postgres-delivery-klp
     environment:
       POSTGRES_USER: kimleepark
@@ -64,7 +64,7 @@ services:
       - db-net
 
   postgres-order:
-    image: pgvector/pgvector:0.8.1-pg18-trixie
+    image: postgres:18
     container_name: postgres-order-klp
     environment:
       POSTGRES_USER: kimleepark
@@ -80,7 +80,7 @@ services:
       - db-net
 
   postgres-notification:
-    image: pgvector/pgvector:0.8.1-pg18-trixie
+    image: postgres:18
     container_name: postgres-notification-klp
     environment:
       POSTGRES_USER: kimleepark
@@ -96,7 +96,7 @@ services:
       - db-net
 
   postgres-promotion:
-    image: pgvector/pgvector:0.8.1-pg18-trixie
+    image: postgres:18
     container_name: postgres-promotion-klp
     environment:
       POSTGRES_USER: kimleepark
@@ -112,7 +112,7 @@ services:
       - db-net
 
   postgres-payment:
-    image: pgvector/pgvector:0.8.1-pg18-trixie
+    image: postgres:18
     container_name: postgres-payment-klp
     environment:
       POSTGRES_USER: kimleepark

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -177,7 +177,7 @@ services:
       KAFKA_JMX_HOSTNAME: kafka
     volumes:
       - klp-kafka-data:/var/lib/kafka/data
-      - ../telemetry/jmx:/opt/jmx-exporter:ro
+      - ./telemetry/jmx:/opt/jmx-exporter:ro
     networks:
       - db-net
 

--- a/order/src/main/resources/application.yml
+++ b/order/src/main/resources/application.yml
@@ -16,7 +16,6 @@ spring:
         max-attempts: 3
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
-
   data:
     redis:
       host: ${REDIS_HOST:localhost}

--- a/telemetry/grafana/provisioning/datasources/datasources.yml
+++ b/telemetry/grafana/provisioning/datasources/datasources.yml
@@ -1,3 +1,5 @@
+apiVersion: 1
+
 datasources:
   - name: Tempo
     uid: tempo


### PR DESCRIPTION
## PR 내용
- [chore: ai서비스를 제외한 도메인 서비스 db 이미지 변경](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/cd5aeece1b97448e5ab40a00f78e52e42453ab02)
  - pgvector의 경우 ai 서비스에서만 사용하기 때문에, 다른 서비스들의 postgresql 이미지를 기존 postgresql:18로 변경했습니다.

- [chore: postgres 컨테이너 extension.sql 사용하지 않도록 설정](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/76803ee110464b78f3f6d99362112babe86dfbf1)
  - extension.sql의 경우 ai 서비스에서만 사용하도록 설정했습니다.
  - Kafka 최신버전을 적용해 zookeeper -> kraft 모드 적용을 설정했습니다.

- [chore: datasources.yml에 apiVersion 명시](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/dfe5f227724482226398639637df88b0a92d46e3)
  - telemetry/datasource.yml에 apiVersion 필드가 누락되어 데이터 소스가 연동되지 않는 문제를 해결했습니다.

- [fix: jmx-exporter 상대경로 수정](https://github.com/Kim-Lee-Park/KimLeePark-Logistics/commit/9aaf2589cffaa7b67e14877d7dda489acbb9d28e)
  - kafka 컨테이너에서 사용하는 jmx-exporter 파일의 상대경로를 GitHub 원격 repo 기준으로 설정했습니다.