### PR TITLE
refactor: 보상 트랜잭션을 위해 트랜잭션 분리 후 실패 이벤트 발행

### DIFF
--- a/promotion/src/main/java/com/klp/promotion/coupon/infrastructure/kafka/config/KafkaConsumerConfig.java
+++ b/promotion/src/main/java/com/klp/promotion/coupon/infrastructure/kafka/config/KafkaConsumerConfig.java
@@ -3,12 +3,11 @@ package com.klp.promotion.coupon.infrastructure.kafka.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.klp.promotion.coupon.domain.event.InventoryDeductedEvent;
 import com.klp.promotion.coupon.domain.event.InventoryDeductedFailedEvent;
-import com.klp.promotion.coupon.domain.event.OrderCancelledEvent;
-import com.klp.promotion.coupon.domain.event.OrderCreatedEvent;
 import com.klp.promotion.coupon.domain.event.OrderFailedEvent;
 import com.klp.promotion.coupon.domain.event.PaymentApprovedEvent;
 import com.klp.promotion.coupon.domain.event.PaymentCancelledEvent;
 import com.klp.promotion.coupon.domain.event.PaymentFailedEvent;
+import com.klp.promotion.global.exception.BusinessException;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -101,7 +100,8 @@ public class KafkaConsumerConfig {
         DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, backOff);
         errorHandler.addNotRetryableExceptions(
             DeserializationException.class,
-            MessageConversionException.class
+            MessageConversionException.class,
+            BusinessException.class
         );
 
         errorHandler.setRetryListeners((record, ex, deliveryAttempt) -> {

--- a/promotion/src/main/java/com/klp/promotion/coupon/infrastructure/kafka/listener/PaymentEventListener.java
+++ b/promotion/src/main/java/com/klp/promotion/coupon/infrastructure/kafka/listener/PaymentEventListener.java
@@ -4,7 +4,6 @@ import com.klp.promotion.coupon.application.facade.UserCouponFacade;
 import com.klp.promotion.coupon.application.service.CouponOutboxEventService;
 import com.klp.promotion.coupon.application.service.UserCouponService;
 import com.klp.promotion.coupon.domain.entity.UserCoupon;
-import com.klp.promotion.coupon.domain.enums.UserCouponStatus;
 import com.klp.promotion.coupon.domain.event.CouponRestoredEvent;
 import com.klp.promotion.coupon.domain.event.CouponUsedEvent;
 import com.klp.promotion.coupon.domain.event.CouponUsedFailedEvent;
@@ -12,6 +11,7 @@ import com.klp.promotion.coupon.domain.event.PaymentApprovedEvent;
 import com.klp.promotion.coupon.domain.event.PaymentCancelledEvent;
 import com.klp.promotion.coupon.domain.event.PaymentFailedEvent;
 import com.klp.promotion.coupon.infrastructure.kafka.config.KafkaTopicConfig;
+import com.klp.promotion.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -20,6 +20,7 @@ import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
@@ -63,19 +64,42 @@ public class PaymentEventListener {
                 acknowledgment.acknowledge();
             }
 
-        } catch (Exception e) {
-            log.error("결제 승인 처리 실패: orderId={}, cause={}", event.orderId(), e.getMessage(), e);
+        } catch (BusinessException e) {
+            log.warn("쿠폰 사용 비즈니스 검증 실패: orderId={}, reason={}",
+                event.orderId(), e.getMessage());
 
-            // 보상 트랜잭션 및 실패 이벤트 처리
-            rollbackCouponUsage(event);
-            couponOutboxEventService.failEvent(event.orderId(), CouponUsedFailedEvent.from(event));
+            publishFailedEvent(event, e.getMessage());
+
+            if (acknowledgment != null) {
+                acknowledgment.acknowledge();
+            }
+
+        } catch (Exception e) {
+
+            log.error("결제 승인 처리 중 시스템 오류: orderId={}, cause={}",
+                event.orderId(), e.getMessage(), e);
 
             throw e;
         }
     }
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void publishFailedEvent(PaymentApprovedEvent event, String reason) {
+        try {
+            couponOutboxEventService.failEvent(
+                event.orderId(),
+                CouponUsedFailedEvent.from(event)
+            );
+            log.info("쿠폰 사용 실패 이벤트 발행 완료: orderId={}, reason={}",
+                event.orderId(), reason);
+        } catch (Exception ex) {
+            log.error("쿠폰 사용 실패 이벤트 발행 실패: orderId={}, error={}",
+                event.orderId(), ex.getMessage(), ex);
+        }
+    }
+
     @KafkaListener(
-        topics = KafkaTopicConfig.PAYMENT_CANCELLED_DLT,
+        topics = KafkaTopicConfig.PAYMENT_CANCELLED_TOPIC,
         groupId = "coupon-service-group",
         containerFactory = "couponKafkaListenerContainerFactory"
     )
@@ -86,13 +110,14 @@ public class PaymentEventListener {
         @Header(KafkaHeaders.OFFSET) long offset,
         Acknowledgment acknowledgment
     ) {
-        log.info("=== 결제 취소 수신: orderId={}, userCouponId={} ===", event.orderId(),
-            event.userCouponId());
+        log.info("=== 결제 취소 수신: orderId={}, userCouponId={} ===",
+            event.orderId(), event.userCouponId());
 
         try {
             if (event.userCouponId() != null) {
                 userCouponFacade.couponRestored(event.userCouponId());
             }
+
             couponOutboxEventService.cancelEvent(
                 event.orderId(),
                 CouponRestoredEvent.from(event)
@@ -104,10 +129,33 @@ public class PaymentEventListener {
                 acknowledgment.acknowledge();
             }
 
+        } catch (BusinessException e) {
+            log.warn("쿠폰 복구 비즈니스 검증 실패: orderId={}, reason={}",
+                event.orderId(), e.getMessage());
+
+            publishRestoredFailedEvent(event, e.getMessage());
+
+            if (acknowledgment != null) {
+                acknowledgment.acknowledge();
+            }
+
         } catch (Exception e) {
-            log.error("결제 취소 처리 실패: orderId={}, cause={}", event.orderId(), e.getMessage(), e);
-            rollbackCouponRestoration(event);
+            log.error("결제 취소 처리 중 시스템 오류: orderId={}, cause={}",
+                event.orderId(), e.getMessage(), e);
             throw e;
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void publishRestoredFailedEvent(PaymentCancelledEvent event, String reason) {
+        try {
+            // 쿠폰 복구가 실패했다고 해서 결제 취소랑 주문 취소를 롤백을 해야하는가?
+            // 아니면 그냥 수동으로 처리해야하는가에 대해 고민을 하게 되네요.
+            log.warn("쿠폰 복구 실패 - 별도 처리 필요: orderId={}, reason={}",
+                event.orderId(), reason);
+        } catch (Exception ex) {
+            log.error("쿠폰 복구 실패 이벤트 발행 실패: orderId={}, error={}",
+                event.orderId(), ex.getMessage(), ex);
         }
     }
 
@@ -123,10 +171,15 @@ public class PaymentEventListener {
             return;
         }
 
-        userCouponService.cancelReserve(event.orderId());
-        log.info("쿠폰 선점 취소 완료");
+        try {
+            userCouponService.cancelReserve(event.userCouponId());
+            log.info("쿠폰 선점 취소 완료: userCouponId={}", event.userCouponId());
+        } catch (Exception e) {
+            log.error("쿠폰 선점 취소 실패: userCouponId={}, error={}",
+                event.userCouponId(), e.getMessage(), e);
+            // 이 경우도 재시도가 필요하면 throw, 아니면 로그만
+        }
     }
-
 
     @KafkaListener(
         topics = KafkaTopicConfig.PAYMENT_APPROVED_DLT,
@@ -154,7 +207,6 @@ public class PaymentEventListener {
         log.error("orderId={}", event.orderId());
     }
 
-
     @KafkaListener(
         topics = KafkaTopicConfig.PAYMENT_FAILED_DLT,
         groupId = "coupon-service-group-dlt",
@@ -166,39 +218,5 @@ public class PaymentEventListener {
         log.error("⚠️ 결제 실패 처리 실패 - 수동 처리 필요!");
         log.error("========================================");
         log.error("orderId={}", event.orderId());
-    }
-
-    private void rollbackCouponUsage(PaymentApprovedEvent event) {
-        if (event.userCouponId() == null) {
-            return;
-        }
-
-        try {
-            UserCoupon userCoupon = userCouponService.findByUserCouponId(event.userCouponId());
-            if (userCoupon.getStatus() == UserCouponStatus.USED) {
-                userCouponFacade.couponRestored(event.userCouponId());
-                log.info("롤백 완료: 쿠폰 상태 원복 (USED -> READY), userCouponId={}", event.userCouponId());
-            }
-        } catch (Exception ex) {
-            log.error("롤백 실패: userCouponId={}", event.userCouponId(), ex);
-        }
-    }
-
-    private void rollbackCouponRestoration(PaymentCancelledEvent event) {
-        if (event.userCouponId() == null) {
-            return;
-        }
-
-        try {
-            UserCoupon userCoupon = userCouponService.findByUserCouponId(event.userCouponId());
-            // READY 상태라면 다시 선점(RESERVE) 상태로 되돌림
-            if (userCoupon.getStatus() == UserCouponStatus.READY) {
-                userCoupon.reserve();
-                log.info("롤백 완료: 쿠폰 재선점 (READY -> RESERVED), userCouponId={}",
-                    event.userCouponId());
-            }
-        } catch (Exception ex) {
-            log.error("롤백 실패: userCouponId={}", event.userCouponId(), ex);
-        }
     }
 }


### PR DESCRIPTION
# 수정사항
## 1. 전에 보상트랜잭션에서는 동일 트랜잭션 내에서 catch문에 보상 이벤트를 발행하는 것을 작성하였습니다.
-  그래서 만약에 롤백이 된다면 그 보상 이벤트도 롤백이 되는 문제가 발생하였습니다.
- 그래서 우선은 retryableException에 Business Exception을 추가하였고
- 비즈니스 적으로 예외가 발생한다면 재시도를 하지 못하도록 막았습니다. (예를 들면 쿠폰없음? 쿠폰 날짜 만료)
- 그리고 @Transactional(propagation = Propagation.REQUIRES_NEW) 를 이용하여 별도의 트랜잭션내에서 실패 이벤트를 발행하여 catch 문이 종료된 후 롤백이 되더라도 영향이 받지 않게 진행하였습니다.

# 추후
orderCancellation에 대해서 병목현상이 발생한다는 것을 알고있습니다.
그래서 ordercancellation을 order랑 양방향 참조를 하는것이 아닌 orderId만 사용하도록 하려고 합니다.
다만 이 작업을 진행하면 수정해야할 파일들이 많을 것 같아 미리 한번 pr올리고  별도 브랜치에서 작업 하도록 하겠습니다.