### PR TITLE
refactor: order와 orderCancellation 분리 작업

### DIFF
--- a/order/src/main/java/com/klp/order/application/facade/OrderFacade.java
+++ b/order/src/main/java/com/klp/order/application/facade/OrderFacade.java
@@ -26,6 +26,7 @@ import com.klp.order.infrastructure.event.event.OrderCancelledEvent;
 import com.klp.order.infrastructure.event.event.OrderCreatedEvent;
 import com.klp.order.infrastructure.event.event.OrderFailedEvent;
 import com.klp.order.infrastructure.event.event.WhichRollback;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -203,7 +204,7 @@ public class OrderFacade {
     // 주문 취소 후 재고 증가 이벤트 발행
     // 이 또한 장애 발생 시 트랜잭션 롤백으로 메시지 소실 방지
     @Transactional
-    public Order cancelOrder(CancelOrderCommand command) {
+    public void cancelOrder(CancelOrderCommand command) {
         log.info("=== 주문 취소 시작: orderId={} ===", command.orderId());
 
         try {
@@ -230,7 +231,9 @@ public class OrderFacade {
                 order,
                 order.getUserCouponId(),
                 InventoryIdempotencyKey,
-                DeliveryIdempotencyKey
+                DeliveryIdempotencyKey,
+                command.cancelReason(),
+                LocalDateTime.now()
             );
 
             // Outbox 저장 실패 시 예외 발생 → 전체 롤백
@@ -238,7 +241,6 @@ public class OrderFacade {
                 "ORDER_CANCELLED", event);
 
             log.info("=== 주문 취소 완료: orderId={} ===", command.orderId());
-            return order;
 
         } catch (Exception e) {
             log.error("=== 주문 취소 실패 - 전체 롤백: orderId={}, error={} ===",

--- a/order/src/main/java/com/klp/order/application/service/OrderCancellationService.java
+++ b/order/src/main/java/com/klp/order/application/service/OrderCancellationService.java
@@ -25,7 +25,7 @@ public class OrderCancellationService {
 
     @Transactional(readOnly = true)
     public OrderCancellation findByOrderId(UUID orderId) {
-        return orderCancellationRepository.findByOrder_OrderId(orderId)
+        return orderCancellationRepository.findByOrderId(orderId)
             .orElseThrow(() -> new BusinessException(
                 OrderCancellationErrorCode.CANCELLATION_BY_ORDER_NOT_FOUND));
     }
@@ -37,26 +37,18 @@ public class OrderCancellationService {
 
     @Transactional
     public OrderCancellation save(OrderCancellation cancellation) {
-        checkCancellationisNull(cancellation);
+        checkCancellationIsNull(cancellation);
         return orderCancellationRepository.save(cancellation);
     }
 
-    private void checkCancellationisNull(OrderCancellation cancellation) {
+    private void checkCancellationIsNull(OrderCancellation cancellation) {
         if (cancellation == null) {
             throw new BusinessException(OrderCancellationErrorCode.CANCELLATION_REQUIRED);
         }
     }
-
-//    @Transactional
-//    public void deleteById(UUID cancellationId) {
-//        // 삭제 전 존재 여부 확인
-//        findById(cancellationId);
-//        orderCancellationRepository.deleteById(cancellationId);
-//    }
-
-
+    
     public boolean isOrderCancelled(UUID orderId) {
-        return orderCancellationRepository.findByOrder_OrderId(orderId).isPresent();
+        return orderCancellationRepository.findByOrderId(orderId).isPresent();
     }
 
 }

--- a/order/src/main/java/com/klp/order/application/service/OrderService.java
+++ b/order/src/main/java/com/klp/order/application/service/OrderService.java
@@ -7,6 +7,7 @@ import com.klp.global.exception.OrderErrorCode;
 import com.klp.order.application.command.CancelOrderCommand;
 import com.klp.order.application.command.CreateOrderCommand;
 import com.klp.order.application.command.UpdateOrderCommand;
+import com.klp.order.domain.entity.cancel.OrderCancellation;
 import com.klp.order.domain.entity.order.Order;
 import com.klp.order.domain.entity.order.OrderStatus;
 import com.klp.order.domain.repository.OrderRepository;
@@ -27,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrderService {
 
     private final OrderRepository orderRepository;
+    private final OrderCancellationService orderCancellationRepository;
 
     @Transactional
     public Order createOrder(CreateOrderCommand command) {
@@ -61,11 +63,12 @@ public class OrderService {
     @Transactional
     public Order cancelOrder(CancelOrderCommand command) {
         Order order = findById(command.orderId());
-        order.cancel(
+        OrderCancellation cancellation = order.cancel(
             command.cancelReason(),
             command.cancelledBy(),
             command.cancelType()
         );
+        orderCancellationRepository.save(cancellation);
         return orderRepository.save(order);
     }
 

--- a/order/src/main/java/com/klp/order/domain/entity/cancel/OrderCancellation.java
+++ b/order/src/main/java/com/klp/order/domain/entity/cancel/OrderCancellation.java
@@ -2,17 +2,13 @@ package com.klp.order.domain.entity.cancel;
 
 import com.klp.global.exception.BusinessException;
 import com.klp.global.exception.OrderCancellationErrorCode;
-import com.klp.order.domain.entity.order.Order;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -30,9 +26,8 @@ public class OrderCancellation {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID orderCancellationId;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "order_id")
-    private Order order;
+    @Column(name = "order_id", nullable = false)
+    private UUID orderId;
 
     @Column(name = "cancel_reason", columnDefinition = "TEXT")
     private String cancelReason;
@@ -47,14 +42,14 @@ public class OrderCancellation {
     @Column(name = "cancel_type", nullable = false)
     private CancelType cancelType;
 
-    public static OrderCancellation create(Order order, String cancelReason, Long cancelledBy,
+    public static OrderCancellation create(UUID orderId, String cancelReason, Long cancelledBy,
         CancelType cancelType) {
-        validateOrder(order);
+        validateOrder(orderId);
         validateCancelledBy(cancelledBy);
         validateCancelType(cancelType);
 
         OrderCancellation cancellation = new OrderCancellation();
-        cancellation.order = order;
+        cancellation.orderId = orderId;
         cancellation.cancelReason = cancelReason;
         cancellation.cancelType = cancelType;
         cancellation.cancelledBy = cancelledBy;
@@ -62,8 +57,8 @@ public class OrderCancellation {
         return cancellation;
     }
 
-    private static void validateOrder(Order order) {
-        if (order == null) {
+    private static void validateOrder(UUID orderId) {
+        if (orderId == null) {
             throw new BusinessException(OrderCancellationErrorCode.ORDER_INFO_REQUIRED);
 
         }

--- a/order/src/main/java/com/klp/order/domain/entity/order/Order.java
+++ b/order/src/main/java/com/klp/order/domain/entity/order/Order.java
@@ -17,7 +17,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -78,9 +77,6 @@ public class Order extends BaseEntity {
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderItem> orderItems = new ArrayList<>();
-
-    @OneToOne(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
-    private OrderCancellation cancellation;
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderOutboundRequest> outboundRequests = new ArrayList<>();
@@ -176,8 +172,7 @@ public class Order extends BaseEntity {
     ) {
         checkCanCancel();
         this.orderStatus = OrderStatus.CANCELLED;
-        this.cancellation = OrderCancellation.create(this, cancelReason, cancelledBy, cancelType);
-        return this.cancellation;
+        return OrderCancellation.create(this.orderId, cancelReason, cancelledBy, cancelType);
     }
 
     public void updateDiscountPrice(int couponDiscountPrice, int gradeDiscountPrice,

--- a/order/src/main/java/com/klp/order/domain/repository/OrderCancellationRepository.java
+++ b/order/src/main/java/com/klp/order/domain/repository/OrderCancellationRepository.java
@@ -15,5 +15,5 @@ public interface OrderCancellationRepository {
 
     void deleteById(UUID orderCancellationId);
 
-    Optional<OrderCancellation> findByOrder_OrderId(UUID orderId);
+    Optional<OrderCancellation> findByOrderId(UUID orderId);
 }

--- a/order/src/main/java/com/klp/order/infrastructure/event/event/OrderCancelledEvent.java
+++ b/order/src/main/java/com/klp/order/infrastructure/event/event/OrderCancelledEvent.java
@@ -29,7 +29,9 @@ public record OrderCancelledEvent(
         Order order,
         UUID userCouponId,
         String inventoryIdempotencyKey,
-        String deliveryIdempotencyKey
+        String deliveryIdempotencyKey,
+        String cancelReason,
+        LocalDateTime cancelledAt
     ) {
         List<ProductReplenishment> products = order.getOrderItems().stream()
             .map(item -> new ProductReplenishment(
@@ -45,9 +47,9 @@ public record OrderCancelledEvent(
             userCouponId,
             inventoryIdempotencyKey,
             deliveryIdempotencyKey,
-            order.getCancellation().getCancelReason(),
+            cancelReason,
             products,
-            order.getCancellation().getCancelledAt(),
+            cancelledAt,
             LocalDateTime.now()
         );
     }

--- a/order/src/main/java/com/klp/order/infrastructure/repository/OrderCancellationJpaRepository.java
+++ b/order/src/main/java/com/klp/order/infrastructure/repository/OrderCancellationJpaRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderCancellationJpaRepository extends JpaRepository<OrderCancellation, UUID> {
 
-    Optional<OrderCancellation> findByOrder_OrderId(UUID orderId);
+    Optional<OrderCancellation> findByOrderId(UUID orderId);
 }

--- a/order/src/main/java/com/klp/order/infrastructure/repository/OrderCancellationRepositoryImpl.java
+++ b/order/src/main/java/com/klp/order/infrastructure/repository/OrderCancellationRepositoryImpl.java
@@ -35,7 +35,7 @@ public class OrderCancellationRepositoryImpl implements OrderCancellationReposit
     }
 
     @Override
-    public Optional<OrderCancellation> findByOrder_OrderId(UUID orderId) {
-        return orderCancellationJpaRepository.findByOrder_OrderId(orderId);
+    public Optional<OrderCancellation> findByOrderId(UUID orderId) {
+        return orderCancellationJpaRepository.findByOrderId(orderId);
     }
 }

--- a/order/src/main/java/com/klp/order/presentation/controller/OrderController.java
+++ b/order/src/main/java/com/klp/order/presentation/controller/OrderController.java
@@ -129,8 +129,8 @@ public class OrderController implements OrderControllerDoc {
         @Valid @RequestBody CancelOrderRequest request
     ) {
         CancelOrderCommand command = request.toCommand(orderId, cancelledBy);
-        Order order = orderFacade.cancelOrder(command);
-        CancelOrderResponse response = CancelOrderResponse.from(order);
+        orderFacade.cancelOrder(command);
+        CancelOrderResponse response = CancelOrderResponse.from(command);
 
         return ResponseEntity.ok(response);
     }

--- a/order/src/main/java/com/klp/order/presentation/dto/order/response/cancel/CancelOrderResponse.java
+++ b/order/src/main/java/com/klp/order/presentation/dto/order/response/cancel/CancelOrderResponse.java
@@ -1,84 +1,31 @@
 package com.klp.order.presentation.dto.order.response.cancel;
 
-import com.klp.order.domain.entity.order.Order;
-import com.klp.order.domain.entity.order.OrderStatus;
-import com.klp.order.presentation.dto.ordercancellation.response.OrderCancellationResponse;
-import com.klp.order.presentation.dto.orderitem.response.OrderItemResponse;
+import com.klp.order.application.command.CancelOrderCommand;
+import com.klp.order.domain.entity.cancel.CancelType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Schema(description = "주문 취소 응답")
 public record CancelOrderResponse(
-    @Schema(description = "주문 ID", example = "UUID")
+    @Schema(description = "주문 ID", example = "550e8400-e29b-41d4-a716-446655440000")
     UUID orderId,
 
-    @Schema(description = "주문 상태 (CANCELLED)", example = "CANCELLED")
-    OrderStatus orderStatus,
+    @Schema(description = "취소 사유", example = "고객 변심")
+    String cancelReason,
 
-    @Schema(description = "공급 업체 ID", example = "UUID")
-    UUID supplierId,
+    @Schema(description = "취소 타입", example = "USER_REQUEST")
+    CancelType cancelType,
 
-    @Schema(description = "사용자 ID", example = "1")
-    Long userId,
-
-    @Schema(description = "사용자 쿠폰 ID", example = "UUID")
-    UUID userCouponId,
-
-    @Schema(description = "원가", example = "3000000")
-    int originalPrice,
-
-    @Schema(description = "쿠폰 할인 금액", example = "150000")
-    int couponDiscountPrice,
-
-    @Schema(description = "등급 할인 금액", example = "50000")
-    int gradeDiscountPrice,
-
-    @Schema(description = "최종 주문 금액", example = "2800000")
-    int orderPrice,
-
-    @Schema(description = "주문 상품 목록")
-    List<OrderItemResponse> orderItems,
-
-    @Schema(description = "취소 정보 (취소 사유, 취소자 등)")
-    OrderCancellationResponse cancellation,
-
-    @Schema(description = "생성일시", example = "2024-01-01T10:00:00")
-    LocalDateTime createdAt,
-
-    @Schema(description = "생성자 ID", example = "1")
-    Long createdBy,
-
-    @Schema(description = "수정일시", example = "2024-01-01T10:00:00")
-    LocalDateTime updatedAt,
-
-    @Schema(description = "수정자 ID", example = "1")
-    Long updatedBy
+    @Schema(description = "취소자 ID", example = "1")
+    Long cancelledBy
 ) {
 
-    public static CancelOrderResponse from(Order order) {
-        List<OrderItemResponse> orderItemResponses = order.getOrderItems().stream()
-            .map(OrderItemResponse::from)
-            .collect(Collectors.toList());
-
+    public static CancelOrderResponse from(CancelOrderCommand command) {
         return new CancelOrderResponse(
-            order.getOrderId(),
-            order.getOrderStatus(),
-            order.getSupplierId(),
-            order.getUserId(),
-            order.getUserCouponId(),
-            order.getOriginalPrice(),
-            order.getCouponDiscountPrice(),
-            order.getGradeDiscountPrice(),
-            order.getOrderPrice(),
-            orderItemResponses,
-            OrderCancellationResponse.from(order.getCancellation()),
-            order.getCreatedAt(),
-            order.getCreatedBy(),
-            order.getUpdatedAt(),
-            order.getUpdatedBy()
+            command.orderId(),
+            command.cancelReason(),
+            command.cancelType(),
+            command.cancelledBy()
         );
     }
 }

--- a/order/src/main/java/com/klp/order/presentation/dto/order/response/create/CreateOrderResponse.java
+++ b/order/src/main/java/com/klp/order/presentation/dto/order/response/create/CreateOrderResponse.java
@@ -2,7 +2,6 @@ package com.klp.order.presentation.dto.order.response.create;
 
 import com.klp.order.domain.entity.order.Order;
 import com.klp.order.domain.entity.order.OrderStatus;
-import com.klp.order.presentation.dto.ordercancellation.response.OrderCancellationResponse;
 import com.klp.order.presentation.dto.orderitem.response.OrderItemResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
@@ -55,9 +54,6 @@ public record CreateOrderResponse(
     @Schema(description = "주문 상품 목록")
     List<OrderItemResponse> orderItems,
 
-    @Schema(description = "취소 정보")
-    OrderCancellationResponse cancellation,
-
     @Schema(description = "생성일시", example = "2024-01-01T10:00:00")
     LocalDateTime createdAt,
 
@@ -97,7 +93,6 @@ public record CreateOrderResponse(
             order.getDeliveryLatitude(),
             order.getDeliveryLongitude(),
             orderItemResponses,
-            OrderCancellationResponse.from(order.getCancellation()),
             order.getCreatedAt(),
             order.getCreatedBy(),
             order.getUpdatedAt(),

--- a/order/src/main/java/com/klp/order/presentation/dto/order/response/get/GetOneOrderResponse.java
+++ b/order/src/main/java/com/klp/order/presentation/dto/order/response/get/GetOneOrderResponse.java
@@ -2,14 +2,12 @@ package com.klp.order.presentation.dto.order.response.get;
 
 import com.klp.order.domain.entity.order.Order;
 import com.klp.order.domain.entity.order.OrderStatus;
-import com.klp.order.presentation.dto.ordercancellation.response.OrderCancellationResponse;
 import com.klp.order.presentation.dto.orderitem.response.OrderItemResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Schema(description = "주문 상세 조회 응답")
 public record GetOneOrderResponse(
@@ -55,9 +53,6 @@ public record GetOneOrderResponse(
     @Schema(description = "주문 상품 목록")
     List<OrderItemResponse> orderItems,
 
-    @Schema(description = "취소 정보")
-    OrderCancellationResponse cancellation,
-
     @Schema(description = "생성일시", example = "2024-01-01T10:00:00")
     LocalDateTime createdAt,
 
@@ -74,7 +69,7 @@ public record GetOneOrderResponse(
     public static GetOneOrderResponse from(Order order) {
         List<OrderItemResponse> orderItemResponses = order.getOrderItems().stream()
             .map(OrderItemResponse::from)
-            .collect(Collectors.toList());
+            .toList();
 
         return new GetOneOrderResponse(
             order.getOrderId(),
@@ -91,7 +86,6 @@ public record GetOneOrderResponse(
             order.getDeliveryLatitude(),
             order.getDeliveryLongitude(),
             orderItemResponses,
-            OrderCancellationResponse.from(order.getCancellation()),
             order.getCreatedAt(),
             order.getCreatedBy(),
             order.getUpdatedAt(),

--- a/order/src/main/java/com/klp/order/presentation/dto/order/response/get/GetOrdersResponse.java
+++ b/order/src/main/java/com/klp/order/presentation/dto/order/response/get/GetOrdersResponse.java
@@ -2,7 +2,6 @@ package com.klp.order.presentation.dto.order.response.get;
 
 import com.klp.order.domain.entity.order.Order;
 import com.klp.order.domain.entity.order.OrderStatus;
-import com.klp.order.presentation.dto.ordercancellation.response.OrderCancellationResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -30,9 +29,6 @@ public record GetOrdersResponse(
     @Schema(description = "최종 주문 금액", example = "2800000")
     int orderPrice,
 
-    @Schema(description = "취소 정보")
-    OrderCancellationResponse cancellation,
-
     @Schema(description = "생성자 ID", example = "1")
     Long createdBy,
 
@@ -49,7 +45,6 @@ public record GetOrdersResponse(
             order.getOrderStatus(),
             order.getOriginalPrice(),
             order.getOrderPrice(),
-            OrderCancellationResponse.from(order.getCancellation()),
             order.getCreatedBy(),
             order.getCreatedAt()
         );

--- a/order/src/main/java/com/klp/order/presentation/dto/order/response/update/UpdateOrderResponse.java
+++ b/order/src/main/java/com/klp/order/presentation/dto/order/response/update/UpdateOrderResponse.java
@@ -2,7 +2,6 @@ package com.klp.order.presentation.dto.order.response.update;
 
 import com.klp.order.domain.entity.order.Order;
 import com.klp.order.domain.entity.order.OrderStatus;
-import com.klp.order.presentation.dto.ordercancellation.response.OrderCancellationResponse;
 import com.klp.order.presentation.dto.orderitem.response.OrderItemResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
@@ -55,9 +54,6 @@ public record UpdateOrderResponse(
     @Schema(description = "주문 상품 목록")
     List<OrderItemResponse> orderItems,
 
-    @Schema(description = "취소 정보")
-    OrderCancellationResponse cancellation,
-
     @Schema(description = "생성일시", example = "2024-01-01T10:00:00")
     LocalDateTime createdAt,
 
@@ -91,7 +87,6 @@ public record UpdateOrderResponse(
             order.getDeliveryLatitude(),
             order.getDeliveryLongitude(),
             orderItemResponses,
-            OrderCancellationResponse.from(order.getCancellation()),
             order.getCreatedAt(),
             order.getCreatedBy(),
             order.getUpdatedAt(),


### PR DESCRIPTION
# 변경사항
1. Order에서 OrderCancellation이 양방향 관계라 모니터링 때 병목현상이 있는 점이 발견되었습니다.
2. 그래서 양방향 관계가 아닌 OrderCancellation에서 orderId만 참조하는 방식으로 변경하였습니다.
3. 컴파일 결과 컴파일은 걸리지 않는것이 발견되었습니다.

# 고려사항
- 고려사항으로는 이제 findById같은 것을 할때 ordercancellation을 어떻게 가져올지 고민입니다. 
- 그냥 cancellation에 orderId만 있는것을 가져올지 그냥 orderCancellation을 무시하다가 orderCancellation 포함해서 조회하는 것을 따로 만들지 그 부분에 대해서 혹시 의견 있으시면 말씀해주세요!
- 